### PR TITLE
fix: Editor Bridge bugfixes from v0.5.82 field testing

### DIFF
--- a/docs/superpowers/plans/2026-03-26-editor-bridge-bugfixes.md
+++ b/docs/superpowers/plans/2026-03-26-editor-bridge-bugfixes.md
@@ -1,0 +1,577 @@
+# Editor Bridge Bugfixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 4 bugs and 2 quality issues from v0.5.82 field testing: non-focus rendering, VRCSDKUploadHandler compile errors, relative paths, unsaved warnings, and GUID error messages.
+
+**Architecture:** Layer-by-layer bottom-up: C# handlers first (EditorControlBridge.cs, VRCSDKUploadHandler.cs), then Python (mcp_server.py path fix, version check), then tests. Screenshot handler already uses Camera.Render() so the focus is on pre-render state updates.
+
+**Tech Stack:** C# (Unity Editor API), Python 3.11+ (FastMCP)
+
+**Spec:** `docs/superpowers/specs/2026-03-26-editor-bridge-bugfixes-design.md`
+
+---
+
+## File Structure
+
+### Modified Files
+
+| File | Responsibility |
+|------|---------------|
+| `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs` | ForceRenderAndRepaint, screenshot pre-render, BuildError/BuildSuccess access, BridgeVersion, unsaved warnings, GUID error |
+| `tools/unity/PrefabSentinel.VRCSDKUploadHandler.cs` | VRC SDK API fixes (if needed after access modifier change) |
+| `prefab_sentinel/mcp_server.py` | _read_asset path resolution, get_project_status version check |
+| `prefab_sentinel/session.py` | Cache bridge_version |
+| `tests/test_editor_bridge.py` | Path resolution tests |
+
+---
+
+## Task 1: C# — Replace RepaintAllViews with ForceRenderAndRepaint
+
+**Files:**
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs:915-925`
+
+- [ ] **Step 1: Replace RepaintAllViews method**
+
+Find `RepaintAllViews` (line 915) and replace with:
+
+```csharp
+        /// <summary>
+        /// Force GPU rendering + GUI repaint. Works even when Unity is unfocused.
+        /// QueuePlayerLoopUpdate forces skinning/physics recalculation,
+        /// alwaysRefresh ensures SceneView renders even without focus.
+        /// </summary>
+        private static void ForceRenderAndRepaint(SceneView sceneView)
+        {
+            EditorApplication.QueuePlayerLoopUpdate();
+
+            bool wasAlwaysRefresh = sceneView.sceneViewState.alwaysRefresh;
+            sceneView.sceneViewState.alwaysRefresh = true;
+
+            sceneView.Repaint();
+            SceneView.RepaintAll();
+            UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+
+            EditorApplication.delayCall += () =>
+            {
+                sceneView.sceneViewState.alwaysRefresh = wasAlwaysRefresh;
+                sceneView.Repaint();
+                SceneView.RepaintAll();
+            };
+        }
+```
+
+- [ ] **Step 2: Rename all call sites**
+
+Replace all `RepaintAllViews(` with `ForceRenderAndRepaint(` at these lines:
+- Line 583 (HandleFrameSelected)
+- Line 1042 (HandleSetCamera)
+- Line 1364 (HandleSetMaterialProperty)
+- Line 1655 (HandleSetBlendShape)
+
+Use find-and-replace: `RepaintAllViews` → `ForceRenderAndRepaint` (4 occurrences).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+git commit -m "fix(bridge): replace RepaintAllViews with ForceRenderAndRepaint for unfocused rendering"
+```
+
+---
+
+## Task 2: C# — Screenshot pre-render enhancement
+
+**Files:**
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs:372-421`
+
+- [ ] **Step 1: Add QueuePlayerLoopUpdate + alwaysRefresh before Camera.Render**
+
+In `HandleCaptureScreenshot`, find the scene view branch (line 385). Before `cam.Render()` (line 405), add pre-render setup:
+
+```csharp
+                    try
+                    {
+                        // Force scene state update before capture (non-focus safe)
+                        EditorApplication.QueuePlayerLoopUpdate();
+                        bool wasAlwaysRefresh = sceneView.sceneViewState.alwaysRefresh;
+                        sceneView.sceneViewState.alwaysRefresh = true;
+                        sceneView.Repaint();
+
+                        rt = new RenderTexture(w, h, 24);
+                        RenderTexture prev = cam.targetTexture;
+                        cam.targetTexture = rt;
+                        cam.Render();
+                        cam.targetTexture = prev;
+
+                        // Restore alwaysRefresh
+                        sceneView.sceneViewState.alwaysRefresh = wasAlwaysRefresh;
+```
+
+Insert the 4 new lines (`QueuePlayerLoopUpdate`, `wasAlwaysRefresh`, `alwaysRefresh = true`, `Repaint`) before the existing `rt = new RenderTexture(...)` line. Add the restore line after `cam.targetTexture = prev;`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+git commit -m "fix(bridge): force scene state update before screenshot capture"
+```
+
+---
+
+## Task 3: C# — BuildError/BuildSuccess access modifier + BridgeVersion
+
+**Files:**
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs:19,1768,1781,1794`
+
+- [ ] **Step 1: Change BuildError/BuildSuccess from private to internal**
+
+At line 1768:
+```csharp
+// Before
+private static EditorControlResponse BuildSuccess(string code, string message, EditorControlData data = null)
+// After
+internal static EditorControlResponse BuildSuccess(string code, string message, EditorControlData data = null)
+```
+
+At line 1781:
+```csharp
+// Before
+private static EditorControlResponse BuildError(string code, string message)
+// After
+internal static EditorControlResponse BuildError(string code, string message)
+```
+
+At line 1794:
+```csharp
+// Before
+private static EditorControlResponse BuildError(string code, string message, EditorControlData data)
+// After
+internal static EditorControlResponse BuildError(string code, string message, EditorControlData data)
+```
+
+- [ ] **Step 2: Add BridgeVersion constant**
+
+At line 19 (next to `ProtocolVersion`), add:
+
+```csharp
+        public const int ProtocolVersion = 1;
+        public const string BridgeVersion = "0.5.82";
+```
+
+- [ ] **Step 3: Add bridge_version to EditorControlResponse**
+
+In the `EditorControlResponse` class (line 245), add:
+
+```csharp
+        public sealed class EditorControlResponse
+        {
+            public int protocol_version = ProtocolVersion;
+            public string bridge_version = BridgeVersion;
+            public bool success = false;
+```
+
+- [ ] **Step 4: Verify VRCSDKUploadHandler compiles**
+
+Check `tools/unity/PrefabSentinel.VRCSDKUploadHandler.cs` — it uses `using static PrefabSentinel.UnityEditorControlBridge;` (line 12) to access `BuildError`/`BuildSuccess`. With `internal` access, this should now compile.
+
+If `EditorUserBuildSettings.GetBuildTargetGroup` (line 147) causes a deprecation error, replace with:
+
+```csharp
+// Before
+EditorUserBuildSettings.GetBuildTargetGroup(originalTarget)
+// After
+BuildPipeline.GetBuildTargetGroup(originalTarget)
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/unity/PrefabSentinel.UnityEditorControlBridge.cs tools/unity/PrefabSentinel.VRCSDKUploadHandler.cs
+git commit -m "fix(bridge): internal BuildError/BuildSuccess, add BridgeVersion"
+```
+
+---
+
+## Task 4: C# — Unsaved warning diagnostics
+
+**Files:**
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs`
+
+- [ ] **Step 1: Add unsaved warning to HandleSetBlendShape**
+
+Find the return statement in HandleSetBlendShape (line 1657). Change:
+
+```csharp
+            return BuildSuccess("EDITOR_CTRL_BLEND_SHAPE_SET_OK",
+                $"BlendShape '{request.blend_shape_name}' set from {before} to {weight}",
+                data: new EditorControlData
+                {
+                    blend_shape_index = index,
+                    blend_shape_name = request.blend_shape_name,
+                    blend_shape_before = before,
+                    blend_shape_after = weight,
+                    executed = true,
+                });
+```
+
+To:
+
+```csharp
+            var resp = BuildSuccess("EDITOR_CTRL_BLEND_SHAPE_SET_OK",
+                $"BlendShape '{request.blend_shape_name}' set from {before} to {weight}",
+                data: new EditorControlData
+                {
+                    blend_shape_index = index,
+                    blend_shape_name = request.blend_shape_name,
+                    blend_shape_before = before,
+                    blend_shape_after = weight,
+                    executed = true,
+                });
+            resp.diagnostics = new[] { new EditorControlDiagnostic
+            {
+                detail = "Runtime modification — save the scene (File > Save) to persist.",
+                evidence = "Undo.RecordObject"
+            }};
+            return resp;
+```
+
+- [ ] **Step 2: Add unsaved warning to HandleSetMaterialProperty**
+
+Find the return statement for `EDITOR_CTRL_SET_MATERIAL_PROPERTY_OK` (around line 1366). Apply the same pattern:
+
+```csharp
+            var resp = BuildSuccess("EDITOR_CTRL_SET_MATERIAL_PROPERTY_OK", ...);
+            resp.diagnostics = new[] { new EditorControlDiagnostic
+            {
+                detail = "Runtime modification — save the scene (File > Save) to persist.",
+                evidence = "Undo.RecordObject"
+            }};
+            return resp;
+```
+
+- [ ] **Step 3: Add unsaved warning to HandleSetMaterial**
+
+Find the return statement for `EDITOR_CTRL_SET_MATERIAL_OK` (around line 740). Apply the same pattern:
+
+```csharp
+            var resp = BuildSuccess("EDITOR_CTRL_SET_MATERIAL_OK",
+                $"Set material[{request.material_index}] to {assetPath}",
+                data: new EditorControlData { executed = true, read_only = false });
+            resp.diagnostics = new[] { new EditorControlDiagnostic
+            {
+                detail = "Runtime modification — save the scene (File > Save) to persist.",
+                evidence = "Undo.RecordObject"
+            }};
+            return resp;
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+git commit -m "fix(bridge): add unsaved runtime modification warnings to diagnostics"
+```
+
+---
+
+## Task 5: C# — Material GUID error message improvement
+
+**Files:**
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs:1299-1324`
+
+- [ ] **Step 1: Improve texture GUID error message**
+
+Find the texture case in HandleSetMaterialProperty (line 1299). Replace the existing error handling:
+
+```csharp
+                case UnityEngine.Rendering.ShaderPropertyType.Texture:
+                {
+                    if (string.IsNullOrEmpty(val))
+                    {
+                        mat.SetTexture(request.property_name, null);
+                    }
+                    else if (val.StartsWith("guid:"))
+                    {
+                        string guid = val.Substring(5);
+                        string texPath = AssetDatabase.GUIDToAssetPath(guid);
+                        if (string.IsNullOrEmpty(texPath))
+                            return BuildError("EDITOR_CTRL_PROPERTY_TYPE_MISMATCH",
+                                $"Texture GUID not found: {guid}");
+                        var tex = AssetDatabase.LoadAssetAtPath<Texture>(texPath);
+                        if (tex == null)
+                        {
+                            // Check if the GUID points to a non-texture asset
+                            if (texPath.EndsWith(".mat"))
+                                return BuildError("EDITOR_CTRL_SET_MAT_PROP_WRONG_GUID",
+                                    $"The specified GUID points to a material asset '{texPath}'. " +
+                                    "Please specify a texture GUID instead.");
+                            return BuildError("EDITOR_CTRL_PROPERTY_TYPE_MISMATCH",
+                                $"Failed to load texture from GUID '{guid}' (resolved to '{texPath}').");
+                        }
+                        mat.SetTexture(request.property_name, tex);
+                    }
+                    else
+                    {
+                        return BuildError("EDITOR_CTRL_PROPERTY_TYPE_MISMATCH",
+                            "Texture value must be 'guid:<hex>' or empty string for null.");
+                    }
+                    break;
+                }
+```
+
+The key change: the `if (tex == null)` block now checks `texPath.EndsWith(".mat")` and returns a specific `EDITOR_CTRL_SET_MAT_PROP_WRONG_GUID` error code with a clear message.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+git commit -m "fix(bridge): clear error when material GUID used as texture GUID"
+```
+
+---
+
+## Task 6: Python — _read_asset relative path fix
+
+**Files:**
+- Modify: `prefab_sentinel/mcp_server.py:85-95`
+- Test: `tests/test_editor_bridge.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_editor_bridge.py`:
+
+```python
+class TestReadAssetPathResolution(unittest.TestCase):
+    """Validate _read_asset resolves Assets/... paths with project root."""
+
+    def test_relative_assets_path_resolved(self) -> None:
+        """Assets/... path is joined with project root when file doesn't exist as relative."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a fake asset at project_root/Assets/test.prefab
+            assets_dir = Path(tmpdir) / "Assets"
+            assets_dir.mkdir()
+            fake_asset = assets_dir / "test.prefab"
+            fake_asset.write_text("%YAML 1.1\n--- !u!1 &1\nGameObject:\n  m_Name: Test\n")
+
+            from prefab_sentinel.mcp_server import _resolve_asset_path
+
+            resolved = _resolve_asset_path("Assets/test.prefab", Path(tmpdir))
+            self.assertEqual(resolved, fake_asset)
+
+    def test_absolute_path_unchanged(self) -> None:
+        """Absolute paths are not modified."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_asset = Path(tmpdir) / "test.prefab"
+            fake_asset.write_text("%YAML 1.1\n--- !u!1 &1\nGameObject:\n  m_Name: Test\n")
+
+            from prefab_sentinel.mcp_server import _resolve_asset_path
+
+            resolved = _resolve_asset_path(str(fake_asset), Path(tmpdir))
+            self.assertEqual(resolved, fake_asset)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m unittest tests.test_editor_bridge.TestReadAssetPathResolution -v`
+Expected: FAIL — `_resolve_asset_path` does not exist.
+
+- [ ] **Step 3: Extract path resolution helper and update _read_asset**
+
+In `prefab_sentinel/mcp_server.py`, add a helper before `_read_asset` (around line 83):
+
+```python
+    def _resolve_asset_path(path: str, project_root: Path | None) -> Path:
+        """Resolve asset path, joining Assets/... paths with project root."""
+        resolved = Path(to_wsl_path(path))
+        if not resolved.is_file() and project_root and not resolved.is_absolute():
+            joined = (project_root / resolved).resolve()
+            if joined.is_file():
+                return joined
+        return resolved
+```
+
+Then update `_read_asset` (line 85):
+
+```python
+    def _read_asset(path: str) -> tuple[str, Path]:
+        """Read a Unity asset file, returning (text, resolved_path)."""
+        resolved = _resolve_asset_path(path, session.project_root)
+        if not resolved.is_file():
+            msg = f"File not found: {path}"
+            raise FileNotFoundError(msg)
+        text = decode_text_file(resolved)
+        if text is None:
+            msg = f"Unable to decode file: {path}"
+            raise ValueError(msg)
+        return text, resolved
+```
+
+**Note:** `_resolve_asset_path` is defined inside the server setup closure so it has access to scope. For testing, we need to import it. Since it's a closure-local function, we'll need to either:
+- Move it to `editor_bridge.py` (like `build_set_camera_kwargs`)
+- Or make it a module-level function
+
+Move it to `prefab_sentinel/unity_assets.py` alongside `resolve_scope_path`:
+
+```python
+def resolve_asset_path(path: str, project_root: Path | None) -> Path:
+    """Resolve asset path, joining Assets/... paths with project root.
+
+    If *path* is relative (e.g. ``Assets/...``) and doesn't exist as-is,
+    tries joining with *project_root*.
+    """
+    from prefab_sentinel.wsl_compat import to_wsl_path
+
+    resolved = Path(to_wsl_path(path))
+    if not resolved.is_file() and project_root and not resolved.is_absolute():
+        joined = (project_root / resolved).resolve()
+        if joined.is_file():
+            return joined
+    return resolved
+```
+
+Update the import in test to use `from prefab_sentinel.unity_assets import resolve_asset_path` and rename test accordingly.
+
+- [ ] **Step 4: Update _read_asset to use resolve_asset_path**
+
+In `prefab_sentinel/mcp_server.py`, update `_read_asset`:
+
+```python
+    def _read_asset(path: str) -> tuple[str, Path]:
+        """Read a Unity asset file, returning (text, resolved_path)."""
+        resolved = resolve_asset_path(path, session.project_root)
+        if not resolved.is_file():
+            msg = f"File not found: {path}"
+            raise FileNotFoundError(msg)
+        text = decode_text_file(resolved)
+        if text is None:
+            msg = f"Unable to decode file: {path}"
+            raise ValueError(msg)
+        return text, resolved
+```
+
+Add import at top of server setup: `from prefab_sentinel.unity_assets import resolve_asset_path`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run python -m unittest tests.test_editor_bridge.TestReadAssetPathResolution -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prefab_sentinel/unity_assets.py prefab_sentinel/mcp_server.py tests/test_editor_bridge.py
+git commit -m "fix(mcp): resolve Assets/... relative paths with project root in get_unity_symbols"
+```
+
+---
+
+## Task 7: Python — Bridge version check in get_project_status
+
+**Files:**
+- Modify: `prefab_sentinel/session.py`
+- Modify: `prefab_sentinel/editor_bridge.py`
+- Modify: `prefab_sentinel/mcp_server.py:160-173`
+
+- [ ] **Step 1: Add bridge_version caching to send_action**
+
+In `prefab_sentinel/editor_bridge.py`, in `send_action` (around line 180 where response is parsed), cache bridge_version:
+
+```python
+    # After parsing response JSON, before return:
+    if "bridge_version" in payload:
+        _last_bridge_version = payload["bridge_version"]
+```
+
+Add module-level variable at top (around line 32):
+
+```python
+_last_bridge_version: str | None = None
+```
+
+Add getter function:
+
+```python
+def get_last_bridge_version() -> str | None:
+    """Return the bridge_version from the last successful response, or None."""
+    return _last_bridge_version
+```
+
+- [ ] **Step 2: Update get_project_status to include version comparison**
+
+In `prefab_sentinel/mcp_server.py`, update `get_project_status` (line 160):
+
+```python
+    @server.tool()
+    def get_project_status() -> dict[str, Any]:
+        """Show current session state: cached items, scope, project root.
+
+        Use this to check whether caches are warm or if activate_project
+        needs to be called.
+        """
+        from importlib.metadata import version as pkg_version
+
+        python_version = pkg_version("prefab-sentinel")
+        bridge_ver = get_last_bridge_version()
+
+        diagnostics = []
+        if bridge_ver and bridge_ver != python_version:
+            diagnostics.append({
+                "detail": f"Bridge version mismatch: Bridge={bridge_ver}, Python={python_version}. "
+                          "Update Bridge C# files and run editor_recompile.",
+                "evidence": f"bridge_version={bridge_ver}, package_version={python_version}",
+            })
+
+        status = session.status()
+        status["python_version"] = python_version
+        status["bridge_version"] = bridge_ver
+
+        return {
+            "success": True,
+            "severity": "warning" if diagnostics else "info",
+            "code": "SESSION_STATUS",
+            "message": "Current session status",
+            "data": status,
+            "diagnostics": diagnostics,
+        }
+```
+
+Add import: `from prefab_sentinel.editor_bridge import get_last_bridge_version`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prefab_sentinel/editor_bridge.py prefab_sentinel/mcp_server.py
+git commit -m "feat(mcp): bridge version check in get_project_status"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run full Python test suite**
+
+Run: `uv run python -m unittest tests.test_editor_bridge -v`
+Expected: all tests PASS.
+
+- [ ] **Step 2: Lint check**
+
+Run: `uv run ruff check prefab_sentinel/editor_bridge.py prefab_sentinel/mcp_server.py prefab_sentinel/unity_assets.py tests/test_editor_bridge.py`
+Expected: no errors.
+
+- [ ] **Step 3: Note for manual Unity verification**
+
+The following require Unity Editor with Bridge running:
+- ForceRenderAndRepaint: set_blend_shape → screenshot with Unity unfocused
+- Screenshot pre-render: same test as above, verify image shows updated blend shape
+- VRCSDKUploadHandler: deploy both .cs files with VRC SDK project, verify compilation
+- BridgeVersion: call any bridge action, verify `bridge_version` in response JSON
+- Unsaved warning: call set_blend_shape, verify `diagnostics` array in response
+- Material GUID error: pass a .mat GUID as texture value, verify error mentions "material asset"
+- Relative paths: call get_unity_symbols with `Assets/...` path after activate_project

--- a/docs/superpowers/specs/2026-03-26-editor-bridge-bugfixes-design.md
+++ b/docs/superpowers/specs/2026-03-26-editor-bridge-bugfixes-design.md
@@ -1,0 +1,190 @@
+# Editor Bridge バグ修正・品質改善設計
+
+**日付:** 2026-03-26
+**由来:** v0.5.82 機能テスト＆レビュー (`report_20260326_feature_test_and_review.md`)
+**アプローチ:** レイヤー別ボトムアップ（C# → Python → ドキュメント）
+
+---
+
+## 概要
+
+v0.5.82 の実地テストで発見されたバグ 4 件 + 品質改善 2 件を修正する。
+
+---
+
+## 1. ForceRenderAndRepaint（非フォーカス描画対策）
+
+### 問題
+
+`RepaintAllViews` は GUI 再描画のみ。GPU レンダリングパイプライン（SkinnedMesh スキニング、マテリアル再描画）は非フォーカス時にスキップされる。`set_blend_shape` / `editor_set_material_property` 後の `editor_screenshot` で変更前の画像がキャプチャされる。
+
+### 設計
+
+既存の `RepaintAllViews` を `ForceRenderAndRepaint` に置き換える。
+
+```csharp
+private static void ForceRenderAndRepaint(SceneView sceneView)
+{
+    // 1. プレイヤーループ強制キュー（スキニング等の再計算）
+    EditorApplication.QueuePlayerLoopUpdate();
+
+    // 2. 一時的に常時リフレッシュ ON（非フォーカスでもレンダリング走行）
+    bool wasAlwaysRefresh = sceneView.sceneViewState.alwaysRefresh;
+    sceneView.sceneViewState.alwaysRefresh = true;
+
+    // 3. GUI 再描画
+    sceneView.Repaint();
+    SceneView.RepaintAll();
+    UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+
+    // 4. 1フレーム後に復元
+    EditorApplication.delayCall += () =>
+    {
+        sceneView.sceneViewState.alwaysRefresh = wasAlwaysRefresh;
+        sceneView.Repaint();
+        SceneView.RepaintAll();
+    };
+}
+```
+
+**適用先:** `set_camera`, `frame_selected`, `set_blend_shape`, `set_material_property`, `set_material` — 既存の `RepaintAllViews` 呼び出しを全て置き換え。
+
+### スクショ時の追加保証
+
+`capture_screenshot` ハンドラの Scene ビューキャプチャ前に `sceneView.camera.Render()` を呼ぶ:
+
+```csharp
+// フォーカス不問でレンダリングを強制
+sceneView.camera.Render();
+```
+
+これにより `ForceRenderAndRepaint` が効かない環境でもスクショ時は確実に最新フレームが得られる。
+
+---
+
+## 2. VRCSDKUploadHandler コンパイルエラー修正
+
+### 問題
+
+`VRCSDKUploadHandler.cs` を配置すると `BuildError`/`BuildSuccess` が `private` でアクセス不可（15件のコンパイルエラー）。Bridge 全体がコンパイル不能になり全エディタ操作が停止。
+
+### 設計
+
+#### アクセス修飾子の修正
+
+`UnityEditorControlBridge.cs` の `BuildError`/`BuildSuccess` を `private` → `internal` に変更:
+
+```csharp
+internal static EditorControlResponse BuildError(string code, string message, ...)
+internal static EditorControlResponse BuildSuccess(string code, string message, ...)
+```
+
+加えて、`#if VRC_SDK_VRCSDK3` ブロック内の VRC SDK API 不整合を全件修正:
+- `GetBuildTargetGroup` の廃止対応
+- `IVRCSdkWorldBuilderApi` の型不整合
+- その他コンパイルエラー
+
+#### ブリッジバージョン検出
+
+`EditorControlBridge` に定数を追加:
+
+```csharp
+public const string BridgeVersion = "0.5.82";
+```
+
+Bridge レスポンスの既存 `protocol_version` に加え `bridge_version` を返す。Python 側の `get_project_status` で Python パッケージバージョンと Bridge バージョンの不一致を `warning` 診断として出力。
+
+---
+
+## 3. get_unity_symbols の相対パス解決
+
+### 問題
+
+`get_unity_symbols` で `Assets/...` 形式の相対パスが `File not found` エラーになる。他のツール（`inspect_materials` 等）は相対パスで動作するため一貫性がない。
+
+### 設計
+
+`get_unity_symbols` の入力パス処理で、`Assets/...` 形式を検出したら `activate_project` で設定済みの Unity プロジェクトルートを先頭に付加して絶対パスに変換:
+
+```python
+if asset_path.startswith("Assets/"):
+    project_root = get_active_project_root()
+    if project_root:
+        asset_path = os.path.join(project_root, asset_path)
+```
+
+他のツールで既にこのパターンを使っている箇所を確認し、共通ヘルパーがあればそれを使う。
+
+### 影響範囲
+
+`get_unity_symbols` のみ。他のツールは既に相対パスが動作しているため変更不要。
+
+---
+
+## 4. set_blend_shape の unsaved warning
+
+### 問題
+
+`set_blend_shape` はランタイム変更（`Undo.RecordObject` 対応）だが、シーンを明示的に保存しないと失われる。レスポンスにその旨の警告がない。
+
+### 設計
+
+`set_blend_shape` のレスポンスに `diagnostics` を追加:
+
+```csharp
+diagnostics = new[] { new EditorControlDiagnostic
+{
+    detail = "BlendShape change is a runtime modification. Save the scene (File > Save) to persist.",
+    evidence = "Undo.RecordObject"
+} }
+```
+
+同様の warning を以下にも追加:
+- `editor_set_material_property`（マテリアルのランタイム変更）
+- `editor_set_material`（マテリアルスロットのランタイム差し替え）
+
+---
+
+## 5. マテリアル GUID エラーメッセージ改善
+
+### 問題
+
+`editor_set_material_property` でテクスチャ GUID 指定時にマテリアル GUID を誤って渡すと「Failed to load texture at: .mat path」という不明瞭なエラーが出る。
+
+### 設計
+
+`HandleSetMaterialProperty` のテクスチャロード失敗時に、渡された GUID が `.mat` アセットを指しているかチェック:
+
+```csharp
+Texture tex = AssetDatabase.LoadAssetAtPath<Texture>(path);
+if (tex == null)
+{
+    string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+    if (assetPath.EndsWith(".mat"))
+        return BuildError("EDITOR_CTRL_SET_MAT_PROP_WRONG_GUID",
+            $"The specified GUID points to a material asset '{assetPath}'. " +
+            "Please specify a texture GUID instead.");
+    return BuildError("EDITOR_CTRL_SET_MAT_PROP_TEXTURE_LOAD_FAIL",
+        $"Failed to load texture from GUID '{guid}' (resolved to '{assetPath}').");
+}
+```
+
+---
+
+## 実装順序
+
+レイヤー別ボトムアップ:
+
+| ステップ | 層 | 内容 |
+|---------|-----|------|
+| 1 | C# | ForceRenderAndRepaint 置換、Camera.Render スクショ強化、VRCSDKUploadHandler 修正、BridgeVersion 定数、unsaved warning、GUID エラー改善 |
+| 2 | Python | get_unity_symbols パス解決、get_project_status バージョンチェック |
+| 3 | テスト | Python パス解決のユニットテスト、バージョンチェックテスト |
+
+---
+
+## スコープ外
+
+- Win32 フォーカス強制（ForceRenderAndRepaint で不十分な場合に次バッチで検討）
+- Bridge C# の条件付き配布（VRC SDK 有無に応じたファイル分割）
+- VRCSDKUploadHandler の partial class 化（internal 化で十分なら不要）

--- a/prefab_sentinel/editor_bridge.py
+++ b/prefab_sentinel/editor_bridge.py
@@ -28,6 +28,8 @@ from prefab_sentinel.bridge_constants import (
 PROTOCOL_VERSION = 1
 # Empirical: sufficient for typical Inspector operations in loaded projects
 DEFAULT_TIMEOUT_SEC = 30
+# Cached bridge version from last successful response
+_last_bridge_version: str | None = None
 DEFAULT_POLL_INTERVAL = 1.0
 
 SUPPORTED_ACTIONS = frozenset(
@@ -190,6 +192,12 @@ def send_action(
 
             payload.setdefault("bridge_mode", "editor")
             payload.setdefault("action", action)
+
+            # Cache bridge version from response
+            global _last_bridge_version
+            if "bridge_version" in payload:
+                _last_bridge_version = payload["bridge_version"]
+
             return payload
 
         time.sleep(DEFAULT_POLL_INTERVAL)
@@ -221,6 +229,11 @@ def bridge_status() -> dict[str, Any]:
         "mode": mode or None,
         "watch_dir": watch_dir or None,
     }
+
+
+def get_last_bridge_version() -> str | None:
+    """Return the bridge_version from the last successful response, or None."""
+    return _last_bridge_version
 
 
 def build_set_camera_kwargs(

--- a/prefab_sentinel/mcp_server.py
+++ b/prefab_sentinel/mcp_server.py
@@ -24,7 +24,11 @@ except ImportError as exc:
         "pip install prefab-sentinel[mcp]"
     ) from exc
 
-from prefab_sentinel.editor_bridge import build_set_camera_kwargs, send_action
+from prefab_sentinel.editor_bridge import (
+    build_set_camera_kwargs,
+    get_last_bridge_version,
+    send_action,
+)
 from prefab_sentinel.fuzzy_match import suggest_similar
 from prefab_sentinel.patch_plan import PLAN_VERSION
 from prefab_sentinel.patch_revert import revert_overrides as revert_overrides_impl
@@ -36,9 +40,8 @@ from prefab_sentinel.symbol_tree import (
     SymbolNotFoundError,
     SymbolTree,
 )
-from prefab_sentinel.unity_assets import decode_text_file
+from prefab_sentinel.unity_assets import decode_text_file, resolve_asset_path
 from prefab_sentinel.unity_yaml_parser import CLASS_ID_MONOBEHAVIOUR
-from prefab_sentinel.wsl_compat import to_wsl_path
 
 __all__ = ["create_server"]
 
@@ -84,7 +87,7 @@ def create_server(
 
     def _read_asset(path: str) -> tuple[str, Path]:
         """Read a Unity asset file, returning (text, resolved_path)."""
-        resolved = Path(to_wsl_path(path))
+        resolved = resolve_asset_path(path, session.project_root)
         if not resolved.is_file():
             msg = f"File not found: {path}"
             raise FileNotFoundError(msg)
@@ -161,15 +164,32 @@ def create_server(
         """Show current session state: cached items, scope, project root.
 
         Use this to check whether caches are warm or if activate_project
-        needs to be called.
+        needs to be called. Also reports bridge version mismatch if detected.
         """
+        from importlib.metadata import version as pkg_version
+
+        python_version = pkg_version("prefab-sentinel")
+        bridge_ver = get_last_bridge_version()
+
+        diagnostics: list[dict[str, str]] = []
+        if bridge_ver and bridge_ver != python_version:
+            diagnostics.append({
+                "detail": f"Bridge version mismatch: Bridge={bridge_ver}, Python={python_version}. "
+                          "Update Bridge C# files and run editor_recompile.",
+                "evidence": f"bridge_version={bridge_ver}, package_version={python_version}",
+            })
+
+        status = session.status()
+        status["python_version"] = python_version
+        status["bridge_version"] = bridge_ver
+
         return {
             "success": True,
-            "severity": "info",
+            "severity": "warning" if diagnostics else "info",
             "code": "SESSION_STATUS",
             "message": "Current session status",
-            "data": session.status(),
-            "diagnostics": [],
+            "data": status,
+            "diagnostics": diagnostics,
         }
 
     # ------------------------------------------------------------------

--- a/prefab_sentinel/unity_assets.py
+++ b/prefab_sentinel/unity_assets.py
@@ -230,6 +230,22 @@ def resolve_scope_path(scope: str, project_root: Path) -> Path:
     return resolved
 
 
+def resolve_asset_path(path: str, project_root: Path | None) -> Path:
+    """Resolve asset path, joining ``Assets/...`` paths with project root.
+
+    If *path* is relative (e.g. ``Assets/Foo/Bar.prefab``) and doesn't exist
+    as-is, tries joining with *project_root*.
+    """
+    from prefab_sentinel.wsl_compat import to_wsl_path
+
+    resolved = Path(to_wsl_path(path))
+    if not resolved.is_file() and project_root and not resolved.is_absolute():
+        joined = (project_root / resolved).resolve()
+        if joined.is_file():
+            return joined
+    return resolved
+
+
 def relative_to_root(path: Path, root: Path) -> str:
     """Return *path* relative to *root* as a POSIX string.
 

--- a/tests/test_editor_bridge.py
+++ b/tests/test_editor_bridge.py
@@ -279,5 +279,45 @@ class TestSetCameraParams(unittest.TestCase):
         self.assertEqual(kwargs["camera_orthographic"], 1)
 
 
+class TestResolveAssetPath(unittest.TestCase):
+    """Validate resolve_asset_path joins Assets/... paths with project root."""
+
+    def test_relative_assets_path_resolved(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from prefab_sentinel.unity_assets import resolve_asset_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assets_dir = Path(tmpdir) / "Assets"
+            assets_dir.mkdir()
+            fake_asset = assets_dir / "test.prefab"
+            fake_asset.write_text("%YAML 1.1\n--- !u!1 &1\nGameObject:\n  m_Name: Test\n")
+
+            resolved = resolve_asset_path("Assets/test.prefab", Path(tmpdir))
+            self.assertEqual(resolved, fake_asset.resolve())
+
+    def test_absolute_path_unchanged(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from prefab_sentinel.unity_assets import resolve_asset_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_asset = Path(tmpdir) / "test.prefab"
+            fake_asset.write_text("%YAML 1.1\n")
+
+            resolved = resolve_asset_path(str(fake_asset), Path(tmpdir))
+            self.assertEqual(resolved, fake_asset)
+
+    def test_no_project_root_returns_as_is(self) -> None:
+        from pathlib import Path
+
+        from prefab_sentinel.unity_assets import resolve_asset_path
+
+        resolved = resolve_asset_path("Assets/nonexistent.prefab", None)
+        self.assertEqual(resolved, Path("Assets/nonexistent.prefab"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -17,6 +17,7 @@ namespace PrefabSentinel
     public static class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
+        public const string BridgeVersion = "0.5.82";
 
         /// <summary>All action strings handled by this bridge.</summary>
         public static readonly HashSet<string> SupportedActions = new HashSet<string>
@@ -245,6 +246,7 @@ namespace PrefabSentinel
         public sealed class EditorControlResponse
         {
             public int protocol_version = ProtocolVersion;
+            public string bridge_version = BridgeVersion;
             public bool success = false;
             public string severity = "error";
             public string code = string.Empty;
@@ -399,11 +401,20 @@ namespace PrefabSentinel
                     Texture2D tex = null;
                     try
                     {
+                        // Force scene state update before capture (non-focus safe)
+                        EditorApplication.QueuePlayerLoopUpdate();
+                        bool wasAlwaysRefresh = sceneView.sceneViewState.alwaysRefresh;
+                        sceneView.sceneViewState.alwaysRefresh = true;
+                        sceneView.Repaint();
+
                         rt = new RenderTexture(w, h, 24);
                         RenderTexture prev = cam.targetTexture;
                         cam.targetTexture = rt;
                         cam.Render();
                         cam.targetTexture = prev;
+
+                        // Restore alwaysRefresh
+                        sceneView.sceneViewState.alwaysRefresh = wasAlwaysRefresh;
 
                         RenderTexture.active = rt;
                         tex = new Texture2D(w, h, TextureFormat.RGB24, false);
@@ -580,7 +591,7 @@ namespace PrefabSentinel
             sceneView.FrameSelected();
             if (request.zoom > 0f)
                 sceneView.size = request.zoom;
-            RepaintAllViews(sceneView);
+            ForceRenderAndRepaint(sceneView);
 
             CameraSnapshot cam = CaptureCameraState(sceneView);
             var data = BuildCameraData(cam);
@@ -737,9 +748,15 @@ namespace PrefabSentinel
             mats[request.material_index] = mat;
             renderer.sharedMaterials = mats;
 
-            return BuildSuccess("EDITOR_CTRL_SET_MATERIAL_OK",
+            var resp = BuildSuccess("EDITOR_CTRL_SET_MATERIAL_OK",
                 $"Set material[{request.material_index}] to {assetPath}",
                 data: new EditorControlData { executed = true, read_only = false });
+            resp.diagnostics = new[] { new EditorControlDiagnostic
+            {
+                detail = "Runtime modification — save the scene (File > Save) to persist.",
+                evidence = "Undo.RecordObject"
+            }};
+            return resp;
         }
 
         private static EditorControlResponse HandleDeleteObject(EditorControlRequest request)
@@ -909,16 +926,24 @@ namespace PrefabSentinel
         }
 
         /// <summary>
-        /// Aggressive repaint: immediate + delayed, all views.
-        /// Ensures changes are visible even when Unity is in the background.
+        /// Force GPU rendering + GUI repaint. Works even when Unity is unfocused.
+        /// QueuePlayerLoopUpdate forces skinning/physics recalculation,
+        /// alwaysRefresh ensures SceneView renders even without focus.
         /// </summary>
-        private static void RepaintAllViews(SceneView sceneView)
+        private static void ForceRenderAndRepaint(SceneView sceneView)
         {
+            EditorApplication.QueuePlayerLoopUpdate();
+
+            bool wasAlwaysRefresh = sceneView.sceneViewState.alwaysRefresh;
+            sceneView.sceneViewState.alwaysRefresh = true;
+
             sceneView.Repaint();
             SceneView.RepaintAll();
             UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+
             EditorApplication.delayCall += () =>
             {
+                sceneView.sceneViewState.alwaysRefresh = wasAlwaysRefresh;
                 sceneView.Repaint();
                 SceneView.RepaintAll();
             };
@@ -1039,7 +1064,7 @@ namespace PrefabSentinel
             if (request.camera_orthographic >= 0)
                 sceneView.orthographic = request.camera_orthographic == 1;
 
-            RepaintAllViews(sceneView);
+            ForceRenderAndRepaint(sceneView);
 
             // Return previous + current state
             CameraSnapshot current = CaptureCameraState(sceneView);
@@ -1311,8 +1336,14 @@ namespace PrefabSentinel
                                     $"Texture GUID not found: {guid}");
                             var tex = AssetDatabase.LoadAssetAtPath<Texture>(texPath);
                             if (tex == null)
+                            {
+                                if (texPath.EndsWith(".mat"))
+                                    return BuildError("EDITOR_CTRL_SET_MAT_PROP_WRONG_GUID",
+                                        $"The specified GUID points to a material asset '{texPath}'. " +
+                                        "Please specify a texture GUID instead.");
                                 return BuildError("EDITOR_CTRL_PROPERTY_TYPE_MISMATCH",
-                                    $"Failed to load texture at: {texPath}");
+                                    $"Failed to load texture from GUID '{guid}' (resolved to '{texPath}').");
+                            }
                             mat.SetTexture(request.property_name, tex);
                         }
                         else
@@ -1361,9 +1392,9 @@ namespace PrefabSentinel
             }
 
             SceneView sv = SceneView.lastActiveSceneView;
-            if (sv != null) RepaintAllViews(sv);
+            if (sv != null) ForceRenderAndRepaint(sv);
 
-            return BuildSuccess("EDITOR_CTRL_SET_MATERIAL_PROPERTY_OK",
+            var resp = BuildSuccess("EDITOR_CTRL_SET_MATERIAL_PROPERTY_OK",
                 $"Set {request.property_name} on material '{mat.name}'",
                 data: new EditorControlData
                 {
@@ -1376,6 +1407,12 @@ namespace PrefabSentinel
                     total_entries = 1,
                     executed = true
                 });
+            resp.diagnostics = new[] { new EditorControlDiagnostic
+            {
+                detail = "Runtime modification — save the scene (File > Save) to persist.",
+                evidence = "Undo.RecordObject"
+            }};
+            return resp;
         }
 
         private static void CollectChildren(Transform parent, int maxDepth, int currentDepth, List<ChildEntry> result)
@@ -1652,9 +1689,9 @@ namespace PrefabSentinel
             smr.SetBlendShapeWeight(index, weight);
 
             SceneView sv = SceneView.lastActiveSceneView;
-            if (sv != null) RepaintAllViews(sv);
+            if (sv != null) ForceRenderAndRepaint(sv);
 
-            return BuildSuccess("EDITOR_CTRL_BLEND_SHAPE_SET_OK",
+            var resp = BuildSuccess("EDITOR_CTRL_BLEND_SHAPE_SET_OK",
                 $"BlendShape '{request.blend_shape_name}' set from {before} to {weight}",
                 data: new EditorControlData
                 {
@@ -1664,6 +1701,12 @@ namespace PrefabSentinel
                     blend_shape_after = weight,
                     executed = true,
                 });
+            resp.diagnostics = new[] { new EditorControlDiagnostic
+            {
+                detail = "Runtime modification — save the scene (File > Save) to persist.",
+                evidence = "Undo.RecordObject"
+            }};
+            return resp;
         }
 
         private static EditorControlResponse HandleListMenuItems(EditorControlRequest request)
@@ -1765,7 +1808,7 @@ namespace PrefabSentinel
 
         // ── Response Builders ──
 
-        private static EditorControlResponse BuildSuccess(string code, string message, EditorControlData data = null)
+        internal static EditorControlResponse BuildSuccess(string code, string message, EditorControlData data = null)
         {
             return new EditorControlResponse
             {
@@ -1778,7 +1821,7 @@ namespace PrefabSentinel
             };
         }
 
-        private static EditorControlResponse BuildError(string code, string message)
+        internal static EditorControlResponse BuildError(string code, string message)
         {
             return new EditorControlResponse
             {


### PR DESCRIPTION
## Summary

v0.5.82 の実地テストで発見されたバグ 4 件 + 品質改善 2 件を修正。

- **ForceRenderAndRepaint**: `RepaintAllViews` を `QueuePlayerLoopUpdate` + `alwaysRefresh` 付きに強化。非フォーカス時の SkinnedMesh/マテリアル描画更新問題に対処
- **Screenshot pre-render**: スクショ前に `QueuePlayerLoopUpdate` + `alwaysRefresh` でシーン状態を強制更新
- **VRCSDKUploadHandler compile fix**: `BuildError`/`BuildSuccess` を `private` → `internal` に変更
- **BridgeVersion**: レスポンスに `bridge_version` を追加、`get_project_status` でバージョン不一致を警告
- **Unsaved warnings**: `set_blend_shape`/`set_material_property`/`set_material` の diagnostics に "runtime modification" 警告を追加
- **Material GUID error**: テクスチャ GUID に .mat GUID を渡した時の明確なエラーメッセージ
- **Relative path fix**: `get_unity_symbols` で `Assets/...` 相対パスが `activate_project` 後に解決されるように

## Test plan

- [x] Python unit tests: 23/23 PASS (resolve_asset_path 3テスト追加)
- [x] Ruff lint: All checks passed
- [ ] Unity: ForceRenderAndRepaint — set_blend_shape → screenshot (非フォーカス)
- [ ] Unity: VRCSDKUploadHandler — VRC SDK プロジェクトでコンパイル確認
- [ ] Unity: BridgeVersion — レスポンスに bridge_version が含まれるか
- [ ] Unity: Unsaved warning — set_blend_shape の diagnostics 確認
- [ ] Unity: GUID error — .mat GUID をテクスチャに渡してエラーメッセージ確認
- [ ] Unity: Relative path — activate_project 後に Assets/... パスで get_unity_symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)