### PR TITLE
fix: SceneView.Focus() for deferred screenshot

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.83",
+  "version": "0.5.84",
   "description": "Unity Prefab/Scene/Asset の検査・編集・参照修復ツール",
   "author": {
     "name": "tyunta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.83"
+version = "0.5.84"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -50,7 +50,7 @@ disable_error_code = ["arg-type", "index", "assignment", "var-annotated", "no-re
 packages = ["prefab_sentinel"]
 
 [tool.bumpversion]
-current_version = "0.5.83"
+current_version = "0.5.84"
 commit = false
 tag = false
 allow_dirty = true

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -293,7 +293,10 @@ namespace PrefabSentinel
                     bool isScene = string.Equals(request.view, "scene", StringComparison.OrdinalIgnoreCase);
                     if (isScene)
                     {
-                        // Defer Scene view capture by 1 frame for skinning recalculation
+                        // Focus SceneView to ensure rendering pipeline runs even when unfocused,
+                        // then defer capture by 1 frame for skinning recalculation
+                        SceneView sv = SceneView.lastActiveSceneView;
+                        if (sv != null) sv.Focus();
                         EditorApplication.QueuePlayerLoopUpdate();
                         string rp = responsePath;  // capture for closure
                         EditorApplication.delayCall += () =>

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.83"
+version = "0.5.84"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

PR #4 のスクショ遅延キャプチャが 100% レグレッション（`EDITOR_BRIDGE_NO_RESPONSE`）。原因: 非フォーカス時に `delayCall` が発火しない。

`SceneView.Focus()` を `delayCall` 前に追加:
1. SceneView がフォーカスを得る → レンダリングパイプラインが起動
2. `delayCall` が次の editor update で発火する
3. スキニング再計算完了後に `Camera.Render()` → 正しい画像がキャプチャされる

## Test plan

- [ ] Unity: `set_blend_shape` → `editor_screenshot`（非フォーカス）→ 変更が反映されるか
- [ ] Unity: `editor_screenshot(view="scene")` がタイムアウトしないか
- [ ] Unity: `editor_screenshot(view="game")` が従来通り動作するか

🤖 Generated with [Claude Code](https://claude.com/claude-code)