### PR TITLE
fix: deferred screenshot + VRCSDK reflection dispatch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.82",
+  "version": "0.5.83",
   "description": "Unity Prefab/Scene/Asset の検査・編集・参照修復ツール",
   "author": {
     "name": "tyunta",

--- a/docs/superpowers/plans/2026-03-26-screenshot-delay-vrcsdk-reflection.md
+++ b/docs/superpowers/plans/2026-03-26-screenshot-delay-vrcsdk-reflection.md
@@ -1,0 +1,209 @@
+# Screenshot Delay + VRCSDK Reflection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix non-focus screenshot rendering by deferring Scene view capture by 1 frame, and make VRCSDKUploadHandler optional via reflection.
+
+**Architecture:** Two independent C# changes in EditorControlBridge.cs. Screenshot handler is restructured to defer Scene view capture via delayCall, writing the response file directly from the callback. VRCSDK dispatch switches from compile-time #if to runtime reflection.
+
+**Tech Stack:** C# (Unity Editor API)
+
+**Spec:** `docs/superpowers/specs/2026-03-26-screenshot-delay-vrcsdk-reflection-design.md`
+
+---
+
+## File Structure
+
+### Modified Files
+
+| File | Responsibility |
+|------|---------------|
+| `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs` | Screenshot deferred capture, VRCSDK reflection dispatch |
+
+---
+
+## Task 1: C# — Deferred Scene view screenshot capture
+
+**Files:**
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs:263-376` (RunFromPaths dispatch)
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs:380-506` (HandleCaptureScreenshot)
+
+- [ ] **Step 1: Restructure dispatch to support deferred responses**
+
+In `RunFromPaths` (line 263), the current structure is:
+```csharp
+EditorControlResponse response;
+switch (request.action) { ... }
+WriteResponse(responsePath, response);
+```
+
+Change the `capture_screenshot` case to handle deferred writing. Replace the entire block from line 287 (`EditorControlResponse response;`) through line 375 (`WriteResponse(responsePath, response);`):
+
+```csharp
+            EditorControlResponse response = null;
+            bool deferred = false;
+            switch (request.action)
+            {
+                case "capture_screenshot":
+                {
+                    bool isScene = string.Equals(request.view, "scene", StringComparison.OrdinalIgnoreCase);
+                    if (isScene)
+                    {
+                        // Defer Scene view capture by 1 frame for skinning recalculation
+                        EditorApplication.QueuePlayerLoopUpdate();
+                        string rp = responsePath;  // capture for closure
+                        EditorApplication.delayCall += () =>
+                        {
+                            var r = HandleCaptureScreenshot(request, requestPath);
+                            WriteResponse(rp, r);
+                        };
+                        deferred = true;
+                    }
+                    else
+                    {
+                        response = HandleCaptureScreenshot(request, requestPath);
+                    }
+                    break;
+                }
+                case "select_object":
+                    response = HandleSelectObject(request);
+                    break;
+```
+
+Keep all other cases exactly as-is (lines 293-372).
+
+After the switch, replace the single `WriteResponse` call with:
+
+```csharp
+            if (!deferred)
+                WriteResponse(responsePath, response);
+```
+
+- [ ] **Step 2: Remove pre-render setup from HandleCaptureScreenshot**
+
+The Scene view branch in `HandleCaptureScreenshot` (lines 410-414) has pre-render setup that was added in PR #2. Since the 1-frame delay now handles this, remove the redundant lines:
+
+Remove these lines (410-414):
+```csharp
+                        // Force scene state update before capture (non-focus safe)
+                        EditorApplication.QueuePlayerLoopUpdate();
+                        bool wasAlwaysRefresh = sceneView.sceneViewState.alwaysRefresh;
+                        sceneView.sceneViewState.alwaysRefresh = true;
+                        sceneView.Repaint();
+```
+
+And remove the restore line (422-423):
+```csharp
+                        // Restore alwaysRefresh
+                        sceneView.sceneViewState.alwaysRefresh = wasAlwaysRefresh;
+```
+
+The `HandleCaptureScreenshot` Scene view try block should now start directly with:
+```csharp
+                    try
+                    {
+                        rt = new RenderTexture(w, h, 24);
+                        RenderTexture prev = cam.targetTexture;
+                        cam.targetTexture = rt;
+                        cam.Render();
+                        cam.targetTexture = prev;
+
+                        RenderTexture.active = rt;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+git commit -m "fix(bridge): defer Scene view screenshot by 1 frame for skinning recalculation"
+```
+
+---
+
+## Task 2: C# — VRCSDKUploadHandler reflection dispatch
+
+**Files:**
+- Modify: `tools/unity/PrefabSentinel.UnityEditorControlBridge.cs:360-367` (vrcsdk_upload case)
+
+- [ ] **Step 1: Replace #if block with reflection call**
+
+Replace lines 360-367:
+```csharp
+                case "vrcsdk_upload":
+#if VRC_SDK_VRCSDK3
+                    response = VRCSDKUploadHandler.Handle(request);
+#else
+                    response = BuildError("VRCSDK_NOT_AVAILABLE",
+                        "VRC SDK not found in project. Install VRChat SDK 3.x");
+#endif
+                    break;
+```
+
+With:
+```csharp
+                case "vrcsdk_upload":
+                    response = TryHandleVrcsdkUpload(request);
+                    break;
+```
+
+- [ ] **Step 2: Add TryHandleVrcsdkUpload method**
+
+Add before the `WriteResponse` helper method (before line 1990):
+
+```csharp
+        private static EditorControlResponse TryHandleVrcsdkUpload(EditorControlRequest request)
+        {
+            var handlerType = System.Type.GetType(
+                "PrefabSentinel.VRCSDKUploadHandler, Assembly-CSharp-Editor");
+            if (handlerType == null)
+                return BuildError("VRCSDK_NOT_AVAILABLE",
+                    "VRCSDKUploadHandler not found. Deploy VRCSDKUploadHandler.cs to Assets/Editor/ " +
+                    "or VRC SDK is not installed in this project.");
+            var method = handlerType.GetMethod("Handle",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            if (method == null)
+                return BuildError("VRCSDK_NOT_AVAILABLE",
+                    "VRCSDKUploadHandler.Handle method not found. Check VRCSDKUploadHandler.cs version.");
+            try
+            {
+                return (EditorControlResponse)method.Invoke(null, new object[] { request });
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                var inner = ex.InnerException ?? ex;
+                return BuildError("VRCSDK_UPLOAD_FAILED", inner.Message);
+            }
+        }
+
+```
+
+Note: `TargetInvocationException` wrapping handles runtime errors from the reflected method gracefully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+git commit -m "fix(bridge): VRCSDK dispatch via reflection, remove compile-time dependency"
+```
+
+---
+
+## Task 3: Final verification
+
+- [ ] **Step 1: Lint Python (no changes expected, sanity check)**
+
+Run: `uv run ruff check prefab_sentinel/ tests/ 2>&1 | head -5`
+Expected: All checks passed (no Python changes in this PR).
+
+- [ ] **Step 2: Run Python tests**
+
+Run: `uv run python -m unittest tests.test_editor_bridge -v 2>&1 | tail -5`
+Expected: all tests PASS (no Python changes).
+
+- [ ] **Step 3: Note for Unity manual verification**
+
+Verify in Unity:
+1. **Deferred screenshot**: `set_blend_shape` (e.g. `vrc.v_aa=100`) → `editor_screenshot` with Unity **unfocused** → image should show updated blend shape
+2. **VRCSDK reflection**:
+   - Without `VRCSDKUploadHandler.cs` in project → `vrcsdk_upload` returns `VRCSDK_NOT_AVAILABLE` with "Deploy VRCSDKUploadHandler.cs" message
+   - With `VRCSDKUploadHandler.cs` in project → `vrcsdk_upload` works as before

--- a/docs/superpowers/specs/2026-03-26-screenshot-delay-vrcsdk-reflection-design.md
+++ b/docs/superpowers/specs/2026-03-26-screenshot-delay-vrcsdk-reflection-design.md
@@ -1,0 +1,103 @@
+# スクショ遅延キャプチャ + VRCSDKUploadHandler リフレクション化設計
+
+**日付:** 2026-03-26
+**由来:** PR #2 バグ修正検証レポート (`report_20260326_session3_bugfix_verification.md`)
+**アプローチ:** C# EditorControlBridge の2箇所修正
+
+---
+
+## 概要
+
+PR #2 で導入した ForceRenderAndRepaint では解決しなかった2件を対処する。
+
+---
+
+## 1. スクショの 1 フレーム遅延キャプチャ
+
+### 問題
+
+`QueuePlayerLoopUpdate` は非同期で次の Editor update にスケジュールするのみ。`set_blend_shape` → `editor_screenshot` が別リクエストでも、SkinnedMeshRenderer のスキニング再計算が間に合わずスクショに反映されない。
+
+### 設計
+
+`HandleCaptureScreenshot` の Scene ビュー分岐を `delayCall` で 1 フレーム遅延。
+
+```csharp
+case "capture_screenshot":
+    if (isSceneView)
+    {
+        EditorApplication.QueuePlayerLoopUpdate();
+        EditorApplication.delayCall += () =>
+        {
+            var response = DoCaptureScreenshot(request, requestPath);
+            WriteResponseAtomic(responsePath, response);
+        };
+        return; // メインパスではレスポンスを書かない
+    }
+    else
+    {
+        response = DoCaptureScreenshot(request, requestPath);
+    }
+    break;
+```
+
+**変更点:**
+- `HandleCaptureScreenshot` のキャプチャロジックを `DoCaptureScreenshot` に抽出
+- Scene ビューの場合のみ `delayCall` で 1 フレーム遅延
+- `delayCall` コールバック内でレスポンスファイルを直接書き込み（`WriteResponseAtomic` を dispatch メソッドから抽出）
+- dispatch のメインパスではレスポンス書き込みをスキップ（`return` で抜ける）
+
+**影響:** Python 側は変更なし。ポーリング間隔 1 秒 >> 1 フレーム ~16ms。
+
+---
+
+## 2. VRCSDKUploadHandler リフレクション化
+
+### 問題
+
+`#if VRC_SDK_VRCSDK3` で `VRCSDKUploadHandler.Handle()` を直接呼ぶため、VRC SDK プロジェクトで `.cs` 未配置時にコンパイルエラー。
+
+### 設計
+
+dispatch の `#if` を除去し、リフレクションでランタイム検出。
+
+```csharp
+private static EditorControlResponse TryHandleVrcsdkUpload(EditorControlRequest request)
+{
+    var handlerType = System.Type.GetType(
+        "PrefabSentinel.VRCSDKUploadHandler, Assembly-CSharp-Editor");
+    if (handlerType == null)
+        return BuildError("VRCSDK_NOT_AVAILABLE",
+            "VRCSDKUploadHandler not found. Copy VRCSDKUploadHandler.cs to Assets/Editor/.");
+    var method = handlerType.GetMethod("Handle",
+        System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+    if (method == null)
+        return BuildError("VRCSDK_NOT_AVAILABLE",
+            "VRCSDKUploadHandler.Handle method not found.");
+    return (EditorControlResponse)method.Invoke(null, new object[] { request });
+}
+```
+
+**変更点:**
+- dispatch の `#if VRC_SDK_VRCSDK3` ブロックを除去、`TryHandleVrcsdkUpload` に置換
+- `VRCSDKUploadHandler.cs` 未配置 → 明確なエラーメッセージ（コンパイルは通る）
+- `VRCSDKUploadHandler.cs` 配置済み → 従来通りリフレクション経由で動作
+- `VRCSDKUploadHandler.cs` 自体は変更なし
+
+---
+
+## 実装順序
+
+| ステップ | 内容 |
+|---------|------|
+| 1 | dispatch から WriteResponseAtomic を抽出、DoCaptureScreenshot を抽出 |
+| 2 | Scene ビュースクショの delayCall 遅延 |
+| 3 | TryHandleVrcsdkUpload リフレクション化、#if 除去 |
+| 4 | テスト・lint |
+
+---
+
+## スコープ外
+
+- Game ビューの遅延キャプチャ（Game ビューは通常フォーカス状態で使う）
+- ForceRenderAndRepaint の除去（他の視覚更新系で引き続き有用）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.82"
+version = "0.5.83"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -50,7 +50,7 @@ disable_error_code = ["arg-type", "index", "assignment", "var-annotated", "no-re
 packages = ["prefab_sentinel"]
 
 [tool.bumpversion]
-current_version = "0.5.82"
+current_version = "0.5.83"
 commit = false
 tag = false
 allow_dirty = true

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -284,12 +284,31 @@ namespace PrefabSentinel
                 return;
             }
 
-            EditorControlResponse response;
+            EditorControlResponse response = null;
+            bool deferred = false;
             switch (request.action)
             {
                 case "capture_screenshot":
-                    response = HandleCaptureScreenshot(request, requestPath);
+                {
+                    bool isScene = string.Equals(request.view, "scene", StringComparison.OrdinalIgnoreCase);
+                    if (isScene)
+                    {
+                        // Defer Scene view capture by 1 frame for skinning recalculation
+                        EditorApplication.QueuePlayerLoopUpdate();
+                        string rp = responsePath;  // capture for closure
+                        EditorApplication.delayCall += () =>
+                        {
+                            var r = HandleCaptureScreenshot(request, requestPath);
+                            WriteResponse(rp, r);
+                        };
+                        deferred = true;
+                    }
+                    else
+                    {
+                        response = HandleCaptureScreenshot(request, requestPath);
+                    }
                     break;
+                }
                 case "select_object":
                     response = HandleSelectObject(request);
                     break;
@@ -358,12 +377,7 @@ namespace PrefabSentinel
                     response = HandleFindRenderersByMaterial(request);
                     break;
                 case "vrcsdk_upload":
-#if VRC_SDK_VRCSDK3
-                    response = VRCSDKUploadHandler.Handle(request);
-#else
-                    response = BuildError("VRCSDK_NOT_AVAILABLE",
-                        "VRC SDK not found in project. Install VRChat SDK 3.x");
-#endif
+                    response = TryHandleVrcsdkUpload(request);
                     break;
                 default:
                     response = BuildError(
@@ -372,7 +386,8 @@ namespace PrefabSentinel
                     break;
             }
 
-            WriteResponse(responsePath, response);
+            if (!deferred)
+                WriteResponse(responsePath, response);
         }
 
         // ── Action Handlers ──
@@ -407,20 +422,11 @@ namespace PrefabSentinel
                     Texture2D tex = null;
                     try
                     {
-                        // Force scene state update before capture (non-focus safe)
-                        EditorApplication.QueuePlayerLoopUpdate();
-                        bool wasAlwaysRefresh = sceneView.sceneViewState.alwaysRefresh;
-                        sceneView.sceneViewState.alwaysRefresh = true;
-                        sceneView.Repaint();
-
                         rt = new RenderTexture(w, h, 24);
                         RenderTexture prev = cam.targetTexture;
                         cam.targetTexture = rt;
                         cam.Render();
                         cam.targetTexture = prev;
-
-                        // Restore alwaysRefresh
-                        sceneView.sceneViewState.alwaysRefresh = wasAlwaysRefresh;
 
                         RenderTexture.active = rt;
                         tex = new Texture2D(w, h, TextureFormat.RGB24, false);
@@ -1985,6 +1991,30 @@ namespace PrefabSentinel
             for (int i = 0; i < count; i++)
                 names.Add(shader.GetPropertyName(i));
             return names;
+        }
+
+        private static EditorControlResponse TryHandleVrcsdkUpload(EditorControlRequest request)
+        {
+            var handlerType = System.Type.GetType(
+                "PrefabSentinel.VRCSDKUploadHandler, Assembly-CSharp-Editor");
+            if (handlerType == null)
+                return BuildError("VRCSDK_NOT_AVAILABLE",
+                    "VRCSDKUploadHandler not found. Deploy VRCSDKUploadHandler.cs to Assets/Editor/ " +
+                    "or VRC SDK is not installed in this project.");
+            var method = handlerType.GetMethod("Handle",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            if (method == null)
+                return BuildError("VRCSDK_NOT_AVAILABLE",
+                    "VRCSDKUploadHandler.Handle method not found. Check VRCSDKUploadHandler.cs version.");
+            try
+            {
+                return (EditorControlResponse)method.Invoke(null, new object[] { request });
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                var inner = ex.InnerException ?? ex;
+                return BuildError("VRCSDK_UPLOAD_FAILED", inner.Message);
+            }
         }
 
         private static void WriteResponse(string responsePath, EditorControlResponse response)

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.82"
+version = "0.5.83"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- **Deferred Scene screenshot**: Scene ビューのスクショを `delayCall` で 1 フレーム遅延。`QueuePlayerLoopUpdate` 後にスキニング再計算が完了してからキャプチャ。非フォーカス時の blend shape / material 変更がスクショに反映される
- **VRCSDK reflection**: `#if VRC_SDK_VRCSDK3` のコンパイル時依存を除去。`VRCSDKUploadHandler.cs` 未配置でもコンパイルエラーにならず、明確なエラーメッセージを返す

## Test plan

- [x] Python unit tests: 23/23 PASS (C# only の変更)
- [ ] Unity: set_blend_shape → editor_screenshot（非フォーカス）で変更が反映されるか
- [ ] Unity: VRCSDKUploadHandler.cs 未配置で vrcsdk_upload → VRCSDK_NOT_AVAILABLE エラー
- [ ] Unity: VRCSDKUploadHandler.cs 配置済みで vrcsdk_upload → 正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)