### PR TITLE
fix: mypy attr-defined errors in smoke_batch_runner.py

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.149",
+  "version": "0.5.150",
   "description": "Unity Prefab/Scene/Asset の検査・編集・参照修復ツール",
   "author": {
     "name": "tyunta",

--- a/prefab_sentinel/smoke_batch_runner.py
+++ b/prefab_sentinel/smoke_batch_runner.py
@@ -5,11 +5,14 @@ import json
 import subprocess
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from prefab_sentinel.bridge_smoke import load_patch_plan
 from prefab_sentinel.json_io import dump_json, load_json
 from prefab_sentinel.smoke_batch_case import _resolve_case_unity_timeout_sec, _wsl_path_exists
+
+if TYPE_CHECKING:
+    from prefab_sentinel.smoke_batch import SmokeCase
 
 
 def _build_smoke_command(
@@ -20,7 +23,7 @@ def _build_smoke_command(
     unity_command: str | None,
     unity_execute_method: str,
     unity_timeout_sec: int | None,
-    case: object,  # SmokeCase
+    case: SmokeCase,
     response_out: Path,
     unity_log_file: Path,
 ) -> list[str]:
@@ -56,7 +59,7 @@ def _build_smoke_command(
 
 def _parse_case_payload(
     *,
-    case: object,  # SmokeCase
+    case: SmokeCase,
     exit_code: int,
     stdout_text: str,
     stderr_text: str,
@@ -105,7 +108,7 @@ def _extract_applied_count(payload: dict[str, Any]) -> int | None:
 
 def _resolve_expected_applied(
     *,
-    case: object,  # SmokeCase
+    case: SmokeCase,
     expect_applied_from_plan: bool,
 ) -> tuple[int | None, str]:
     expected_applied = getattr(case, "expected_applied", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.149"
+version = "0.5.150"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -53,7 +53,7 @@ packages = ["prefab_sentinel"]
 "tools/unity" = "prefab_sentinel/_bridge_files"
 
 [tool.bumpversion]
-current_version = "0.5.149"
+current_version = "0.5.150"
 commit = false
 tag = false
 allow_dirty = true

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -17,7 +17,7 @@ namespace PrefabSentinel
     public static class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.149";
+        public const string BridgeVersion = "0.5.150";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         public static readonly System.Collections.Generic.HashSet<string> AsyncActions =

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.149"
+version = "0.5.150"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- `case: object` を `case: SmokeCase` に修正し、`TYPE_CHECKING` ガードで循環 import を回避
- mypy の `attr-defined` エラー 3 件を解消

Closes #80

## Test plan
- [x] `uv run mypy prefab_sentinel/smoke_batch_runner.py` — Success
- [x] `uv run ruff check prefab_sentinel/smoke_batch_runner.py` — All checks passed
- [x] ランタイム import 確認 — 循環 import なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)