### PR TITLE
feat: implement 7 GitHub issues (#44, #46, #48, #50, #51, #53, #56)

### DIFF
--- a/prefab_sentinel/bridge_smoke.py
+++ b/prefab_sentinel/bridge_smoke.py
@@ -14,6 +14,7 @@ from prefab_sentinel.bridge_constants import (
     UNITY_TIMEOUT_SEC_ENV,
     VALID_SEVERITIES,
 )
+from prefab_sentinel.json_io import dump_json, load_json
 from prefab_sentinel.patch_plan import (
     build_bridge_request as _build_bridge_request_impl,
     count_plan_ops,
@@ -110,7 +111,7 @@ def run_bridge(
 ) -> dict[str, Any]:
     completed = subprocess.run(
         [python_executable, str(bridge_script)],
-        input=json.dumps(request, ensure_ascii=False),
+        input=dump_json(request, indent=None),
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -123,7 +124,7 @@ def run_bridge(
             f"Bridge process exited with {completed.returncode}: {completed.stderr.strip()}"
         )
     try:
-        payload = json.loads(completed.stdout)
+        payload = load_json(completed.stdout)
     except json.JSONDecodeError as exc:
         raise RuntimeError("Bridge stdout is not valid JSON.") from exc
     if not isinstance(payload, dict):

--- a/prefab_sentinel/editor_bridge.py
+++ b/prefab_sentinel/editor_bridge.py
@@ -24,6 +24,11 @@ from prefab_sentinel.bridge_constants import (
     BRIDGE_WATCH_DIR_ENV,
     UNITY_TIMEOUT_SEC_ENV as BRIDGE_TIMEOUT_ENV,
 )
+from prefab_sentinel.editor_bridge_builders import (  # noqa: F401
+    build_create_empty_kwargs,
+    build_set_camera_kwargs,
+)
+from prefab_sentinel.json_io import dump_json, load_json
 
 PROTOCOL_VERSION = 1
 # Empirical: sufficient for typical Inspector operations in loaded projects
@@ -179,7 +184,7 @@ def send_action(
     try:
         watch_dir.mkdir(parents=True, exist_ok=True)
         tmp_file.write_text(
-            json.dumps(request_payload, ensure_ascii=False),
+            dump_json(request_payload, indent=None),
             encoding="utf-8",
         )
         tmp_file.rename(request_file)
@@ -196,7 +201,7 @@ def send_action(
         if response_file.exists():
             try:
                 raw = response_file.read_text(encoding="utf-8")
-                payload = json.loads(raw)
+                payload = load_json(raw)
             except (OSError, json.JSONDecodeError) as exc:
                 return _error_response(
                     code="EDITOR_BRIDGE_RESPONSE_READ",
@@ -259,60 +264,3 @@ def get_last_bridge_version() -> str | None:
     return _last_bridge_version
 
 
-def build_set_camera_kwargs(
-    *,
-    pivot: str = "",
-    yaw: float = float("nan"),
-    pitch: float = float("nan"),
-    distance: float = -1.0,
-    orthographic: int = -1,
-    position: str = "",
-    look_at: str = "",
-) -> dict[str, Any]:
-    """Build send_action kwargs from set_camera parameters.
-
-    Keeps parameter parsing separate from MCP server for testability.
-    """
-    import json as _json
-    import math
-
-    kwargs: dict[str, Any] = {}
-
-    if position:
-        p = _json.loads(position)
-        kwargs["camera_position"] = [p["x"], p["y"], p["z"]]
-    if look_at:
-        la = _json.loads(look_at)
-        kwargs["camera_look_at"] = [la["x"], la["y"], la["z"]]
-    if pivot:
-        pv = _json.loads(pivot)
-        kwargs["camera_pivot"] = [pv["x"], pv["y"], pv["z"]]
-    if not math.isnan(yaw):
-        kwargs["yaw"] = yaw
-    if not math.isnan(pitch):
-        kwargs["pitch"] = pitch
-    if distance >= 0:
-        kwargs["distance"] = distance
-    if orthographic >= 0:
-        kwargs["camera_orthographic"] = orthographic
-
-    return kwargs
-
-
-def build_create_empty_kwargs(
-    *,
-    name: str,
-    parent_path: str = "",
-    position: str = "",
-) -> dict[str, str]:
-    """Build send_action kwargs from editor_create_empty parameters.
-
-    Omits empty optional fields so the bridge receives only explicitly
-    specified values.
-    """
-    kwargs: dict[str, str] = {"new_name": name}
-    if parent_path:
-        kwargs["hierarchy_path"] = parent_path
-    if position:
-        kwargs["property_value"] = position
-    return kwargs

--- a/prefab_sentinel/editor_bridge_builders.py
+++ b/prefab_sentinel/editor_bridge_builders.py
@@ -1,0 +1,58 @@
+"""Builder functions for editor bridge action kwargs.
+
+Converts MCP tool parameters into the dict format expected by
+:func:`~prefab_sentinel.editor_bridge.send_action`.
+"""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from prefab_sentinel.json_io import load_json
+
+
+def build_set_camera_kwargs(
+    *,
+    pivot: str = "",
+    yaw: float = float("nan"),
+    pitch: float = float("nan"),
+    distance: float = -1.0,
+    orthographic: int = -1,
+    position: str = "",
+    look_at: str = "",
+) -> dict[str, Any]:
+    """Build send_action kwargs from set_camera parameters."""
+    kwargs: dict[str, Any] = {}
+    if position:
+        p = load_json(position)
+        kwargs["camera_position"] = [p["x"], p["y"], p["z"]]
+    if look_at:
+        la = load_json(look_at)
+        kwargs["camera_look_at"] = [la["x"], la["y"], la["z"]]
+    if pivot:
+        pv = load_json(pivot)
+        kwargs["camera_pivot"] = [pv["x"], pv["y"], pv["z"]]
+    if not math.isnan(yaw):
+        kwargs["yaw"] = yaw
+    if not math.isnan(pitch):
+        kwargs["pitch"] = pitch
+    if distance >= 0:
+        kwargs["distance"] = distance
+    if orthographic >= 0:
+        kwargs["camera_orthographic"] = orthographic
+    return kwargs
+
+
+def build_create_empty_kwargs(
+    *,
+    name: str,
+    parent_path: str = "",
+    position: str = "",
+) -> dict[str, str]:
+    """Build send_action kwargs from editor_create_empty parameters."""
+    kwargs: dict[str, str] = {"new_name": name}
+    if parent_path:
+        kwargs["hierarchy_path"] = parent_path
+    if position:
+        kwargs["property_value"] = position
+    return kwargs

--- a/prefab_sentinel/integration_tests.py
+++ b/prefab_sentinel/integration_tests.py
@@ -13,13 +13,13 @@ This module provides:
 
 from __future__ import annotations
 
-import json
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
 
 from prefab_sentinel.bridge_constants import VALID_SEVERITIES
+from prefab_sentinel.json_io import load_json
 from prefab_sentinel.wsl_compat import needs_windows_paths, split_unity_command, to_windows_path
 
 _CS_FILES = [
@@ -161,7 +161,7 @@ _REQUIRED_FIELDS = {"success", "severity", "code", "message", "data"}
 def parse_integration_results(results_path: Path) -> dict[str, Any]:
     """Read, validate, and return integration test results."""
     text = results_path.read_text(encoding="utf-8")
-    data: dict[str, Any] = json.loads(text)
+    data: dict[str, Any] = load_json(text)
 
     missing = _REQUIRED_FIELDS - set(data.keys())
     if missing:

--- a/prefab_sentinel/json_io.py
+++ b/prefab_sentinel/json_io.py
@@ -1,0 +1,34 @@
+"""Centralized JSON serialization and deserialization helpers."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def dump_json(data: Any, **kwargs: Any) -> str:
+    """Serialize *data* to a JSON string.
+
+    Defaults to ``ensure_ascii=False`` and ``indent=2``.
+    Callers may override any ``json.dumps`` keyword via **kwargs.
+    """
+    merged = {"ensure_ascii": False, "indent": 2, **kwargs}
+    return json.dumps(data, **merged)
+
+
+def load_json(text: str, **kwargs: Any) -> Any:
+    """Deserialize a JSON string.
+
+    Propagates ``json.JSONDecodeError`` without swallowing it.
+    """
+    return json.loads(text, **kwargs)
+
+
+def load_json_file(path: str | Path) -> Any:
+    """Read a file and parse its content as JSON.
+
+    Raises:
+        OSError: If the file cannot be read.
+        json.JSONDecodeError: If the content is not valid JSON.
+    """
+    return json.loads(Path(path).read_text(encoding="utf-8"))

--- a/prefab_sentinel/material_asset_inspector.py
+++ b/prefab_sentinel/material_asset_inspector.py
@@ -8,6 +8,7 @@ file *itself*.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from pathlib import Path
 
 from prefab_sentinel.contracts import error_dict as _error_dict, success_dict as _success_dict
 from prefab_sentinel.fuzzy_match import suggest_similar
+from prefab_sentinel.json_io import load_json
 from prefab_sentinel.unity_assets import (
     collect_project_guid_index,
     decode_text_file,
@@ -428,8 +430,6 @@ def _replace_property(
     category: str,
 ) -> str:
     """Replace a property value in the full .mat text."""
-    import json as _json
-
     if category == "float":
         try:
             float(value)
@@ -452,11 +452,11 @@ def _replace_property(
 
     if category == "color":
         try:
-            parts = _json.loads(value)
+            parts = load_json(value)
             if not isinstance(parts, list) or len(parts) != 4:
                 raise ValueError("Color must be [r, g, b, a]")
             r, g, b, a = (float(x) for x in parts)
-        except (ValueError, TypeError, _json.JSONDecodeError) as exc:
+        except (ValueError, TypeError, json.JSONDecodeError) as exc:
             raise ValueError(f"Invalid color value '{value}': {exc}") from None
         new_val = f"{{r: {r}, g: {g}, b: {b}, a: {a}}}"
         pattern = re.compile(

--- a/prefab_sentinel/mcp_server.py
+++ b/prefab_sentinel/mcp_server.py
@@ -32,6 +32,7 @@ from prefab_sentinel.editor_bridge import (
     send_action,
 )
 from prefab_sentinel.fuzzy_match import suggest_similar
+from prefab_sentinel.json_io import dump_json, load_json
 from prefab_sentinel.patch_plan import PLAN_VERSION
 from prefab_sentinel.patch_revert import revert_overrides as revert_overrides_impl
 from prefab_sentinel.session import InvalidProjectRootError, ProjectSession
@@ -1442,7 +1443,7 @@ def create_server(
 
         if report_path is not None and effective_confirm:
             report_path.write_text(
-                json.dumps(result, ensure_ascii=False, indent=2) + "\n",
+                dump_json(result) + "\n",
                 encoding="utf-8",
             )
 
@@ -1767,7 +1768,7 @@ def create_server(
         if isinstance(data, dict):
             prj = data.pop("platform_results_json", "")
             if prj:
-                data["platform_results"] = json.loads(prj)
+                data["platform_results"] = load_json(prj)
             if not confirm:
                 data["platforms"] = platforms
 
@@ -1896,7 +1897,7 @@ def create_server(
             "component_type": component_type,
         }
         if properties:
-            kwargs["properties_json"] = json.dumps(properties, ensure_ascii=False)
+            kwargs["properties_json"] = dump_json(properties, indent=None)
         return send_action(action="editor_add_component", **kwargs)
 
     @server.tool()
@@ -2141,7 +2142,7 @@ def create_server(
         """
         return send_action(
             action="editor_create_empty",
-            **build_create_empty_kwargs(name=name, parent_path=parent_path, position=position),  # type: ignore[arg-type]
+            **build_create_empty_kwargs(name=name, parent_path=parent_path, position=position),  # type: ignore[arg-type]  # dict[str, str] unpacks safely into **kwargs: Any
         )
 
     @server.tool()
@@ -2191,7 +2192,7 @@ def create_server(
         """
         return send_action(
             action="editor_batch_create",
-            batch_objects_json=json.dumps(objects, ensure_ascii=False),
+            batch_objects_json=dump_json(objects, indent=None),
         )
 
     @server.tool()
@@ -2208,7 +2209,7 @@ def create_server(
         """
         return send_action(
             action="editor_batch_set_property",
-            batch_operations_json=json.dumps(operations, ensure_ascii=False),
+            batch_operations_json=dump_json(operations, indent=None),
         )
 
     @server.tool()
@@ -2289,7 +2290,7 @@ def create_server(
 
         return send_action(
             action="editor_batch_set_property",
-            batch_operations_json=json.dumps(operations, ensure_ascii=False),
+            batch_operations_json=dump_json(operations, indent=None),
         )
 
     @server.tool()
@@ -2320,7 +2321,7 @@ def create_server(
         ]
 
         kwargs: dict[str, Any] = {
-            "batch_operations_json": json.dumps(normalized, ensure_ascii=False),
+            "batch_operations_json": dump_json(normalized, indent=None),
         }
         if hierarchy_path:
             kwargs["hierarchy_path"] = hierarchy_path
@@ -2388,12 +2389,12 @@ def create_server(
             op_copy = dict(op)
             props = op_copy.pop("properties", None)
             if props and "properties_json" not in op_copy:
-                op_copy["properties_json"] = json.dumps(props, ensure_ascii=False)
+                op_copy["properties_json"] = dump_json(props, indent=None)
             serialized_ops.append(op_copy)
 
         return send_action(
             action="editor_batch_add_component",
-            batch_operations_json=json.dumps(serialized_ops, ensure_ascii=False),
+            batch_operations_json=dump_json(serialized_ops, indent=None),
         )
 
     @server.tool()
@@ -2499,7 +2500,7 @@ def create_server(
             raw_json = data.pop("reflect_result_json", "")
             if raw_json:
                 try:
-                    data.update(json.loads(raw_json))
+                    data.update(load_json(raw_json))
                 except json.JSONDecodeError as exc:
                     return _reflect_error(
                         "EDITOR_REFLECT_PARSE",
@@ -2748,7 +2749,7 @@ def create_server(
             plan_dict = plan
         else:
             try:
-                plan_dict = json.loads(plan)
+                plan_dict = load_json(plan)
             except (ValueError, TypeError) as exc:
                 return {
                     "success": False, "severity": "error", "code": "INVALID_PLAN_JSON",

--- a/prefab_sentinel/patch_plan.py
+++ b/prefab_sentinel/patch_plan.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import json
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
+
+from prefab_sentinel.json_io import load_json_file
 
 PLAN_VERSION = 2
 _DEFAULT_RESOURCE_ID = "target"
@@ -157,7 +158,7 @@ def normalize_patch_plan(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def load_patch_plan(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = load_json_file(path)
     return normalize_patch_plan(payload)
 
 

--- a/prefab_sentinel/plan_builder.py
+++ b/prefab_sentinel/plan_builder.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Self
 
+from prefab_sentinel.json_io import dump_json
 from prefab_sentinel.patch_plan import PLAN_VERSION, normalize_patch_plan
 
 
@@ -201,7 +201,7 @@ class PatchPlanBuilder:
         return normalize_patch_plan(raw)
 
     def to_json(self, *, indent: int = 2) -> str:
-        return json.dumps(self.build(), ensure_ascii=False, indent=indent)
+        return dump_json(self.build(), indent=indent)
 
     def write(self, path: str | Path) -> None:
         dest = Path(path)

--- a/prefab_sentinel/reporting.py
+++ b/prefab_sentinel/reporting.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import csv
 import io
-import json
 from pathlib import Path
 from typing import Any
+
+from prefab_sentinel.json_io import dump_json
 
 
 def _extract_ref_scan_data(payload_data: dict[str, Any]) -> dict[str, Any]:
@@ -208,7 +209,7 @@ def render_markdown_report(
         [
             "## Data",
             "```json",
-            json.dumps(payload_data, ensure_ascii=False, indent=2),
+            dump_json(payload_data),
             "```",
             "",
             "## Diagnostics",
@@ -284,7 +285,7 @@ def export_report(
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     if fmt == "json":
-        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        out.write_text(dump_json(payload) + "\n", encoding="utf-8")
     elif fmt == "md":
         out.write_text(
             render_markdown_report(

--- a/prefab_sentinel/services/runtime_validation.py
+++ b/prefab_sentinel/services/runtime_validation.py
@@ -21,6 +21,7 @@ from prefab_sentinel.bridge_constants import (
     UNITY_TIMEOUT_SEC_ENV,
 )
 from prefab_sentinel.contracts import Diagnostic, Severity, ToolResponse, error_response, max_severity, success_response
+from prefab_sentinel.json_io import dump_json, load_json, load_json_file
 from prefab_sentinel.unity_assets import decode_text_file, find_project_root, relative_to_root, resolve_scope_path
 from prefab_sentinel.wsl_compat import needs_windows_paths, split_unity_command, to_windows_path, to_wsl_path
 
@@ -316,7 +317,7 @@ class RuntimeValidationService:
                 "timeout_sec": int(config["timeout_sec"]),
             }
             request_path.write_text(
-                json.dumps(payload, ensure_ascii=False),
+                dump_json(payload, indent=None),
                 encoding="utf-8",
             )
             command = self._build_runtime_command(
@@ -384,7 +385,7 @@ class RuntimeValidationService:
             response_error: str | None = None
             if response_path.exists():
                 try:
-                    response_payload = json.loads(response_path.read_text(encoding="utf-8"))
+                    response_payload = load_json_file(response_path)
                 except (OSError, json.JSONDecodeError) as exc:
                     response_payload = None
                     response_error = str(exc)
@@ -501,7 +502,7 @@ class RuntimeValidationService:
         try:
             watch_dir.mkdir(parents=True, exist_ok=True)
             tmp_file.write_text(
-                json.dumps(payload, ensure_ascii=False),
+                dump_json(payload, indent=None),
                 encoding="utf-8",
             )
             tmp_file.rename(request_file)
@@ -524,7 +525,7 @@ class RuntimeValidationService:
             if response_file.exists():
                 try:
                     raw = response_file.read_text(encoding="utf-8")
-                    response_payload = json.loads(raw)
+                    response_payload = load_json(raw)
                 except (OSError, json.JSONDecodeError) as exc:
                     return error_response(
                         "RUN_EDITOR_BRIDGE_RESPONSE",

--- a/prefab_sentinel/services/serialized_object.py
+++ b/prefab_sentinel/services/serialized_object.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from prefab_sentinel.contracts import Diagnostic, Severity, ToolResponse, error_response, success_response
+from prefab_sentinel.json_io import dump_json, load_json
 from prefab_sentinel.patch_plan import (
     PLAN_VERSION,
     build_bridge_request,
@@ -668,7 +669,7 @@ class SerializedObjectService:
         try:
             completed = subprocess.run(
                 list(self.bridge_command),
-                input=json.dumps(request_payload, ensure_ascii=False),
+                input=dump_json(request_payload, indent=None),
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
@@ -720,7 +721,7 @@ class SerializedObjectService:
             )
 
         try:
-            payload = json.loads(completed.stdout)
+            payload = load_json(completed.stdout)
         except json.JSONDecodeError as exc:
             return error_response(
                 "SER_BRIDGE_PROTOCOL",
@@ -3082,7 +3083,7 @@ class SerializedObjectService:
             )
 
         try:
-            loaded = json.loads(decode_text_file(target_path))
+            loaded = load_json(decode_text_file(target_path))
         except OSError as exc:
             return error_response(
                 "SER_IO_ERROR",
@@ -3143,7 +3144,7 @@ class SerializedObjectService:
 
         try:
             target_path.write_text(
-                f"{json.dumps(working, ensure_ascii=False, indent=2)}\n",
+                f"{dump_json(working)}\n",
                 encoding="utf-8",
             )
         except OSError as exc:

--- a/prefab_sentinel/session.py
+++ b/prefab_sentinel/session.py
@@ -167,17 +167,11 @@ class ProjectSession:
         if self._script_name_map is None:
             if self._project_root is None:
                 return {}
-            self._script_name_map = build_script_name_map(self._project_root)
+            self._script_name_map = build_script_name_map(self.guid_index())
         return self._script_name_map
 
     def guid_index(self) -> dict[str, Path]:
-        """Return the cached GUID index, building on first call.
-
-        Known limitation: build_script_name_map() internally calls
-        collect_project_guid_index(), so the first activate_project
-        scans the GUID index twice. Tracked in
-        project_improve_guid_index_cache_unification.md.
-        """
+        """Return the cached GUID index, building on first call."""
         if self._guid_index is None:
             if self._project_root is None:
                 return {}

--- a/prefab_sentinel/smoke_batch.py
+++ b/prefab_sentinel/smoke_batch.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from prefab_sentinel.bridge_smoke import load_patch_plan
+from prefab_sentinel.json_io import dump_json, load_json, load_json_file
 from prefab_sentinel.wsl_compat import to_wsl_path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -263,7 +264,7 @@ def _build_cases(args: argparse.Namespace) -> list[SmokeCase]:
 
 
 def _load_timeout_profile_map(timeout_profile_path: Path) -> dict[str, int]:
-    payload = json.loads(timeout_profile_path.read_text(encoding="utf-8"))
+    payload = load_json_file(timeout_profile_path)
     if not isinstance(payload, dict):
         raise ValueError("timeout profile root must be an object.")
 
@@ -361,7 +362,7 @@ def _parse_case_payload(
     stderr_text: str,
 ) -> dict[str, Any]:
     try:
-        payload = json.loads(stdout_text)
+        payload = load_json(stdout_text)
     except json.JSONDecodeError:
         payload = {
             "success": False,
@@ -630,7 +631,7 @@ def _execute_batch_cases(
                 matched_expectation = False
             if not response_path.exists():
                 response_path.write_text(
-                    json.dumps(case_payload, ensure_ascii=False, indent=2),
+                    dump_json(case_payload),
                     encoding="utf-8",
                 )
             results.append(
@@ -714,7 +715,7 @@ def _build_batch_summary(
     summary_json = Path(args.summary_json) if args.summary_json else out_dir / "summary.json"
     summary_json.parent.mkdir(parents=True, exist_ok=True)
     summary_json.write_text(
-        json.dumps(summary_payload, ensure_ascii=False, indent=2),
+        dump_json(summary_payload),
         encoding="utf-8",
     )
 

--- a/prefab_sentinel/smoke_history.py
+++ b/prefab_sentinel/smoke_history.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import argparse
 import csv
 import glob
-import json
 import math
 import sys
 from pathlib import Path
 from typing import Any
+
+from prefab_sentinel.json_io import dump_json, load_json_file
 
 
 def _pass_pct(total: int, failures: int) -> float | None:
@@ -670,7 +671,7 @@ def _compute_profile_timeout_metrics(
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    path.write_text(dump_json(payload), encoding="utf-8")
 
 
 def _write_csv(out_path: Path, header: list[str], rows: list[dict[str, Any]]) -> None:
@@ -893,7 +894,7 @@ def _load_history_rows(
     include_targets = {target for target in args.target}
     rows: list[dict[str, Any]] = []
     for source in input_paths:
-        payload = json.loads(source.read_text(encoding="utf-8"))
+        payload = load_json_file(source)
         if not _is_smoke_batch_summary(payload):
             continue
         cases = payload.get("data", {}).get("cases", [])

--- a/prefab_sentinel/symbol_tree.py
+++ b/prefab_sentinel/symbol_tree.py
@@ -509,23 +509,18 @@ class SymbolTree:
 # ---------------------------------------------------------------------------
 
 
-def build_script_name_map(project_root: Path | str) -> dict[str, str]:
-    """Build a guid -> script_class_name map from .cs.meta files.
+def build_script_name_map(guid_index: dict[str, Path]) -> dict[str, str]:
+    """Build a guid -> script_class_name map from a pre-computed GUID index.
 
-    Scans the project for .cs.meta files and extracts the GUID-to-class-name
-    mapping.  Does not include PackageCache to keep the map focused on
-    project-local scripts.
+    Filters the index for ``.cs`` entries and maps GUIDs to class names (file stems).
 
     Args:
-        project_root: Unity project root directory.
+        guid_index: Pre-computed GUID-to-Path mapping (e.g. from
+            ``collect_project_guid_index``).
 
     Returns:
         Dict mapping lowercase GUID strings to script class names (file stems).
     """
-    from prefab_sentinel.unity_assets import collect_project_guid_index
-
-    root = Path(project_root) if isinstance(project_root, str) else project_root
-    guid_index = collect_project_guid_index(root, include_package_cache=False)
     return {
         guid: asset_path.stem
         for guid, asset_path in guid_index.items()

--- a/prefab_sentinel/unity_assets.py
+++ b/prefab_sentinel/unity_assets.py
@@ -8,6 +8,7 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
+from prefab_sentinel.json_io import load_json_file
 from prefab_sentinel.wsl_compat import to_wsl_path
 
 UNITY_TEXT_ASSET_SUFFIXES = {
@@ -235,6 +236,9 @@ def resolve_asset_path(path: str, project_root: Path | None) -> Path:
 
     If *path* is relative (e.g. ``Assets/Foo/Bar.prefab``) and doesn't exist
     as-is, tries joining with *project_root*.
+
+    Raises:
+        ValueError: If the resolved path escapes the project root.
     """
     from prefab_sentinel.wsl_compat import to_wsl_path
 
@@ -242,7 +246,20 @@ def resolve_asset_path(path: str, project_root: Path | None) -> Path:
     if not resolved.is_file() and project_root and not resolved.is_absolute():
         joined = (project_root / resolved).resolve()
         if joined.is_file():
-            return joined
+            resolved = joined
+
+    # Path containment guard: resolved must not escape project root.
+    # Uses is_relative_to (Python 3.9+) to avoid prefix-collision bypass.
+    if project_root is not None:
+        resolved_abs = resolved.resolve()
+        root_abs = Path(project_root).resolve()
+        if not resolved_abs.is_relative_to(root_abs):
+            msg = (
+                f"Path escapes project root: {path!r} "
+                f"resolves to {resolved_abs} which is outside {root_abs}"
+            )
+            raise ValueError(msg)
+
     return resolved
 
 
@@ -260,7 +277,7 @@ def relative_to_root(path: Path, root: Path) -> str:
 def _read_json_file(path: Path) -> dict[str, object] | None:
     """Read a JSON file, returning None on failure or non-object content."""
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = load_json_file(path)
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
     if not isinstance(data, dict):

--- a/tests/test_editor_bridge.py
+++ b/tests/test_editor_bridge.py
@@ -17,6 +17,7 @@ from prefab_sentinel.editor_bridge import (
     check_editor_bridge_env,
     send_action,
 )
+from prefab_sentinel.unity_assets import resolve_asset_path
 
 
 class TestCheckEditorBridgeEnv(unittest.TestCase):
@@ -134,7 +135,7 @@ class TestSendAction(unittest.TestCase):
                             },
                             "diagnostics": [],
                         }
-                        resp_path.write_text(json.dumps(resp))
+                        resp_path.write_text(json.dumps(resp), encoding="utf-8")
                         break
 
             import threading
@@ -297,46 +298,6 @@ class TestSetCameraParams(unittest.TestCase):
         self.assertEqual(kwargs["camera_orthographic"], 1)
 
 
-class TestResolveAssetPath(unittest.TestCase):
-    """Validate resolve_asset_path joins Assets/... paths with project root."""
-
-    def test_relative_assets_path_resolved(self) -> None:
-
-        from pathlib import Path
-
-        from prefab_sentinel.unity_assets import resolve_asset_path
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            assets_dir = Path(tmpdir) / "Assets"
-            assets_dir.mkdir()
-            fake_asset = assets_dir / "test.prefab"
-            fake_asset.write_text("%YAML 1.1\n--- !u!1 &1\nGameObject:\n  m_Name: Test\n")
-
-            resolved = resolve_asset_path("Assets/test.prefab", Path(tmpdir))
-            self.assertEqual(resolved, fake_asset.resolve())
-
-    def test_absolute_path_unchanged(self) -> None:
-
-        from pathlib import Path
-
-        from prefab_sentinel.unity_assets import resolve_asset_path
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            fake_asset = Path(tmpdir) / "test.prefab"
-            fake_asset.write_text("%YAML 1.1\n")
-
-            resolved = resolve_asset_path(str(fake_asset), Path(tmpdir))
-            self.assertEqual(resolved, fake_asset)
-
-    def test_no_project_root_returns_as_is(self) -> None:
-        from pathlib import Path
-
-        from prefab_sentinel.unity_assets import resolve_asset_path
-
-        resolved = resolve_asset_path("Assets/nonexistent.prefab", None)
-        self.assertEqual(resolved, Path("Assets/nonexistent.prefab"))
-
-
 class TestCreateEmptyKwargs(unittest.TestCase):
     """I4: build_create_empty_kwargs omits empty optional fields."""
 
@@ -373,6 +334,60 @@ class TestCreateEmptyKwargs(unittest.TestCase):
         self.assertEqual(result, {"new_name": "Obj"})
         self.assertNotIn("hierarchy_path", result)
         self.assertNotIn("property_value", result)
+
+
+class TestResolveAssetPath(unittest.TestCase):
+    """Validate resolve_asset_path joins Assets/... paths with project root."""
+
+    def test_relative_assets_path_resolved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assets_dir = Path(tmpdir) / "Assets"
+            assets_dir.mkdir()
+            fake_asset = assets_dir / "test.prefab"
+            fake_asset.write_text(
+                "%YAML 1.1\n--- !u!1 &1\nGameObject:\n  m_Name: Test\n",
+                encoding="utf-8",
+            )
+
+            resolved = resolve_asset_path("Assets/test.prefab", Path(tmpdir))
+            self.assertEqual(resolved, fake_asset.resolve())
+
+    def test_absolute_path_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_asset = Path(tmpdir) / "test.prefab"
+            fake_asset.write_text("%YAML 1.1\n", encoding="utf-8")
+
+            resolved = resolve_asset_path(str(fake_asset), Path(tmpdir))
+            self.assertEqual(resolved, fake_asset)
+
+    def test_no_project_root_returns_as_is(self) -> None:
+        resolved = resolve_asset_path("Assets/nonexistent.prefab", None)
+        self.assertEqual(resolved, Path("Assets/nonexistent.prefab"))
+
+    def test_path_traversal_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError) as ctx:
+                resolve_asset_path("Assets/../../etc/passwd", Path(tmpdir))
+            self.assertIn("escapes project root", str(ctx.exception))
+
+    def test_absolute_outside_root_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError) as ctx:
+                resolve_asset_path("/outside/path.prefab", Path(tmpdir))
+            self.assertIn("escapes project root", str(ctx.exception))
+
+    def test_valid_relative_inside_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assets_dir = Path(tmpdir) / "Assets"
+            assets_dir.mkdir()
+            asset = assets_dir / "test.prefab"
+            asset.write_text("%YAML 1.1\n", encoding="utf-8")
+            resolved = resolve_asset_path("Assets/test.prefab", Path(tmpdir))
+            self.assertEqual(resolved, asset.resolve())
+
+    def test_no_root_skips_guard(self) -> None:
+        resolved = resolve_asset_path("../../etc/passwd", None)
+        self.assertEqual(resolved, Path("../../etc/passwd"))
 
 
 if __name__ == "__main__":

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -1,0 +1,71 @@
+"""Tests for prefab_sentinel.json_io module."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+from prefab_sentinel.json_io import dump_json, load_json, load_json_file
+
+
+class TestDumpJson(unittest.TestCase):
+    """dump_json serializes with ensure_ascii=False and indent=2 by default."""
+
+    def test_defaults(self) -> None:
+        result = dump_json({"a": 1})
+        self.assertEqual(result, '{\n  "a": 1\n}')
+
+    def test_non_ascii_compact(self) -> None:
+        result = dump_json({"a": "あ"}, indent=None)
+        self.assertEqual(result, '{"a": "あ"}')
+
+    def test_override_ensure_ascii(self) -> None:
+        result = dump_json({"a": "あ"}, ensure_ascii=True)
+        parsed = json.loads(result)
+        self.assertEqual(parsed, {"a": "あ"})
+        self.assertNotIn("あ", result)
+
+    def test_non_serializable_raises_type_error(self) -> None:
+        with self.assertRaises(TypeError):
+            dump_json(object())
+
+
+class TestLoadJson(unittest.TestCase):
+    """load_json deserializes JSON strings."""
+
+    def test_valid_json(self) -> None:
+        result = load_json('{"a": 1}')
+        self.assertEqual(result, {"a": 1})
+
+    def test_invalid_json_raises(self) -> None:
+        with self.assertRaises(json.JSONDecodeError):
+            load_json("invalid")
+
+
+class TestLoadJsonFile(unittest.TestCase):
+    """load_json_file reads and parses JSON files."""
+
+    def test_valid_file(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8") as f:
+            f.write('{"x": 1}')
+            f.flush()
+            self.addCleanup(os.unlink, f.name)
+            result = load_json_file(f.name)
+        self.assertEqual(result, {"x": 1})
+
+    def test_missing_file_raises_os_error(self) -> None:
+        with self.assertRaises(OSError):
+            load_json_file("/nonexistent/path/to/file.json")
+
+    def test_bad_json_raises(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8") as f:
+            f.write("{broken")
+            f.flush()
+            self.addCleanup(os.unlink, f.name)
+            with self.assertRaises(json.JSONDecodeError):
+                load_json_file(f.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_smoke.py
+++ b/tests/test_mcp_smoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import unittest
 from pathlib import Path
@@ -14,7 +15,19 @@ FIXTURES = Path(__file__).parent / "fixtures" / "smoke"
 
 
 def _run(coro: Any) -> Any:
-    return asyncio.run(coro)
+    """Run an async coroutine synchronously.
+
+    When the result is a call_tool response (list[TextContent]), normalises
+    across MCP versions to always return a 2-tuple (content_list, parsed_dict)
+    so tests can use ``_, result = _run(server.call_tool(...))``.
+    """
+    raw = asyncio.run(coro)
+    if isinstance(raw, tuple) and len(raw) == 2 and isinstance(raw[1], dict):
+        return raw
+    if isinstance(raw, list) and raw and hasattr(raw[0], "text"):
+        parsed = json.loads(raw[0].text)
+        return raw, parsed
+    return raw
 
 
 class McpSmokeTests(unittest.TestCase):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -95,12 +95,14 @@ class TestScriptNameMapCaching(unittest.TestCase):
         mock_build.return_value = {"guid1": "MyScript"}
         root = Path("/fake/project")
         session = ProjectSession(project_root=root)
+        fake_index = {"guid1": Path("/fake/MyScript.cs")}
+        session._guid_index = fake_index
 
         map1 = session.script_name_map()
         map2 = session.script_name_map()
 
         self.assertIs(map1, map2)
-        mock_build.assert_called_once_with(root)
+        mock_build.assert_called_once_with(fake_index)
 
     @patch("prefab_sentinel.session.build_script_name_map")
     def test_returns_empty_when_no_root(self, mock_build: MagicMock) -> None:
@@ -109,9 +111,11 @@ class TestScriptNameMapCaching(unittest.TestCase):
         self.assertEqual(result, {})
         mock_build.assert_not_called()
 
+    @patch("prefab_sentinel.session.collect_project_guid_index")
     @patch("prefab_sentinel.session.build_script_name_map")
-    def test_cleared_by_invalidate_guid_index(self, mock_build: MagicMock) -> None:
+    def test_cleared_by_invalidate_guid_index(self, mock_build: MagicMock, mock_collect: MagicMock) -> None:
         mock_build.return_value = {"g": "S"}
+        mock_collect.return_value = {"g": Path("/fake/S.cs")}
         session = ProjectSession(project_root=Path("/fake"))
 
         session.script_name_map()
@@ -124,6 +128,8 @@ class TestScriptNameMapCaching(unittest.TestCase):
     def test_cleared_by_invalidate_script_map(self, mock_build: MagicMock) -> None:
         mock_build.return_value = {"g": "S"}
         session = ProjectSession(project_root=Path("/fake"))
+        fake_index = {"g": Path("/fake/S.cs")}
+        session._guid_index = fake_index
 
         session.script_name_map()
         session.invalidate_script_map()

--- a/tests/test_symbol_tree.py
+++ b/tests/test_symbol_tree.py
@@ -12,6 +12,7 @@ from prefab_sentinel.symbol_tree import (
     SymbolNode,
     SymbolNotFoundError,
     SymbolTree,
+    build_script_name_map,
 )
 from tests.yaml_helpers import (
     YAML_HEADER,
@@ -746,7 +747,7 @@ class TestSymbolTreeNestedExpansion(unittest.TestCase):
             + make_transform("600", "500")
             + make_meshrenderer("700", "500")
         )
-        child_path.write_text(child_text)
+        child_path.write_text(child_text, encoding="utf-8")
         return child_path
 
     def _parent_text_with_instance(self) -> str:
@@ -867,7 +868,7 @@ class TestSymbolTreeNestedResolution(unittest.TestCase):
             + make_transform("600", "500")
             + make_meshrenderer("700", "500")
         )
-        child_path.write_text(child_text)
+        child_path.write_text(child_text, encoding="utf-8")
         return child_path
 
     def _parent_text_with_instance(self) -> str:
@@ -950,13 +951,32 @@ class TestSessionCacheBypass(unittest.TestCase):
         text = YAML_HEADER + make_gameobject("100", "Root", ["200"]) + make_transform("200", "100")
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "test.prefab"
-            path.write_text(text)
+            path.write_text(text, encoding="utf-8")
             # First call caches
             tree1 = session.get_symbol_tree(path, text)
             # Second call with expand_nested should NOT return cached
             tree2 = session.get_symbol_tree(path, text, expand_nested=True)
             # They should be different objects (not cached)
             self.assertIsNot(tree1, tree2)
+
+
+class TestBuildScriptNameMap(unittest.TestCase):
+    """Direct unit tests for build_script_name_map."""
+
+    def test_empty_index(self) -> None:
+        result = build_script_name_map({})
+        self.assertEqual(result, {})
+
+    def test_single_cs_entry(self) -> None:
+        result = build_script_name_map({"abc": Path("Foo.cs")})
+        self.assertEqual(result, {"abc": "Foo"})
+
+    def test_filters_non_cs_entries(self) -> None:
+        result = build_script_name_map({
+            "abc": Path("Foo.cs"),
+            "def": Path("Bar.mat"),
+        })
+        self.assertEqual(result, {"abc": "Foo"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **#44**: `build_script_name_map` が `guid_index` dict を直接受け取るようリファクタ（`project_root` 依存を除去）
- **#46**: `json_io.py` を新設し `dump_json`/`load_json`/`load_json_file` を抽出（`ensure_ascii=False` デフォルト）。全 callsite を移行
- **#48**: `resolve_asset_path` にパストラバーサルガードを追加（`is_relative_to` で検証、脱出時 `ValueError`）
- **#50**: `test_symbol_tree.py` の全 `write_text` に `encoding="utf-8"` を追加
- **#51**: `build_set_camera_kwargs` / `build_create_empty_kwargs` を `editor_bridge_builders.py` に抽出
- **#53**: `test_mcp_smoke.py` の `_run()` ヘルパーが `list[TextContent]` を正規化して返すよう修正、`import json` 追加
- **#56**: `editor_bridge.py` の関数内 `import json`/`import math` をモジュールレベルに移動

## Test plan
- [x] 既存テストが全パス
- [ ] `test_json_io.py` の新規テストがパス
- [ ] `test_editor_bridge.py` のリファクタ後テストがパス
- [ ] `test_mcp_smoke.py` の修正後テストがパス

Closes #44, closes #46, closes #48, closes #50, closes #51, closes #53, closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>