### PR TITLE
feat: add editor_batch_set_material_property MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ prefab-sentinel-mcp --transport streamable-http
 | `editor_create_primitive` | プリミティブ (Cube/Sphere 等) を1回で作成 (位置・スケール・回転指定) |
 | `editor_batch_create` | 複数オブジェクトを1リクエストで一括生成 (Undo グループ) |
 | `editor_batch_set_property` | 複数プロパティを1リクエストで一括設定 (Undo グループ) |
+| `editor_batch_set_material_property` | 同一マテリアルの複数シェーダープロパティを1リクエストで一括設定 (Undo グループ) |
 | `editor_open_scene` | シーンを開く (single/additive) |
 | `editor_save_scene` | シーンを保存 |
 | `editor_batch_add_component` | 複数オブジェクトにコンポーネントを一括追加 (Undo グループ、初期値対応) |

--- a/prefab_sentinel/editor_bridge.py
+++ b/prefab_sentinel/editor_bridge.py
@@ -72,6 +72,7 @@ SUPPORTED_ACTIONS = frozenset(
         "editor_create_primitive",
         "editor_batch_create",
         "editor_batch_set_property",
+        "editor_batch_set_material_property",
         "editor_open_scene",
         "editor_save_scene",
         # Phase 7: UX Review improvements

--- a/prefab_sentinel/mcp_server.py
+++ b/prefab_sentinel/mcp_server.py
@@ -77,6 +77,11 @@ def _extract_description(path: Path) -> str:
     return path.stem
 
 
+def _normalize_material_value(value: str | list | int | float) -> str:
+    """Serialize a material property value to its string representation."""
+    return value if isinstance(value, str) else json.dumps(value)
+
+
 def create_server(
     project_root: str | Path | None = None,
 ) -> FastMCP:
@@ -1242,14 +1247,38 @@ def create_server(
                 Vector: "[0, 1, 0, 0]" (XYZW)
                 Texture: "guid:abc123..." or "path:Assets/Tex/foo.png" or "" (null)
         """
-        import json as _json
-        str_value = value if isinstance(value, str) else _json.dumps(value)
         return send_action(
             action="set_material_property",
             hierarchy_path=hierarchy_path,
             material_index=material_index,
             property_name=property_name,
-            property_value=str_value,
+            property_value=_normalize_material_value(value),
+        )
+
+    @server.tool()
+    def editor_batch_set_material_property(
+        hierarchy_path: str,
+        material_index: int,
+        properties: list[dict[str, str | list | int | float]],
+    ) -> dict[str, Any]:
+        """Set multiple shader properties on one material in a single request (Undo-grouped).
+
+        Args:
+            hierarchy_path: Hierarchy path to the GameObject with a Renderer.
+            material_index: Material slot index (0-based).
+            properties: List of property dicts, each with "name" and "value".
+                Value formats are the same as editor_set_material_property.
+        """
+        normalized = [
+            {"name": prop["name"], "value": _normalize_material_value(prop["value"])}
+            for prop in properties
+        ]
+
+        return send_action(
+            action="editor_batch_set_material_property",
+            hierarchy_path=hierarchy_path,
+            material_index=material_index,
+            batch_operations_json=json.dumps(normalized, ensure_ascii=False),
         )
 
     @server.tool()

--- a/tests/test_editor_bridge.py
+++ b/tests/test_editor_bridge.py
@@ -201,6 +201,7 @@ class TestSupportedActions(unittest.TestCase):
             "editor_create_primitive",
             "editor_batch_create",
             "editor_batch_set_property",
+            "editor_batch_set_material_property",
             "editor_open_scene",
             "editor_save_scene",
             "editor_batch_add_component",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -84,6 +84,7 @@ class TestToolRegistration(unittest.TestCase):
             "editor_set_parent",
             "editor_create_empty", "editor_create_primitive",
             "editor_batch_create", "editor_batch_set_property",
+            "editor_batch_set_material_property",
             "editor_open_scene", "editor_save_scene",
             "editor_batch_add_component", "editor_create_scene",
             # Infrastructure tools
@@ -99,7 +100,7 @@ class TestToolRegistration(unittest.TestCase):
     def test_tool_count(self) -> None:
         server = create_server()
         tools = _run(server.list_tools())
-        self.assertEqual(62, len(tools))
+        self.assertEqual(63, len(tools))
 
 
 class TestSymbolTools(unittest.TestCase):
@@ -2033,6 +2034,27 @@ class TestEditorWriteTools(unittest.TestCase):
             property_name="_Color",
             property_value="[1, 0, 0, 1]",
         )
+
+    def test_editor_batch_set_material_property_delegates(self) -> None:
+        server = create_server()
+        with patch("prefab_sentinel.mcp_server.send_action", return_value={"success": True}) as mock_send:
+            _run(server.call_tool("editor_batch_set_material_property", {
+                "hierarchy_path": "/Avatar/Hair",
+                "material_index": 0,
+                "properties": [
+                    {"name": "_Color", "value": "[1, 0, 0, 1]"},
+                    {"name": "_MainTexHSVG", "value": [0.02, 0.48, 1.18, 1]},
+                ],
+            }))
+        args = mock_send.call_args
+        self.assertEqual(args.kwargs["action"], "editor_batch_set_material_property")
+        self.assertEqual(args.kwargs["hierarchy_path"], "/Avatar/Hair")
+        self.assertEqual(args.kwargs["material_index"], 0)
+        import json
+        ops = json.loads(args.kwargs["batch_operations_json"])
+        self.assertEqual(len(ops), 2)
+        self.assertEqual(ops[0], {"name": "_Color", "value": "[1, 0, 0, 1]"})
+        self.assertEqual(ops[1], {"name": "_MainTexHSVG", "value": "[0.02, 0.48, 1.18, 1]"})
 
     def test_editor_delete_delegates(self) -> None:
         server = create_server()

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -422,6 +422,9 @@ namespace PrefabSentinel
                 case "editor_batch_set_property":
                     response = HandleEditorBatchSetProperty(request);
                     break;
+                case "editor_batch_set_material_property":
+                    response = HandleEditorBatchSetMaterialProperty(request);
+                    break;
                 case "editor_open_scene":
                     response = HandleEditorOpenScene(request);
                     break;
@@ -1515,6 +1518,69 @@ namespace PrefabSentinel
                 evidence = "Undo.RecordObject"
             }};
             return resp;
+        }
+
+        private static EditorControlResponse HandleEditorBatchSetMaterialProperty(EditorControlRequest request)
+        {
+            if (string.IsNullOrEmpty(request.batch_operations_json))
+                return BuildError("EDITOR_CTRL_BATCH_SET_MAT_PROP_NO_DATA", "batch_operations_json is required.");
+
+            BatchSetMaterialPropertyArray wrapper;
+            try
+            {
+                wrapper = JsonUtility.FromJson<BatchSetMaterialPropertyArray>(
+                    "{\"items\":" + request.batch_operations_json + "}");
+            }
+            catch (System.Exception ex)
+            {
+                return BuildError("EDITOR_CTRL_BATCH_SET_MAT_PROP_JSON_ERROR",
+                    $"Failed to parse batch_operations_json: {ex.Message}");
+            }
+
+            if (wrapper.items == null || wrapper.items.Length == 0)
+                return BuildError("EDITOR_CTRL_BATCH_SET_MAT_PROP_EMPTY", "batch_operations_json is empty.");
+
+            int undoGroup = Undo.GetCurrentGroup();
+            Undo.SetCurrentGroupName("PrefabSentinel: Batch SetMaterialProperty");
+
+            var setNames = new System.Collections.Generic.List<string>();
+
+            foreach (var op in wrapper.items)
+            {
+                var subReq = new EditorControlRequest
+                {
+                    action = "set_material_property",
+                    hierarchy_path = request.hierarchy_path,
+                    material_index = request.material_index,
+                    property_name = op.name,
+                    property_value = op.value,
+                };
+                var subResp = HandleSetMaterialProperty(subReq);
+                if (!subResp.success)
+                {
+                    Undo.CollapseUndoOperations(undoGroup);
+                    return BuildError("EDITOR_CTRL_BATCH_SET_MAT_PROP_FAILED",
+                        $"Operation failed at index {setNames.Count}: {subResp.message}");
+                }
+                setNames.Add(op.name);
+            }
+
+            Undo.CollapseUndoOperations(undoGroup);
+
+            var batchResp = BuildSuccess("EDITOR_CTRL_BATCH_SET_MAT_PROP_OK",
+                $"Set {setNames.Count} material properties",
+                data: new EditorControlData
+                {
+                    executed = true,
+                    read_only = false,
+                    suggestions = setNames.ToArray(),
+                });
+            batchResp.diagnostics = new[] { new EditorControlDiagnostic
+            {
+                detail = "Runtime modification \u2014 save the scene (File > Save) to persist.",
+                evidence = "Undo.CollapseUndoOperations"
+            }};
+            return batchResp;
         }
 
         private static void CollectChildren(Transform parent, int maxDepth, int currentDepth, List<ChildEntry> result)
@@ -2989,6 +3055,16 @@ namespace PrefabSentinel
 
         [Serializable]
         private sealed class BatchSetPropertyArray { public BatchSetPropertyOp[] items; }
+
+        [Serializable]
+        private sealed class BatchSetMaterialPropertyOp
+        {
+            public string name = string.Empty;
+            public string value = string.Empty;
+        }
+
+        [Serializable]
+        private sealed class BatchSetMaterialPropertyArray { public BatchSetMaterialPropertyOp[] items; }
 
         [Serializable]
         private sealed class PropertyEntry


### PR DESCRIPTION
## Summary
- Add `editor_batch_set_material_property` MCP tool to set multiple shader properties on a single material in one call
- Implements C# handler with Undo grouping, error reporting at failed index, and JSON deserialization
- Extracts shared `_normalize_material_value` helper (DRY with existing single-property tool)
- Updates README.md, SUPPORTED_ACTIONS, and adds delegate + registration tests

## Test plan
- [x] All 158 unit tests pass (`test_mcp_server.py`, `test_editor_bridge.py`)
- [x] No regressions (1324 passed across full suite; 10 pre-existing smoke failures unchanged)
- [x] Tool count updated from 62 → 63
- [x] Value normalization tested (string passthrough, list→JSON serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)