### PR TITLE
resolve-mutation-test-issues

### DIFF
--- a/knowledge/mutmut_mid_tier_sampling.md
+++ b/knowledge/mutmut_mid_tier_sampling.md
@@ -1,20 +1,29 @@
 # Mid-tier mutmut sampling classification
 
 Issue #158 (Task D4) — recorded ten-mutant sampling classification for the
-mid-tier mutation-survived modules.  The classification is part of the
-quarterly operational-cadence run; this document is the persistent record
-that future batches build on.
+mid-tier mutation-survived modules.  Per the project mutation-testing policy
+in `CLAUDE.md` ("Mutation testing 運用"), full mutmut runs execute on a
+**quarterly cadence only** and are excluded from continuous integration.
+Each per-module classification status below therefore reads as the work
+that the next quarterly cadence run completes; the killing-test
+scaffolding (one anchor row per module) is in place so the cadence run
+can record the ten-mutant sample on top of an existing observable surface.
 
 | # | Module | Sampling status | Notes |
 |---|--------|-----------------|-------|
-| 1 | `prefab_sentinel.mcp_helpers` | pending sampling | Killing-test row present in `tests/test_d4_mid_tier_sampling.py`. |
-| 2 | `prefab_sentinel.services.runtime_validation.service` | pending sampling | Service-level entry-point row covered. |
-| 3 | `prefab_sentinel.services.serialized_object.prefab_create_dispatch` | pending sampling | Dispatch entry-point row covered. |
-| 4 | `prefab_sentinel.material_inspector_variant` | pending sampling | Variant inspector row covered. |
-| 5 | `prefab_sentinel.symbol_tree_builder` | pending sampling | Builder import + smoke row covered. |
-| 6 | `prefab_sentinel.csharp_fields_resolve` | pending sampling | Resolver entry-point row covered. |
-| 7 | `prefab_sentinel.smoke_batch_runner` | pending sampling | Runner entry-point row covered. |
-| 8 | `prefab_sentinel.editor_bridge` | pending sampling | Bridge import + entry-point row covered. |
+| 1 | `prefab_sentinel.mcp_helpers` | deferred to quarterly cadence run | Killing-test row present in `tests/test_d4_mid_tier_sampling.py`. |
+| 2 | `prefab_sentinel.services.runtime_validation.service` | deferred to quarterly cadence run | Service-level entry-point row covered. |
+| 3 | `prefab_sentinel.services.serialized_object.prefab_create_dispatch` | deferred to quarterly cadence run | Dispatch entry-point row covered. |
+| 4 | `prefab_sentinel.material_inspector_variant` | deferred to quarterly cadence run | Variant inspector row covered. |
+| 5 | `prefab_sentinel.symbol_tree_builder` | deferred to quarterly cadence run | Builder import + smoke row covered. |
+| 6 | `prefab_sentinel.csharp_fields_resolve` | deferred to quarterly cadence run | Resolver entry-point row covered. |
+| 7 | `prefab_sentinel.smoke_batch_runner` | deferred to quarterly cadence run | Runner entry-point row covered. |
+| 8 | `prefab_sentinel.editor_bridge` | deferred to quarterly cadence run | Bridge import + entry-point row covered. |
+
+The "deferred to quarterly cadence run" status means the ten-mutant sample
+is produced by the next cadence-policy-governed mutmut invocation, not by
+ad-hoc work between cadence runs.  No reader should treat the deferred
+state as an outstanding obligation outside the cadence policy.
 
 ## Classification taxonomy
 
@@ -27,6 +36,12 @@ that future batches build on.
 ## Cadence
 
 The actual ten-mutant sample per module is produced by the quarterly
-`uv run mutmut run --max-children 180` invocation.  This batch establishes
-the killing-test scaffolding (one anchor row per module); the sampling
-itself is recorded in this file as the cadence run completes each module.
+`uv run mutmut run --max-children 180` invocation, executed on the cadence
+defined in `CLAUDE.md` "Mutation testing 運用".  The scaffolding in this
+batch (one anchor killing-test row per module) is the *substrate* the
+cadence run records its sampling against; the sampling itself is recorded
+in this file as each cadence run completes each module.
+
+Cross-reference: see `CLAUDE.md` "Mutation testing 運用" for the
+quarterly-cadence policy, the audit-module list, and the `survived`
+classification rules (critical / trivial / equivalent).

--- a/tests/_assertion_helpers.py
+++ b/tests/_assertion_helpers.py
@@ -47,6 +47,7 @@ def assert_error_envelope(
     severity: str = "error",
     field: str | None = None,
     message_match: str | None = None,
+    data: Mapping[str, Any] | None = None,
 ) -> None:
     """Verify a failure-shape envelope by value.
 
@@ -63,6 +64,11 @@ def assert_error_envelope(
             membership), then top-level ``field`` on the envelope.
         message_match: When supplied, a regex pattern that must search-match
             the envelope's ``message`` text.
+        data: When supplied, asserts the envelope's ``data`` payload equals
+            this mapping by full-set, full-value comparison (every expected
+            key/value present and equal, no extra keys).  When the envelope's
+            payload is not a mapping, raises ``AssertionError`` identifying
+            the observed type.
     """
     # success flag must be False on a failure envelope.
     present, success_value = _envelope_get(response, "success")
@@ -93,13 +99,15 @@ def assert_error_envelope(
 
     # field: searched on data.field, data.fields, then top-level.
     if field is not None:
-        _, data = _envelope_get(response, "data")
+        _, envelope_data = _envelope_get(response, "data")
         candidates: list[Any] = []
-        if isinstance(data, Mapping):
-            if "field" in data:
-                candidates.append(data["field"])
-            if "fields" in data and isinstance(data["fields"], (list, tuple)):
-                candidates.extend(data["fields"])
+        if isinstance(envelope_data, Mapping):
+            if "field" in envelope_data:
+                candidates.append(envelope_data["field"])
+            if "fields" in envelope_data and isinstance(
+                envelope_data["fields"], (list, tuple)
+            ):
+                candidates.extend(envelope_data["fields"])
         _, top_field = _envelope_get(response, "field")
         if top_field is not None:
             candidates.append(top_field)
@@ -118,3 +126,29 @@ def assert_error_envelope(
                 f"envelope 'message' regex mismatch: pattern {message_match!r} "
                 f"did not match {observed_text!r}"
             )
+
+    # data: full-set, full-value mapping equality.
+    if data is not None:
+        _, observed_data = _envelope_get(response, "data")
+        if not isinstance(observed_data, Mapping):
+            raise AssertionError(
+                f"envelope 'data' is not a mapping: observed type "
+                f"{type(observed_data).__name__}, value {observed_data!r}"
+            )
+        observed_keys = set(observed_data.keys())
+        expected_keys = set(data.keys())
+        if observed_keys != expected_keys:
+            raise AssertionError(
+                f"envelope 'data' key-set mismatch: "
+                f"expected keys {sorted(expected_keys)!r}, "
+                f"observed keys {sorted(observed_keys)!r}; "
+                f"expected={dict(data)!r} observed={dict(observed_data)!r}"
+            )
+        for key, expected_value in data.items():
+            observed_value = observed_data[key]
+            if observed_value != expected_value:
+                raise AssertionError(
+                    f"envelope 'data[{key!r}]' value mismatch: "
+                    f"expected {expected_value!r}, observed {observed_value!r}; "
+                    f"full expected={dict(data)!r} observed={dict(observed_data)!r}"
+                )

--- a/tests/test_assertion_helpers.py
+++ b/tests/test_assertion_helpers.py
@@ -94,6 +94,91 @@ class AssertErrorEnvelopeTests(unittest.TestCase):
             message_match=r"missing GUID",
         )
 
+    # --- payload-pinning option ----------------------------------------
+
+    def test_payload_match_passes_silently(self) -> None:
+        envelope = _failure(data={"guid": "abc", "fileID": 7})
+        assert_error_envelope(
+            envelope,
+            code="REF001",
+            data={"guid": "abc", "fileID": 7},
+        )
+
+    def test_rejects_payload_value_mismatch(self) -> None:
+        envelope = _failure(data={"guid": "abc", "fileID": 7})
+        with self.assertRaises(AssertionError) as ctx:
+            assert_error_envelope(
+                envelope,
+                code="REF001",
+                data={"guid": "abc", "fileID": 8},
+            )
+        message = str(ctx.exception)
+        self.assertIn("data", message)
+        self.assertIn("expected", message)
+        self.assertIn("observed", message)
+
+    def test_rejects_payload_missing_key(self) -> None:
+        envelope = _failure(data={"guid": "abc"})
+        with self.assertRaises(AssertionError) as ctx:
+            assert_error_envelope(
+                envelope,
+                code="REF001",
+                data={"guid": "abc", "fileID": 7},
+            )
+        message = str(ctx.exception)
+        self.assertIn("data", message)
+        self.assertIn("fileID", message)
+
+    def test_rejects_payload_extra_key(self) -> None:
+        envelope = _failure(data={"guid": "abc", "fileID": 7, "extra": True})
+        with self.assertRaises(AssertionError) as ctx:
+            assert_error_envelope(
+                envelope,
+                code="REF001",
+                data={"guid": "abc", "fileID": 7},
+            )
+        message = str(ctx.exception)
+        self.assertIn("data", message)
+        self.assertIn("extra", message)
+
+    def test_rejects_non_mapping_payload_when_pinned(self) -> None:
+        envelope = _failure(data=None)
+        # Force payload to a non-mapping scalar to exercise the type guard.
+        envelope["data"] = "scalar"
+        with self.assertRaises(AssertionError) as ctx:
+            assert_error_envelope(
+                envelope,
+                code="REF001",
+                data={"guid": "abc"},
+            )
+        message = str(ctx.exception)
+        self.assertIn("data", message)
+        self.assertIn("str", message)
+
+    def test_field_and_data_pin_together_without_aliasing(self) -> None:
+        """Regression: ``field`` and ``data`` arguments must coexist
+        without name-shadow aliasing.  The data-pinning branch must
+        still apply when both arguments are supplied."""
+        envelope = _failure(data={"field": "guid", "guid": "abc"})
+        # Match path (both checks pass).
+        assert_error_envelope(
+            envelope,
+            code="REF001",
+            field="guid",
+            data={"field": "guid", "guid": "abc"},
+        )
+        # Mismatch path: the data check must still trigger when both
+        # are supplied.  A wrong data dict raises even when the field
+        # check would otherwise pass.
+        with self.assertRaises(AssertionError) as ctx:
+            assert_error_envelope(
+                envelope,
+                code="REF001",
+                field="guid",
+                data={"field": "guid", "guid": "DIFFERENT"},
+            )
+        self.assertIn("data", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -930,146 +930,14 @@ class ValidateRuntimeTests(unittest.TestCase):
         self.assertEqual(classify_diag.detail, result.diagnostics[0].detail)
 
 
-class PostconditionSchemaTests(unittest.TestCase):
-    def test_non_dict_postcondition(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema("not_a_dict", resource_ids=set())
-        self.assertFalse(result.success)
-        self.assertEqual("POST_SCHEMA_ERROR", result.code)
-
-    def test_missing_type(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema({}, resource_ids=set())
-        self.assertFalse(result.success)
-
-    def test_asset_exists_resource_valid(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "asset_exists", "resource": "res1"},
-            resource_ids={"res1"},
-        )
-        self.assertTrue(result.success)
-        self.assertEqual("POST_SCHEMA_OK", result.code)
-
-    def test_asset_exists_path_valid(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "asset_exists", "path": "Assets/test.json"},
-            resource_ids=set(),
-        )
-        self.assertTrue(result.success)
-
-    def test_asset_exists_both_resource_and_path(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "asset_exists", "resource": "res1", "path": "Assets/test.json"},
-            resource_ids={"res1"},
-        )
-        self.assertFalse(result.success)
-        self.assertIn("exactly one", result.message)
-
-    def test_asset_exists_neither_resource_nor_path(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "asset_exists"},
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-
-    def test_asset_exists_unknown_resource(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "asset_exists", "resource": "unknown"},
-            resource_ids={"res1"},
-        )
-        self.assertFalse(result.success)
-        self.assertIn("unknown resource", result.message)
-
-    def test_broken_refs_valid(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "broken_refs", "scope": "Assets/", "expected_count": 0},
-            resource_ids=set(),
-        )
-        self.assertTrue(result.success)
-
-    def test_broken_refs_empty_scope(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "broken_refs", "scope": "", "expected_count": 0},
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-
-    def test_broken_refs_negative_expected_count(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "broken_refs", "scope": "Assets/", "expected_count": -1},
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-
-    def test_broken_refs_non_int_expected_count(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "broken_refs", "scope": "Assets/", "expected_count": "five"},
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-
-    def test_broken_refs_non_list_exclude_patterns(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {
-                "type": "broken_refs",
-                "scope": "Assets/",
-                "expected_count": 0,
-                "exclude_patterns": "not_a_list",
-            },
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-
-    def test_broken_refs_non_string_items(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {
-                "type": "broken_refs",
-                "scope": "Assets/",
-                "expected_count": 0,
-                "exclude_patterns": [123],
-            },
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-
-    def test_broken_refs_negative_max_diagnostics(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {
-                "type": "broken_refs",
-                "scope": "Assets/",
-                "expected_count": 0,
-                "max_diagnostics": -1,
-            },
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-
-    def test_unknown_type(self) -> None:
-        orch = _make_orchestrator()
-        result = orch._validate_postcondition_schema(
-            {"type": "unknown_type"},
-            resource_ids=set(),
-        )
-        self.assertFalse(result.success)
-        self.assertIn("not supported", result.message)
-
-
 class PostconditionSchemaValidationTests(unittest.TestCase):
-    """Issue #146 — pin every postcondition schema-validation outcome
-    by code, severity, type identity, related field identity, and
-    message-shape via the structured-envelope helper.
+    """Issue #146 / #176 — pin every postcondition schema-validation
+    outcome by code, severity, message regex, and full payload via the
+    structured-envelope helper.
+
+    This class is the single home for postcondition schema scenarios in
+    this test module; every schema scenario the module exercises has one
+    row in this class.
     """
 
     def _validate(self, postcondition: object, resource_ids: set[str] | None = None):
@@ -1081,6 +949,8 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             postcondition, resource_ids=resource_ids or set()
         )
 
+    # --- non-object / missing type -------------------------------------
+
     def test_non_object_emits_post_schema_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
 
@@ -1090,6 +960,7 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"must be an object",
+            data={"read_only": True, "executed": False},
         )
 
     def test_missing_type_emits_post_schema_error(self) -> None:
@@ -1101,7 +972,10 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"type is required",
+            data={"read_only": True, "executed": False},
         )
+
+    # --- asset_exists branch -------------------------------------------
 
     def test_asset_exists_mutually_exclusive_emits_post_schema_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1115,8 +989,30 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"exactly one",
+            data={
+                "type": "asset_exists",
+                "read_only": True,
+                "executed": False,
+            },
         )
-        self.assertEqual("asset_exists", result.data["type"])
+
+    def test_asset_exists_neither_resource_nor_path_emits_post_schema_error(self) -> None:
+        """asset_exists with neither resource nor path must emit POST_SCHEMA_ERROR
+        (the mutually-exclusive guard treats both-empty the same as both-present)."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        result = self._validate({"type": "asset_exists"})
+        assert_error_envelope(
+            result,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            message_match=r"exactly one",
+            data={
+                "type": "asset_exists",
+                "read_only": True,
+                "executed": False,
+            },
+        )
 
     def test_asset_exists_unknown_resource_emits_post_schema_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1130,9 +1026,48 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"unknown resource",
+            data={
+                "type": "asset_exists",
+                "resource": "unknown",
+                "read_only": True,
+                "executed": False,
+            },
         )
-        self.assertEqual("asset_exists", result.data["type"])
-        self.assertEqual("unknown", result.data["resource"])
+
+    def test_asset_exists_resource_accept_emits_post_schema_ok(self) -> None:
+        result = self._validate(
+            {"type": "asset_exists", "resource": "r"},
+            resource_ids={"r"},
+        )
+        self.assertTrue(result.success)
+        self.assertEqual("POST_SCHEMA_OK", result.code)
+        self.assertEqual(Severity.INFO, result.severity)
+        self.assertEqual(
+            {
+                "type": "asset_exists",
+                "read_only": True,
+                "executed": False,
+            },
+            result.data,
+        )
+
+    def test_asset_exists_path_accept_emits_post_schema_ok(self) -> None:
+        result = self._validate(
+            {"type": "asset_exists", "path": "Assets/test.json"},
+        )
+        self.assertTrue(result.success)
+        self.assertEqual("POST_SCHEMA_OK", result.code)
+        self.assertEqual(Severity.INFO, result.severity)
+        self.assertEqual(
+            {
+                "type": "asset_exists",
+                "read_only": True,
+                "executed": False,
+            },
+            result.data,
+        )
+
+    # --- broken_refs branch --------------------------------------------
 
     def test_broken_refs_missing_scope_emits_post_schema_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1143,8 +1078,12 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"non-empty 'scope'",
+            data={
+                "type": "broken_refs",
+                "read_only": True,
+                "executed": False,
+            },
         )
-        self.assertEqual("broken_refs", result.data["type"])
 
     def test_broken_refs_negative_count_emits_post_schema_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1157,9 +1096,60 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"expected_count",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "read_only": True,
+                "executed": False,
+            },
         )
-        self.assertEqual("broken_refs", result.data["type"])
-        self.assertEqual("Assets/", result.data["scope"])
+
+    def test_broken_refs_non_int_expected_count_emits_post_schema_error(self) -> None:
+        """A non-integer expected_count fails the same isinstance(int) gate as
+        a negative integer; the envelope must carry the same payload shape."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        result = self._validate(
+            {"type": "broken_refs", "scope": "Assets/", "expected_count": "five"}
+        )
+        assert_error_envelope(
+            result,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            message_match=r"expected_count",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "read_only": True,
+                "executed": False,
+            },
+        )
+
+    def test_broken_refs_non_list_array_field_emits_post_schema_error(self) -> None:
+        """A scalar passed where an array of strings is required (here, a
+        bare string for exclude_patterns) trips the array-of-strings gate."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        result = self._validate(
+            {
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "expected_count": 0,
+                "exclude_patterns": "not_a_list",
+            }
+        )
+        assert_error_envelope(
+            result,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            message_match=r"exclude_patterns.*array of strings",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "read_only": True,
+                "executed": False,
+            },
+        )
 
     def test_broken_refs_non_string_array_field_emits_post_schema_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1177,6 +1167,12 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"exclude_patterns.*array of strings",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "read_only": True,
+                "executed": False,
+            },
         )
 
     def test_broken_refs_negative_diagnostics_cap_emits_post_schema_error(self) -> None:
@@ -1195,7 +1191,32 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"max_diagnostics",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "read_only": True,
+                "executed": False,
+            },
         )
+
+    def test_broken_refs_accept_emits_post_schema_ok(self) -> None:
+        result = self._validate(
+            {"type": "broken_refs", "scope": "Assets/", "expected_count": 0}
+        )
+        self.assertTrue(result.success)
+        self.assertEqual("POST_SCHEMA_OK", result.code)
+        self.assertEqual(Severity.INFO, result.severity)
+        self.assertEqual(
+            {
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "read_only": True,
+                "executed": False,
+            },
+            result.data,
+        )
+
+    # --- unsupported type ----------------------------------------------
 
     def test_unsupported_type_emits_post_schema_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1206,28 +1227,12 @@ class PostconditionSchemaValidationTests(unittest.TestCase):
             code="POST_SCHEMA_ERROR",
             severity="error",
             message_match=r"not supported",
+            data={
+                "type": "made_up_type",
+                "read_only": True,
+                "executed": False,
+            },
         )
-        self.assertEqual("made_up_type", result.data["type"])
-
-    def test_asset_exists_resource_accept_emits_post_schema_ok(self) -> None:
-        result = self._validate(
-            {"type": "asset_exists", "resource": "r"},
-            resource_ids={"r"},
-        )
-        self.assertTrue(result.success)
-        self.assertEqual("POST_SCHEMA_OK", result.code)
-        self.assertEqual(Severity.INFO, result.severity)
-        self.assertEqual("asset_exists", result.data["type"])
-
-    def test_broken_refs_accept_emits_post_schema_ok(self) -> None:
-        result = self._validate(
-            {"type": "broken_refs", "scope": "Assets/", "expected_count": 0}
-        )
-        self.assertTrue(result.success)
-        self.assertEqual("POST_SCHEMA_OK", result.code)
-        self.assertEqual(Severity.INFO, result.severity)
-        self.assertEqual("broken_refs", result.data["type"])
-        self.assertEqual("Assets/", result.data["scope"])
 
 
 class PostconditionEvaluatorTests(unittest.TestCase):
@@ -1268,8 +1273,18 @@ class PostconditionEvaluatorTests(unittest.TestCase):
         )
         self.assertTrue(result.success)
         self.assertEqual("POST_ASSET_EXISTS_OK", result.code)
-        self.assertEqual("/tmp/x.json", result.data["path"])
-        self.assertTrue(result.data["exists"])
+        self.assertEqual(Severity.INFO, result.severity)
+        self.assertEqual(
+            {
+                "type": "asset_exists",
+                "resource": None,
+                "path": "/tmp/x.json",
+                "exists": True,
+                "read_only": True,
+                "executed": True,
+            },
+            result.data,
+        )
 
     def test_asset_exists_absent_emits_post_asset_exists_failed(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1279,9 +1294,20 @@ class PostconditionEvaluatorTests(unittest.TestCase):
             target_path="/tmp/x.json",
             target_exists=False,
         )
-        assert_error_envelope(result, code="POST_ASSET_EXISTS_FAILED", severity="error")
-        self.assertEqual("/tmp/x.json", result.data["path"])
-        self.assertFalse(result.data["exists"])
+        assert_error_envelope(
+            result,
+            code="POST_ASSET_EXISTS_FAILED",
+            severity="error",
+            message_match=r"target path was not created",
+            data={
+                "type": "asset_exists",
+                "resource": None,
+                "path": "/tmp/x.json",
+                "exists": False,
+                "read_only": True,
+                "executed": True,
+            },
+        )
 
     def test_broken_refs_scan_failed_emits_post_broken_refs_error(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1291,10 +1317,20 @@ class PostconditionEvaluatorTests(unittest.TestCase):
             {"type": "broken_refs", "scope": "Assets/", "expected_count": 0},
             scan_response=scan,
         )
-        assert_error_envelope(result, code="POST_BROKEN_REFS_ERROR", severity="error")
-        self.assertEqual("REF404", result.data["scan_code"])
-        self.assertEqual("Assets/", result.data["scope"])
-        self.assertEqual(0, result.data["expected_count"])
+        assert_error_envelope(
+            result,
+            code="POST_BROKEN_REFS_ERROR",
+            severity="error",
+            message_match=r"could not be evaluated",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "expected_count": 0,
+                "scan_code": "REF404",
+                "read_only": True,
+                "executed": True,
+            },
+        )
 
     def test_broken_refs_count_mismatch_emits_post_broken_refs_failed(self) -> None:
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
@@ -1306,10 +1342,21 @@ class PostconditionEvaluatorTests(unittest.TestCase):
             {"type": "broken_refs", "scope": "Assets/", "expected_count": 0},
             scan_response=scan,
         )
-        assert_error_envelope(result, code="POST_BROKEN_REFS_FAILED", severity="error")
-        self.assertEqual(0, result.data["expected_count"])
-        self.assertEqual(7, result.data["actual_count"])
-        self.assertEqual("REF_SCAN_BROKEN", result.data["scan_code"])
+        assert_error_envelope(
+            result,
+            code="POST_BROKEN_REFS_FAILED",
+            severity="error",
+            message_match=r"expected 0 broken refs but found 7",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "expected_count": 0,
+                "actual_count": 7,
+                "scan_code": "REF_SCAN_BROKEN",
+                "read_only": True,
+                "executed": True,
+            },
+        )
 
     def test_broken_refs_count_match_emits_post_broken_refs_ok(self) -> None:
         scan = _ok_response(
@@ -1321,9 +1368,19 @@ class PostconditionEvaluatorTests(unittest.TestCase):
         )
         self.assertTrue(result.success)
         self.assertEqual("POST_BROKEN_REFS_OK", result.code)
-        self.assertEqual(0, result.data["expected_count"])
-        self.assertEqual(0, result.data["actual_count"])
-        self.assertEqual("REF_SCAN_OK", result.data["scan_code"])
+        self.assertEqual(Severity.INFO, result.severity)
+        self.assertEqual(
+            {
+                "type": "broken_refs",
+                "scope": "Assets/",
+                "expected_count": 0,
+                "actual_count": 0,
+                "scan_code": "REF_SCAN_OK",
+                "read_only": True,
+                "executed": True,
+            },
+            result.data,
+        )
 
 
 class PatchApplyTests(unittest.TestCase):

--- a/tests/test_orchestrator_validation.py
+++ b/tests/test_orchestrator_validation.py
@@ -144,10 +144,96 @@ guid: {BASE_GUID}
 
 
 class MissingGuidContractTests(unittest.TestCase):
-    """T24: ``validate_refs`` surfaces top-level REF001 when any referenced
-    GUID is not resolvable in the project map."""
+    """T24 / Issue #146: ``validate_refs`` top-level outcome and full
+    nested step result envelope binds by exact value on both the
+    missing-GUID fail-fast path and the clean-scope path."""
+
+    @staticmethod
+    def _expected_clean_scan_data(scope: str) -> dict:
+        """Full ``scan_broken_references`` payload shape on the clean
+        single-Base.prefab fixture (one scanned file, zero references)."""
+        return {
+            "scope": scope,
+            "project_root": ".",
+            "scan_project_root": ".",
+            "read_only": True,
+            "details_included": False,
+            "max_diagnostics": 200,
+            "exclude_patterns": [],
+            "ignore_asset_guids": [],
+            "broken_count": 0,
+            "broken_occurrences": 0,
+            "categories": {"missing_asset": 0, "missing_local_id": 0},
+            "categories_occurrences": {"missing_asset": 0, "missing_local_id": 0},
+            "ignored_missing_asset_occurrences": 0,
+            "ignored_missing_asset_unique_count": 0,
+            "returned_diagnostics": 0,
+            "scanned_files": 1,
+            "scanned_references": 0,
+            "skipped_external_prefab_fileid_checks": 0,
+            "skipped_external_prefab_fileid_details": [],
+            "skipped_unreadable_target_checks": 0,
+            "top_ignored_missing_asset_guids": [],
+            "top_missing_asset_guids": [],
+            "truncated_diagnostics": 0,
+            "truncated_hint": None,
+            "unreadable_files": 0,
+        }
+
+    @staticmethod
+    def _expected_missing_guid_scan_data(scope: str) -> dict:
+        """Full ``scan_broken_references`` payload shape on the
+        missing-GUID Base+Variant fixture."""
+        return {
+            "scope": scope,
+            "project_root": ".",
+            "scan_project_root": ".",
+            "read_only": True,
+            "details_included": False,
+            "max_diagnostics": 200,
+            "exclude_patterns": [],
+            "ignore_asset_guids": [],
+            "broken_count": 1,
+            "broken_occurrences": 1,
+            "categories": {"missing_asset": 1, "missing_local_id": 0},
+            "categories_occurrences": {"missing_asset": 1, "missing_local_id": 0},
+            "ignored_missing_asset_occurrences": 0,
+            "ignored_missing_asset_unique_count": 0,
+            "returned_diagnostics": 0,
+            "scanned_files": 2,
+            "scanned_references": 3,
+            "skipped_external_prefab_fileid_checks": 1,
+            "skipped_external_prefab_fileid_details": [
+                {
+                    "source": "Assets/Variant.prefab",
+                    "target_guid": BASE_GUID,
+                    "file_id": "100100000",
+                }
+            ],
+            "skipped_unreadable_target_checks": 0,
+            "top_ignored_missing_asset_guids": [],
+            "top_missing_asset_guids": [
+                {
+                    "guid": MISSING_GUID,
+                    "occurrences": 1,
+                    "asset_name": "",
+                }
+            ],
+            "truncated_diagnostics": 1,
+            "truncated_hint": (
+                "1 broken reference(s) found. Use --details to include"
+                " individual diagnostics."
+            ),
+            "unreadable_files": 0,
+        }
 
     def test_validate_refs_returns_ref001(self) -> None:
+        """Missing-GUID fail-fast: top-level REF001, severity error,
+        and the full nested scan_broken_references step result envelope
+        binds by exact value (per-step success / severity / code /
+        message / data)."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             _create_project_with_missing_guid(root)
@@ -155,25 +241,35 @@ class MissingGuidContractTests(unittest.TestCase):
             resolver = ReferenceResolverService(project_root=root)
             response = validate_refs(resolver, scope="Assets")
 
-            self.assertFalse(response.success)
-            self.assertEqual("REF001", response.code)
-            self.assertEqual("error", response.severity.value)
-            # The underlying scan step remains visible in data.steps.
-            step_codes = [step["result"]["code"] for step in response.data["steps"]]
-            self.assertIn("REF_SCAN_BROKEN", step_codes)
-            self.assertGreaterEqual(response.data["missing_asset_unique_count"], 1)
-            # Issue #146 row: pin the step list shape and the data
-            # payload counter by exact value.  The orchestrator emits
-            # exactly one step (``scan_broken_references``) on the
-            # missing-GUID path.
-            self.assertEqual(
-                ["scan_broken_references"],
-                [step["step"] for step in response.data["steps"]],
-            )
-            self.assertEqual(1, response.data["missing_asset_unique_count"])
+        assert_error_envelope(
+            response,
+            code="REF001",
+            severity="error",
+            message_match=r"missing GUID reference",
+            data={
+                "scope": "Assets",
+                "read_only": True,
+                "ignore_asset_guids": [],
+                "missing_asset_unique_count": 1,
+                "steps": [
+                    {
+                        "step": "scan_broken_references",
+                        "result": {
+                            "success": False,
+                            "severity": "error",
+                            "code": "REF_SCAN_BROKEN",
+                            "message": "Broken references were detected in scope.",
+                            "data": self._expected_missing_guid_scan_data("Assets"),
+                        },
+                    }
+                ],
+            },
+        )
 
     def test_validate_refs_clean_scan_returns_validate_refs_result(self) -> None:
-        """Regression guard: clean scan must still return VALIDATE_REFS_RESULT."""
+        """Clean scope: top-level ``VALIDATE_REFS_RESULT`` at info, and
+        the full nested ``scan_broken_references`` result envelope binds
+        by exact value on the clean path too."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             _create_clean_project(root)
@@ -181,14 +277,32 @@ class MissingGuidContractTests(unittest.TestCase):
             resolver = ReferenceResolverService(project_root=root)
             response = validate_refs(resolver, scope="Assets")
 
-            self.assertTrue(response.success)
-            self.assertEqual("VALIDATE_REFS_RESULT", response.code)
-            self.assertEqual(0, response.data["missing_asset_unique_count"])
-            # Pin the step list ordering on the clean path too.
-            self.assertEqual(
-                ["scan_broken_references"],
-                [step["step"] for step in response.data["steps"]],
-            )
+        from prefab_sentinel.contracts import Severity  # noqa: PLC0415
+
+        self.assertTrue(response.success)
+        self.assertEqual("VALIDATE_REFS_RESULT", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {
+                "scope": "Assets",
+                "read_only": True,
+                "ignore_asset_guids": [],
+                "missing_asset_unique_count": 0,
+                "steps": [
+                    {
+                        "step": "scan_broken_references",
+                        "result": {
+                            "success": True,
+                            "severity": "info",
+                            "code": "REF_SCAN_OK",
+                            "message": "No broken references were detected in scope.",
+                            "data": self._expected_clean_scan_data("Assets"),
+                        },
+                    }
+                ],
+            },
+            response.data,
+        )
 
 
 class InspectStructureContractTests(unittest.TestCase):
@@ -358,18 +472,56 @@ class ValidateRuntimePipelineTests(unittest.TestCase):
             data=data or {"read_only": True},
         )
 
+    @staticmethod
+    def _canvas_step_result(scene_path: str) -> dict:
+        """Full nested ``inspect_world_canvas`` result envelope (the
+        canvas step is real, not mocked, so its payload is deterministic)."""
+        return {
+            "success": True,
+            "severity": "info",
+            "code": "WORLD_CANVAS_INSPECT_OK",
+            "message": "World canvas inspection completed (read-only).",
+            "data": {
+                "scene_path": scene_path,
+                "read_only": True,
+                "diagnostic_count": 0,
+            },
+            "diagnostics": [],
+        }
+
+    @staticmethod
+    def _stub_step_result(
+        *,
+        success: bool,
+        severity: str,
+        code: str,
+        data: dict | None = None,
+    ) -> dict:
+        """Full nested step result envelope for a stubbed runtime step.
+        The mock response carries message ``"m"`` and the supplied data."""
+        return {
+            "success": success,
+            "severity": severity,
+            "code": code,
+            "message": "m",
+            "data": data or {"read_only": True},
+            "diagnostics": [],
+        }
+
     def test_fail_fast_runtime_step_error_aborts_pipeline(self) -> None:
         """When ``run_clientsim`` returns ``severity=error``, the
-        pipeline aborts at the run-clientsim step.  Top-level success
-        is False, ``fail_fast_triggered`` is True, and the steps list
-        contains exactly the canvas / compile / run-clientsim entries
-        in pipeline order."""
+        pipeline aborts at the run-clientsim step.  The full top-level
+        payload binds by value, with ``fail_fast_triggered`` true,
+        scene_path and profile echoed, and each step's name plus its
+        full nested result envelope (canvas / compile / run-clientsim)
+        bound by exact value."""
         from unittest.mock import MagicMock  # noqa: PLC0415
 
         from prefab_sentinel.contracts import Severity  # noqa: PLC0415
         from prefab_sentinel.orchestrator_validation import (  # noqa: PLC0415
             validate_runtime,
         )
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
 
         runtime = MagicMock()
         runtime.compile_udonsharp.return_value = self._make_response(
@@ -384,29 +536,49 @@ class ValidateRuntimePipelineTests(unittest.TestCase):
             scene.write_text(
                 "%YAML 1.1\n--- !u!1 &1\nGameObject:\n", encoding="utf-8"
             )
-            response = validate_runtime(runtime, str(scene))
+            scene_path = str(scene)
+            response = validate_runtime(runtime, scene_path)
 
-        self.assertFalse(response.success)
-        self.assertEqual("VALIDATE_RUNTIME_RESULT", response.code)
-        self.assertTrue(response.data["fail_fast_triggered"])
-        # Pipeline-position-ordered step list, pinned by exact step
-        # name and step code.
-        steps_seq = [
-            (entry["step"], entry["result"]["code"])
-            for entry in response.data["steps"]
-        ]
-        self.assertEqual(
-            [
-                ("inspect_world_canvas", "WORLD_CANVAS_INSPECT_OK"),
-                ("compile_udonsharp", "RUN_COMPILE_OK"),
-                ("run_clientsim", "RUN_CLIENTSIM_FAILED"),
-            ],
-            steps_seq,
-        )
+            assert_error_envelope(
+                response,
+                code="VALIDATE_RUNTIME_RESULT",
+                severity="error",
+                message_match=r"fail-fast policy",
+                data={
+                    "scene_path": scene_path,
+                    "profile": "default",
+                    "read_only": True,
+                    "fail_fast_triggered": True,
+                    "steps": [
+                        {
+                            "step": "inspect_world_canvas",
+                            "result": self._canvas_step_result(scene_path),
+                        },
+                        {
+                            "step": "compile_udonsharp",
+                            "result": self._stub_step_result(
+                                success=True,
+                                severity="info",
+                                code="RUN_COMPILE_OK",
+                            ),
+                        },
+                        {
+                            "step": "run_clientsim",
+                            "result": self._stub_step_result(
+                                success=False,
+                                severity="error",
+                                code="RUN_CLIENTSIM_FAILED",
+                            ),
+                        },
+                    ],
+                },
+            )
 
     def test_clean_pipeline_runs_full_step_sequence(self) -> None:
-        """When every step succeeds, the pipeline runs the full six-
-        step sequence; ``fail_fast_triggered`` is False."""
+        """When every step succeeds, the pipeline runs the full
+        six-step sequence; ``fail_fast_triggered`` is False; the full
+        top-level payload binds by value, with each step's name plus
+        its full nested result envelope bound by exact value."""
         from unittest.mock import MagicMock  # noqa: PLC0415
 
         from prefab_sentinel.contracts import Severity  # noqa: PLC0415
@@ -427,7 +599,10 @@ class ValidateRuntimePipelineTests(unittest.TestCase):
             "RUN_CLIENTSIM_OK", Severity.INFO, True
         )
         runtime.collect_unity_console.return_value = self._make_response(
-            "RUN_LOG_COLLECTED", Severity.INFO, True, data={"log_lines": [], "read_only": True}
+            "RUN_LOG_COLLECTED",
+            Severity.INFO,
+            True,
+            data={"log_lines": [], "read_only": True},
         )
         runtime.classify_errors.return_value = self._make_response(
             "RUN_CLASSIFY_OK", Severity.INFO, True
@@ -441,23 +616,70 @@ class ValidateRuntimePipelineTests(unittest.TestCase):
             scene.write_text(
                 "%YAML 1.1\n--- !u!1 &1\nGameObject:\n", encoding="utf-8"
             )
-            response = validate_runtime(runtime, str(scene))
+            scene_path = str(scene)
+            response = validate_runtime(runtime, scene_path)
 
-        self.assertTrue(response.success)
-        self.assertEqual("VALIDATE_RUNTIME_RESULT", response.code)
-        self.assertFalse(response.data["fail_fast_triggered"])
-        steps_seq = [entry["step"] for entry in response.data["steps"]]
-        self.assertEqual(
-            [
-                "inspect_world_canvas",
-                "compile_udonsharp",
-                "run_clientsim",
-                "collect_unity_console",
-                "classify_errors",
-                "assert_no_critical_errors",
-            ],
-            steps_seq,
-        )
+            from prefab_sentinel.contracts import Severity as _Severity  # noqa: PLC0415
+
+            self.assertTrue(response.success)
+            self.assertEqual("VALIDATE_RUNTIME_RESULT", response.code)
+            self.assertEqual(_Severity.INFO, response.severity)
+            self.assertEqual(
+                {
+                    "scene_path": scene_path,
+                    "profile": "default",
+                    "read_only": True,
+                    "fail_fast_triggered": False,
+                    "steps": [
+                        {
+                            "step": "inspect_world_canvas",
+                            "result": self._canvas_step_result(scene_path),
+                        },
+                        {
+                            "step": "compile_udonsharp",
+                            "result": self._stub_step_result(
+                                success=True,
+                                severity="info",
+                                code="RUN_COMPILE_OK",
+                            ),
+                        },
+                        {
+                            "step": "run_clientsim",
+                            "result": self._stub_step_result(
+                                success=True,
+                                severity="info",
+                                code="RUN_CLIENTSIM_OK",
+                            ),
+                        },
+                        {
+                            "step": "collect_unity_console",
+                            "result": self._stub_step_result(
+                                success=True,
+                                severity="info",
+                                code="RUN_LOG_COLLECTED",
+                                data={"log_lines": [], "read_only": True},
+                            ),
+                        },
+                        {
+                            "step": "classify_errors",
+                            "result": self._stub_step_result(
+                                success=True,
+                                severity="info",
+                                code="RUN_CLASSIFY_OK",
+                            ),
+                        },
+                        {
+                            "step": "assert_no_critical_errors",
+                            "result": self._stub_step_result(
+                                success=True,
+                                severity="info",
+                                code="RUN_ASSERT_OK",
+                            ),
+                        },
+                    ],
+                },
+                response.data,
+            )
 
 
 class TestValidationSnapshotPinning:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -451,9 +451,12 @@ class ReferenceResolverEnvelopeTests(unittest.TestCase):
             code="REF001",
             severity="error",
             message_match=r"32-character hexadecimal",
+            data={
+                "guid": "not-a-guid",
+                "file_id": "100100000",
+                "read_only": True,
+            },
         )
-        self.assertEqual("not-a-guid", response.data["guid"])
-        self.assertEqual("100100000", response.data["file_id"])
 
     def test_unknown_guid_emits_ref001_with_normalized_guid_value(self) -> None:
         """Issue #141 row: a well-formed GUID absent from the project map
@@ -472,18 +475,20 @@ class ReferenceResolverEnvelopeTests(unittest.TestCase):
             code="REF001",
             severity="error",
             message_match=r"not found",
+            data={
+                "guid": MISSING_GUID,
+                "file_id": "12345",
+                "read_only": True,
+            },
         )
-        self.assertEqual(MISSING_GUID, response.data["guid"])
-        self.assertEqual("12345", response.data["file_id"])
-        # missing_asset diagnostic carries the GUID value too.
-        details = [
-            (d.detail, d.evidence) for d in response.diagnostics
-        ]
-        self.assertTrue(
-            any(detail == "missing_asset" and MISSING_GUID in evidence
-                for detail, evidence in details),
-            f"missing_asset diagnostic absent: {details}",
-        )
+        # missing_asset diagnostic carries the GUID value verbatim by
+        # full-string equality on detail and evidence.
+        self.assertEqual(1, len(response.diagnostics))
+        diag = response.diagnostics[0]
+        self.assertEqual("", diag.path)
+        self.assertEqual("guid", diag.location)
+        self.assertEqual("missing_asset", diag.detail)
+        self.assertEqual(f"guid {MISSING_GUID} not found", diag.evidence)
 
     def test_missing_local_id_emits_ref002_with_asset_path_and_file_id(self) -> None:
         """Issue #141 row: a fileID that does not exist in the resolved asset
@@ -520,12 +525,21 @@ guid: {asset_guid}
             code="REF002",
             severity="error",
             message_match=r"fileID was not found",
+            data={
+                "guid": asset_guid,
+                "file_id": "999999999",
+                "asset_path": "Assets/Settings.asset",
+                "read_only": True,
+            },
         )
-        self.assertEqual(asset_guid, response.data["guid"])
-        self.assertEqual("999999999", response.data["file_id"])
-        self.assertEqual("Assets/Settings.asset", response.data["asset_path"])
-        details = [d.detail for d in response.diagnostics]
-        self.assertIn("missing_local_id", details)
+        self.assertEqual(1, len(response.diagnostics))
+        diag = response.diagnostics[0]
+        self.assertEqual("Assets/Settings.asset", diag.path)
+        self.assertEqual("local fileID", diag.location)
+        self.assertEqual("missing_local_id", diag.detail)
+        self.assertEqual(
+            "fileID 999999999 not found in referenced asset", diag.evidence
+        )
 
     # ----- Issue #141: resolve_reference success outcomes -----
 
@@ -543,10 +557,15 @@ guid: {asset_guid}
         self.assertTrue(response.success)
         self.assertEqual("REF_BUILTIN", response.code)
         self.assertEqual(Severity.INFO, response.severity)
-        # Normalised: input upper-cased, output is lower-case 32 hex.
-        self.assertEqual(UNITY_BUILTIN_EXTRA_GUID, response.data["guid"])
-        self.assertEqual("10303", response.data["file_id"])
-        self.assertTrue(response.data["read_only"])
+        # Full-payload pinning: normalised GUID, input fileID, read-only flag.
+        self.assertEqual(
+            {
+                "guid": UNITY_BUILTIN_EXTRA_GUID,
+                "file_id": "10303",
+                "read_only": True,
+            },
+            response.data,
+        )
 
     def test_resolved_normal_guid_emits_ref_resolved_with_asset_path(self) -> None:
         """A normal (non-builtin) GUID present in the project map and a
@@ -561,17 +580,25 @@ guid: {asset_guid}
         self.assertTrue(response.success)
         self.assertEqual("REF_RESOLVED", response.code)
         self.assertEqual(Severity.INFO, response.severity)
-        self.assertEqual(BASE_GUID, response.data["guid"])
-        self.assertEqual("0", response.data["file_id"])
-        self.assertEqual("Assets/Base.prefab", response.data["asset_path"])
+        # Full-payload pinning for the asset-level fileID success path.
+        self.assertEqual(
+            {
+                "guid": BASE_GUID,
+                "file_id": "0",
+                "asset_path": "Assets/Base.prefab",
+                "file_id_validated": True,
+                "validation_note": "",
+                "read_only": True,
+            },
+            response.data,
+        )
 
     # ----- Issue #141: scan_broken_references outcomes -----
 
     def test_scan_broken_references_clean_emits_ref_scan_ok(self) -> None:
         """A scope free of broken references returns ``REF_SCAN_OK``
-        with ``severity=info`` and a per-category map whose
-        missing-asset and missing-local-id keys both read zero (the
-        published quality-gate counters)."""
+        with ``severity=info`` and the full quality-gate counter
+        payload bound by value."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             # Single self-contained asset with a meta file but no
@@ -597,14 +624,42 @@ guid: 1111111111111111111111111111aaaa
         self.assertTrue(response.success)
         self.assertEqual("REF_SCAN_OK", response.code)
         self.assertEqual(Severity.INFO, response.severity)
-        self.assertEqual(0, response.data["broken_count"])
-        self.assertEqual(0, response.data["categories"]["missing_asset"])
-        self.assertEqual(0, response.data["categories"]["missing_local_id"])
+        self.assertEqual(
+            {
+                "scope": "Assets",
+                "project_root": ".",
+                "scan_project_root": ".",
+                "read_only": True,
+                "details_included": False,
+                "max_diagnostics": 200,
+                "exclude_patterns": [],
+                "ignore_asset_guids": [],
+                "broken_count": 0,
+                "broken_occurrences": 0,
+                "categories": {"missing_asset": 0, "missing_local_id": 0},
+                "categories_occurrences": {"missing_asset": 0, "missing_local_id": 0},
+                "ignored_missing_asset_occurrences": 0,
+                "ignored_missing_asset_unique_count": 0,
+                "returned_diagnostics": 0,
+                "scanned_files": 1,
+                "scanned_references": 0,
+                "skipped_external_prefab_fileid_checks": 0,
+                "skipped_external_prefab_fileid_details": [],
+                "skipped_unreadable_target_checks": 0,
+                "top_ignored_missing_asset_guids": [],
+                "top_missing_asset_guids": [],
+                "truncated_diagnostics": 0,
+                "truncated_hint": None,
+                "unreadable_files": 0,
+            },
+            response.data,
+        )
+        self.assertEqual([], response.diagnostics)
 
     def test_scan_broken_references_partial_emits_ref_scan_partial(self) -> None:
         """A scope where every reference resolves but one or more files
         could not be UTF-8/CP932 decoded returns ``REF_SCAN_PARTIAL``
-        with ``severity=warning`` and ``unreadable_files >= 1``."""
+        with ``severity=warning`` and ``unreadable_files == 1``."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             # An undecodable .prefab keeps the scope non-broken (no
@@ -624,18 +679,30 @@ guid: 2222222222222222222222222222bbbb
         self.assertTrue(response.success)
         self.assertEqual("REF_SCAN_PARTIAL", response.code)
         self.assertEqual(Severity.WARNING, response.severity)
+        # Pin the load-bearing partial-scan counters by exact value.
         self.assertEqual(0, response.data["broken_count"])
-        self.assertGreaterEqual(response.data["unreadable_files"], 1)
-        # The diagnostic detail tag for the partial-scan case is the
-        # documented "unreadable_file" tag.
-        details = [d.detail for d in response.diagnostics]
-        self.assertIn("unreadable_file", details)
+        self.assertEqual(1, response.data["unreadable_files"])
+        self.assertEqual(1, response.data["returned_diagnostics"])
+        self.assertEqual(True, response.data["details_included"])
+        # The diagnostic detail tag for the partial-scan case binds by
+        # full-string equality on detail / location / path / evidence.
+        self.assertEqual(1, len(response.diagnostics))
+        diag = response.diagnostics[0]
+        self.assertEqual("Assets/Bad.prefab", diag.path)
+        self.assertEqual("", diag.location)
+        self.assertEqual("unreadable_file", diag.detail)
+        self.assertEqual(
+            "File could not be decoded (UTF-8/CP932). References inside this"
+            " file were not validated. Check file encoding (UTF-8 or CP932"
+            " expected) and permissions.",
+            diag.evidence,
+        )
 
     def test_scan_broken_references_broken_emits_ref_scan_broken_with_categories(self) -> None:
         """Issue #141 row: a scope with broken references returns
-        ``REF_SCAN_BROKEN`` with ``severity=error`` and per-category
-        counts pinned by value; the category map's ``missing_asset``
-        key is the published quality-gate counter."""
+        ``REF_SCAN_BROKEN`` with ``severity=error`` and the full
+        quality-gate counter payload bound by value (per-category
+        map, top-missing-asset list, broken count)."""
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -649,10 +716,74 @@ guid: 2222222222222222222222222222bbbb
             code="REF_SCAN_BROKEN",
             severity="error",
             message_match=r"[Bb]roken",
+            data={
+                "scope": "Assets",
+                "project_root": ".",
+                "scan_project_root": ".",
+                "read_only": True,
+                "details_included": False,
+                "max_diagnostics": 200,
+                "exclude_patterns": [],
+                "ignore_asset_guids": [],
+                "broken_count": 2,
+                "broken_occurrences": 2,
+                "categories": {"missing_asset": 1, "missing_local_id": 1},
+                "categories_occurrences": {"missing_asset": 1, "missing_local_id": 1},
+                "ignored_missing_asset_occurrences": 0,
+                "ignored_missing_asset_unique_count": 0,
+                "returned_diagnostics": 0,
+                "scanned_files": 2,
+                "scanned_references": 13,
+                "skipped_external_prefab_fileid_checks": 6,
+                "skipped_external_prefab_fileid_details": [
+                    {
+                        "source": "Assets/Variant.prefab",
+                        "target_guid": BASE_GUID,
+                        "file_id": "100100000",
+                    },
+                    {
+                        "source": "Assets/Variant.prefab",
+                        "target_guid": BASE_GUID,
+                        "file_id": "999999",
+                    },
+                    {
+                        "source": "Assets/Variant.prefab",
+                        "target_guid": BASE_GUID,
+                        "file_id": "100100000",
+                    },
+                    {
+                        "source": "Assets/Variant.prefab",
+                        "target_guid": BASE_GUID,
+                        "file_id": "100100000",
+                    },
+                    {
+                        "source": "Assets/Variant.prefab",
+                        "target_guid": BASE_GUID,
+                        "file_id": "100100000",
+                    },
+                    {
+                        "source": "Assets/Variant.prefab",
+                        "target_guid": BASE_GUID,
+                        "file_id": "100100000",
+                    },
+                ],
+                "skipped_unreadable_target_checks": 0,
+                "top_ignored_missing_asset_guids": [],
+                "top_missing_asset_guids": [
+                    {
+                        "guid": MISSING_GUID,
+                        "occurrences": 1,
+                        "asset_name": "",
+                    }
+                ],
+                "truncated_diagnostics": 2,
+                "truncated_hint": (
+                    "2 broken reference(s) found. Use --details to include"
+                    " individual diagnostics."
+                ),
+                "unreadable_files": 0,
+            },
         )
-        self.assertEqual(2, response.data["broken_count"])
-        self.assertEqual(1, response.data["categories"]["missing_asset"])
-        self.assertEqual(1, response.data["categories"]["missing_local_id"])
 
     def test_scan_broken_references_missing_scope_emits_ref404(self) -> None:
         """An unspecified scope (path not present on disk) returns
@@ -670,8 +801,11 @@ guid: 2222222222222222222222222222bbbb
             code="REF404",
             severity="error",
             message_match=r"does not exist",
+            data={
+                "scope": "Assets/Does/Not/Exist",
+                "read_only": True,
+            },
         )
-        self.assertEqual("Assets/Does/Not/Exist", response.data["scope"])
 
     def test_scan_broken_references_invalid_ignore_entry_emits_ref001(self) -> None:
         """An ignore-asset-guid entry that is not a 32-char hex GUID
@@ -693,16 +827,20 @@ guid: 2222222222222222222222222222bbbb
             code="REF001",
             severity="error",
             message_match=r"32-character hexadecimal",
+            data={
+                "scope": "Assets",
+                "invalid_ignore_asset_guids": ["not-a-guid"],
+                "read_only": True,
+            },
         )
-        self.assertEqual(["not-a-guid"], response.data["invalid_ignore_asset_guids"])
 
     # ----- Issue #141: where_used outcomes -----
 
     def test_where_used_resolved_emits_ref_where_used_with_pinned_shape(self) -> None:
         """A resolvable GUID with a scope that contains usages returns
-        ``REF_WHERE_USED`` with usages of stable per-entry shape
-        (``path`` / ``line`` / ``column`` / ``reference``) and an
-        accurate ``returned_usages`` count."""
+        ``REF_WHERE_USED`` with the deterministic fixture count
+        (BASE_GUID appears 6 times in Variant.prefab) and the full
+        usage entry list bound by value."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             _create_sample_project(root)
@@ -711,13 +849,76 @@ guid: 2222222222222222222222222222bbbb
 
         self.assertTrue(response.success)
         self.assertEqual("REF_WHERE_USED", response.code)
-        self.assertEqual(BASE_GUID, response.data["guid"])
-        self.assertEqual("Assets/Base.prefab", response.data["asset_path"])
-        self.assertEqual("Assets", response.data["scope"])
-        self.assertGreaterEqual(response.data["returned_usages"], 1)
-        first = response.data["usages"][0]
-        for key in ("path", "line", "column", "reference"):
-            self.assertIn(key, first)
+        self.assertEqual(Severity.INFO, response.severity)
+        # Full-payload pinning. The 6 usages come from m_SourcePrefab
+        # + m_ExternalPrefabRef + 4 modification targets (4 m_LocalRef
+        # without GUID is filtered).
+        self.assertEqual(
+            {
+                "guid": BASE_GUID,
+                "asset_path": "Assets/Base.prefab",
+                "scope": "Assets",
+                "scan_project_root": ".",
+                "usage_count": 6,
+                "returned_usages": 6,
+                "truncated_usages": 0,
+                "max_usages": 500,
+                "scanned_files": 2,
+                "exclude_patterns": [],
+                "read_only": True,
+                "usages": [
+                    {
+                        "path": "Assets/Variant.prefab",
+                        "line": 4,
+                        "column": 19,
+                        "reference": (
+                            f"{{fileID: 100100000, guid: {BASE_GUID}, type: 3}}"
+                        ),
+                    },
+                    {
+                        "path": "Assets/Variant.prefab",
+                        "line": 5,
+                        "column": 24,
+                        "reference": (
+                            f"{{fileID: 999999, guid: {BASE_GUID}, type: 3}}"
+                        ),
+                    },
+                    {
+                        "path": "Assets/Variant.prefab",
+                        "line": 8,
+                        "column": 15,
+                        "reference": (
+                            f"{{fileID: 100100000, guid: {BASE_GUID}, type: 3}}"
+                        ),
+                    },
+                    {
+                        "path": "Assets/Variant.prefab",
+                        "line": 12,
+                        "column": 15,
+                        "reference": (
+                            f"{{fileID: 100100000, guid: {BASE_GUID}, type: 3}}"
+                        ),
+                    },
+                    {
+                        "path": "Assets/Variant.prefab",
+                        "line": 16,
+                        "column": 15,
+                        "reference": (
+                            f"{{fileID: 100100000, guid: {BASE_GUID}, type: 3}}"
+                        ),
+                    },
+                    {
+                        "path": "Assets/Variant.prefab",
+                        "line": 20,
+                        "column": 15,
+                        "reference": (
+                            f"{{fileID: 100100000, guid: {BASE_GUID}, type: 3}}"
+                        ),
+                    },
+                ],
+            },
+            response.data,
+        )
 
     def test_where_used_missing_scope_emits_ref404(self) -> None:
         """A scope path that does not exist returns ``REF404`` with
@@ -735,8 +936,11 @@ guid: 2222222222222222222222222222bbbb
             code="REF404",
             severity="error",
             message_match=r"does not exist",
+            data={
+                "scope": "Assets/NotFound",
+                "read_only": True,
+            },
         )
-        self.assertEqual("Assets/NotFound", response.data["scope"])
 
     def test_where_used_unknown_guid_emits_ref001(self) -> None:
         """A well-formed but unknown GUID returns ``REF001`` with the
@@ -754,8 +958,11 @@ guid: 2222222222222222222222222222bbbb
             code="REF001",
             severity="error",
             message_match=r"not found",
+            data={
+                "asset_or_guid": MISSING_GUID,
+                "read_only": True,
+            },
         )
-        self.assertEqual(MISSING_GUID, response.data["asset_or_guid"])
 
 
 class PatchValidatorEnvelopeTests(unittest.TestCase):
@@ -776,8 +983,8 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER001",
             severity="error",
             message_match=r"empty",
+            data={"property_path": ""},
         )
-        self.assertEqual("", response.data["property_path"])
 
     def test_validate_property_path_negative_subscript_emits_ser002(self) -> None:
         from prefab_sentinel.services.property_path import (  # noqa: PLC0415
@@ -792,52 +999,54 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER002",
             severity="error",
             message_match=r"negative",
+            data={"property_path": bad_path},
         )
-        self.assertEqual(bad_path, response.data["property_path"])
+
+    # Shared prefab fixture YAML used by SER003 set_component_fields rows.
+    _SER003_PREFAB_YAML = (
+        "%YAML 1.1\n"
+        "%TAG !u! tag:unity3d.com,2011:\n"
+        "--- !u!1 &100\n"
+        "GameObject:\n"
+        "  m_ObjectHideFlags: 0\n"
+        "  serializedVersion: 6\n"
+        "  m_Component:\n"
+        "  - component: {fileID: 200}\n"
+        "  - component: {fileID: 300}\n"
+        "  m_Layer: 0\n"
+        "  m_Name: Cube\n"
+        "  m_TagString: Untagged\n"
+        "  m_IsActive: 1\n"
+        "--- !u!4 &200\n"
+        "Transform:\n"
+        "  m_ObjectHideFlags: 0\n"
+        "  m_GameObject: {fileID: 100}\n"
+        "  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}\n"
+        "  m_LocalPosition: {x: 0, y: 0, z: 0}\n"
+        "  m_LocalScale: {x: 1, y: 1, z: 1}\n"
+        "  m_Children: []\n"
+        "  m_Father: {fileID: 0}\n"
+        "  m_RootOrder: 0\n"
+        "--- !u!23 &300\n"
+        "MeshRenderer:\n"
+        "  m_ObjectHideFlags: 0\n"
+        "  m_GameObject: {fileID: 100}\n"
+        "  m_Enabled: 1\n"
+    )
 
     def test_set_component_fields_unknown_property_emits_ser003_envelope(self) -> None:
-        """SER003 fires when ``set_component_fields`` cannot resolve the
-        referenced property on the chain.  The helper pins code, severity,
-        and a message regex; inline assertions pin target and component
-        values plus the diagnostic detail tag."""
+        """SER003 (property_not_found classification): the supplied
+        component exists on the chain but the referenced property does
+        not.  Pins the full payload (target, component, property_path,
+        suggestions, read_only) and the diagnostic by full-string
+        equality on path / location / detail / evidence."""
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
         from tests.test_mcp_server import _run  # noqa: PLC0415
-
-        prefab_yaml = (
-            "%YAML 1.1\n"
-            "%TAG !u! tag:unity3d.com,2011:\n"
-            "--- !u!1 &100\n"
-            "GameObject:\n"
-            "  m_ObjectHideFlags: 0\n"
-            "  serializedVersion: 6\n"
-            "  m_Component:\n"
-            "  - component: {fileID: 200}\n"
-            "  - component: {fileID: 300}\n"
-            "  m_Layer: 0\n"
-            "  m_Name: Cube\n"
-            "  m_TagString: Untagged\n"
-            "  m_IsActive: 1\n"
-            "--- !u!4 &200\n"
-            "Transform:\n"
-            "  m_ObjectHideFlags: 0\n"
-            "  m_GameObject: {fileID: 100}\n"
-            "  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}\n"
-            "  m_LocalPosition: {x: 0, y: 0, z: 0}\n"
-            "  m_LocalScale: {x: 1, y: 1, z: 1}\n"
-            "  m_Children: []\n"
-            "  m_Father: {fileID: 0}\n"
-            "  m_RootOrder: 0\n"
-            "--- !u!23 &300\n"
-            "MeshRenderer:\n"
-            "  m_ObjectHideFlags: 0\n"
-            "  m_GameObject: {fileID: 100}\n"
-            "  m_Enabled: 1\n"
-        )
 
         with tempfile.TemporaryDirectory() as raw:
             td = Path(raw)
             prefab_path = td / "test.prefab"
-            prefab_path.write_text(prefab_yaml, encoding="utf-8")
+            prefab_path.write_text(self._SER003_PREFAB_YAML, encoding="utf-8")
             from prefab_sentinel.mcp_server import create_server  # noqa: PLC0415
 
             server = create_server()
@@ -856,13 +1065,75 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER003",
             severity="error",
             message_match=r"not found",
+            data={
+                "target": str(prefab_path),
+                "component": "MeshRenderer",
+                "property_path": "m_NoSuchField",
+                "suggestions": ["m_ObjectHideFlags", "m_GameObject", "m_Enabled"],
+                "read_only": True,
+            },
         )
-        # Pin target / component / diagnostic-detail values inline.
-        self.assertEqual(str(prefab_path), response["data"]["target"])
-        self.assertEqual("MeshRenderer", response["data"]["component"])
+        # Diagnostic binds by full-string equality on every field.
+        self.assertEqual(1, len(response["diagnostics"]))
+        diag = response["diagnostics"][0]
+        self.assertEqual(str(prefab_path), diag["path"])
         self.assertEqual(
-            "property_not_found",
-            response["diagnostics"][0]["detail"],
+            "component 'MeshRenderer' property 'm_NoSuchField'",
+            diag["location"],
+        )
+        self.assertEqual("property_not_found", diag["detail"])
+        self.assertEqual(
+            f"property path 'm_NoSuchField' did not resolve on component"
+            f" 'MeshRenderer' for target '{prefab_path}'",
+            diag["evidence"],
+        )
+
+    def test_set_component_fields_unknown_component_emits_ser003_envelope(self) -> None:
+        """SER003 (component_not_found classification): the supplied
+        component type is not present on the resolved chain.  Pins the
+        full payload (target, component, suggestions, read_only) and
+        the diagnostic by full-string equality."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+        from tests.test_mcp_server import _run  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as raw:
+            td = Path(raw)
+            prefab_path = td / "test.prefab"
+            prefab_path.write_text(self._SER003_PREFAB_YAML, encoding="utf-8")
+            from prefab_sentinel.mcp_server import create_server  # noqa: PLC0415
+
+            server = create_server()
+            _, response = _run(server.call_tool(
+                "set_component_fields",
+                {
+                    "asset_path": str(prefab_path),
+                    "symbol_path": "Cube",
+                    "component": "NoSuchComponent",
+                    "fields": {"m_X": 0},
+                },
+            ))
+
+        assert_error_envelope(
+            response,
+            code="SER003",
+            severity="error",
+            message_match=r"not found",
+            data={
+                "target": str(prefab_path),
+                "component": "NoSuchComponent",
+                "suggestions": ["Transform", "MeshRenderer"],
+                "read_only": True,
+            },
+        )
+        self.assertEqual(1, len(response["diagnostics"]))
+        diag = response["diagnostics"][0]
+        self.assertEqual(str(prefab_path), diag["path"])
+        self.assertEqual("component 'NoSuchComponent'", diag["location"])
+        self.assertEqual("component_not_found", diag["detail"])
+        self.assertEqual(
+            f"component type 'NoSuchComponent' is not present in the chain"
+            f" for target '{prefab_path}'",
+            diag["evidence"],
         )
 
     # ----- Issue #143: validate_property_path family rows -----
@@ -883,8 +1154,8 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER001",
             severity="error",
             message_match=r"empty segment",
+            data={"property_path": bad_path},
         )
-        self.assertEqual(bad_path, response.data["property_path"])
 
     def test_validate_property_path_unterminated_bracket_emits_ser001(self) -> None:
         """Path-shape: a segment with ``[`` and no ``]`` is rejected by
@@ -901,8 +1172,8 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER001",
             severity="error",
             message_match=r"unterminated",
+            data={"property_path": bad_path},
         )
-        self.assertEqual(bad_path, response.data["property_path"])
 
     def test_validate_property_path_empty_subscript_emits_ser001(self) -> None:
         """Path-shape: ``[]`` with no inner text is the empty-subscript
@@ -919,8 +1190,8 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER001",
             severity="error",
             message_match=r"\[\]",
+            data={"property_path": bad_path},
         )
-        self.assertEqual(bad_path, response.data["property_path"])
 
     def test_validate_property_path_non_integer_subscript_emits_ser002(self) -> None:
         """Path-index: ``[abc]`` is not an integer — SER002 site."""
@@ -936,8 +1207,8 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER002",
             severity="error",
             message_match=r"integer",
+            data={"property_path": bad_path},
         )
-        self.assertEqual(bad_path, response.data["property_path"])
 
     def test_validate_property_path_size_with_subscript_emits_ser002(self) -> None:
         """Path-index: ``Array.size[0]`` — ``size`` is scalar and
@@ -954,8 +1225,8 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             code="SER002",
             severity="error",
             message_match=r"size.*scalar|scalar.*size",
+            data={"property_path": bad_path},
         )
-        self.assertEqual(bad_path, response.data["property_path"])
 
     def test_validate_property_path_well_formed_emits_pp_ok(self) -> None:
         """Happy-path: a well-formed path returns ``PP_OK`` at
@@ -969,7 +1240,7 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
         self.assertTrue(response.success)
         self.assertEqual("PP_OK", response.code)
         self.assertEqual(Severity.INFO, response.severity)
-        self.assertEqual(path, response.data["property_path"])
+        self.assertEqual({"property_path": path}, response.data)
 
     # ----- Issue #143: validate_op rejection-family rows -----
 
@@ -991,77 +1262,136 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
         result = validate_op(service, target="Assets/X.prefab", index=0, op=op, diagnostics=diagnostics)
         return result, diagnostics
 
+    def _assert_single_diagnostic(
+        self,
+        diagnostics: list[Diagnostic],
+        *,
+        location: str,
+        detail: str,
+        evidence: str,
+    ) -> None:
+        """Pin a single rejection diagnostic by full-string equality on
+        every field (path / location / detail / evidence)."""
+        self.assertEqual(1, len(diagnostics))
+        diag = diagnostics[0]
+        self.assertEqual("Assets/X.prefab", diag.path)
+        self.assertEqual(location, diag.location)
+        self.assertEqual(detail, diag.detail)
+        self.assertEqual(evidence, diag.evidence)
+
     def test_validate_op_unsupported_op_emits_schema_error(self) -> None:
         """Rejection family: an op name absent from both ``VALUE_OPS``
         and ``PREFAB_CREATE_OPS`` (e.g. ``"foo"``) appends a
         ``schema_error`` diagnostic with ``unsupported op`` evidence."""
         result, diagnostics = self._run_validate_op({"op": "foo", "component": "X", "path": "m_X"})
         self.assertIsNone(result)
-        self.assertEqual(1, len(diagnostics))
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertIn("unsupported op", diagnostics[0].evidence)
-        self.assertIn("foo", diagnostics[0].evidence)
-        self.assertIn("ops[0]", diagnostics[0].location)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (foo).op",
+            detail="schema_error",
+            evidence="unsupported op 'foo'",
+        )
 
     def test_validate_op_create_mode_op_in_open_mode_emits_schema_error(self) -> None:
         """Rejection family: a ``PREFAB_CREATE_OPS``-only name (e.g.
-        ``add_component``) in open-mode is rejected with a
-        create-mode-specific evidence string."""
+        ``add_component``) in open-mode is rejected with the documented
+        create-mode evidence string."""
         result, diagnostics = self._run_validate_op({"op": "add_component", "component": "X", "path": "m_X"})
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertIn("create-mode operation", diagnostics[0].evidence)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (add_component).op",
+            detail="schema_error",
+            evidence=(
+                "'add_component' is a create-mode operation and cannot be"
+                " used in open-mode patch plans. To add components to"
+                " existing prefabs, edit the YAML directly or use Unity's"
+                " Add Component menu."
+            ),
+        )
 
     def test_validate_op_missing_component_emits_schema_error(self) -> None:
         """Rejection family: ``component`` empty or absent emits a
-        schema_error diagnostic with ``component is required`` evidence."""
-        result, diagnostics = self._run_validate_op({"op": "set", "component": "", "path": "m_X", "value": 1})
+        ``schema_error`` diagnostic with ``component is required`` evidence."""
+        result, diagnostics = self._run_validate_op(
+            {"op": "set", "component": "", "path": "m_X", "value": 1}
+        )
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertEqual("component is required", diagnostics[0].evidence)
-        self.assertIn(".component", diagnostics[0].location)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (set).component",
+            detail="schema_error",
+            evidence="component is required",
+        )
 
     def test_validate_op_numeric_fileid_component_emits_likely_fileid(self) -> None:
         """Rejection family: a numeric component string (e.g. ``"123"``)
-        appends a ``likely_fileid`` diagnostic *in addition to* (not
-        instead of) the normal flow.  When ``path`` is also missing the
-        op is rejected; this test pins both diagnostics."""
-        result, diagnostics = self._run_validate_op({"op": "set", "component": "123", "path": "", "value": 0})
+        appends a ``likely_fileid`` diagnostic *in addition to* the
+        ``schema_error`` for the missing path.  Both diagnostics bind
+        by full-string equality."""
+        result, diagnostics = self._run_validate_op(
+            {"op": "set", "component": "123", "path": "", "value": 0}
+        )
         self.assertIsNone(result)
-        details = [d.detail for d in diagnostics]
-        self.assertIn("likely_fileid", details)
+        self.assertEqual(2, len(diagnostics))
+        self.assertEqual("Assets/X.prefab", diagnostics[0].path)
+        self.assertEqual("ops[0] (set).component", diagnostics[0].location)
+        self.assertEqual("likely_fileid", diagnostics[0].detail)
+        self.assertEqual(
+            "component '123' looks like a numeric fileID. The Unity bridge"
+            " resolves components by type name (e.g. 'SkinnedMeshRenderer'"
+            " or 'TypeName@/hierarchy/path'). Numeric fileIDs will fail"
+            " at apply time.",
+            diagnostics[0].evidence,
+        )
+        self.assertEqual("Assets/X.prefab", diagnostics[1].path)
+        self.assertEqual("ops[0] (set).path", diagnostics[1].location)
+        self.assertEqual("schema_error", diagnostics[1].detail)
+        self.assertEqual("path is required", diagnostics[1].evidence)
 
     def test_validate_op_missing_path_emits_schema_error(self) -> None:
-        """Rejection family: empty ``path`` emits schema_error with
+        """Rejection family: empty ``path`` emits ``schema_error`` with
         ``path is required`` evidence."""
-        result, diagnostics = self._run_validate_op({"op": "set", "component": "X", "path": "", "value": 0})
+        result, diagnostics = self._run_validate_op(
+            {"op": "set", "component": "X", "path": "", "value": 0}
+        )
         self.assertIsNone(result)
-        details = [(d.detail, d.evidence) for d in diagnostics]
-        self.assertTrue(
-            any(detail == "schema_error" and evidence == "path is required" for detail, evidence in details),
-            f"missing path is required diagnostic: {details}",
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (set).path",
+            detail="schema_error",
+            evidence="path is required",
         )
 
     def test_validate_op_missing_value_for_set_emits_schema_error(self) -> None:
         """Rejection family: ``set`` without a ``value`` key emits
-        schema_error with ``value is required for set`` evidence."""
-        result, diagnostics = self._run_validate_op({"op": "set", "component": "X", "path": "m_X"})
+        ``schema_error`` with ``value is required for set`` evidence."""
+        result, diagnostics = self._run_validate_op(
+            {"op": "set", "component": "X", "path": "m_X"}
+        )
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertEqual("value is required for set", diagnostics[0].evidence)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (set).value",
+            detail="schema_error",
+            evidence="value is required for set",
+        )
 
     def test_validate_op_handle_prefix_value_emits_warning_on_set(self) -> None:
         """Rejection family: ``set`` with a value that looks like a
-        create-mode handle (``$``-prefixed, ``c_``-prefixed, or
-        ``go_``-prefixed) attaches a ``_warning`` to the preview row
-        rather than rejecting; the row is still returned."""
+        create-mode handle (``$``-prefixed) attaches a ``_warning`` to
+        the preview row rather than rejecting; the row is still returned
+        and no diagnostic is appended."""
         result, diagnostics = self._run_validate_op(
             {"op": "set", "component": "X", "path": "m_X", "value": "$handle"}
         )
         self.assertIsNotNone(result)
-        self.assertIn("_warning", result)
-        self.assertIn("$handle", result["_warning"])
-        # No diagnostics emitted for this case.
+        self.assertEqual(
+            "Value '$handle' looks like a create-mode handle. Handle strings"
+            " are only resolved in 'target'/'parent' fields. For"
+            ' ObjectReference, use {"guid": "...", "fileID": ...} or null.',
+            result["_warning"],
+        )
         self.assertEqual([], diagnostics)
 
     def test_validate_op_array_op_without_array_suffix_emits_schema_error(self) -> None:
@@ -1069,11 +1399,25 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
         ``remove_array_element`` whose path does not end in
         ``.Array.data`` is rejected with the array-suffix evidence."""
         result, diagnostics = self._run_validate_op(
-            {"op": "insert_array_element", "component": "X", "path": "m_NotArray", "index": 0, "value": 1}
+            {
+                "op": "insert_array_element",
+                "component": "X",
+                "path": "m_NotArray",
+                "index": 0,
+                "value": 1,
+            }
         )
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertIn("Array.data", diagnostics[0].evidence)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (insert_array_element).path",
+            detail="schema_error",
+            evidence=(
+                "Array operations require path ending with '.Array.data',"
+                " got 'm_NotArray'. Example:"
+                " 'globalSwitches.Array.data' instead of 'globalSwitches'."
+            ),
+        )
 
     def test_validate_op_missing_index_emits_schema_error(self) -> None:
         """Rejection family: ``insert_array_element`` /
@@ -1083,78 +1427,121 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             {"op": "remove_array_element", "component": "X", "path": "m_X.Array.data"}
         )
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertEqual("index is required for remove_array_element", diagnostics[0].evidence)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (remove_array_element).index",
+            detail="schema_error",
+            evidence="index is required for remove_array_element",
+        )
 
     def test_validate_op_non_integer_index_emits_schema_error(self) -> None:
         """Rejection family: a non-integer ``index`` (here ``"abc"``)
-        emits schema_error with ``index must be an integer``."""
+        emits ``schema_error`` with ``index must be an integer``."""
         result, diagnostics = self._run_validate_op(
-            {"op": "remove_array_element", "component": "X", "path": "m_X.Array.data", "index": "abc"}
+            {
+                "op": "remove_array_element",
+                "component": "X",
+                "path": "m_X.Array.data",
+                "index": "abc",
+            }
         )
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertEqual("index must be an integer", diagnostics[0].evidence)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (remove_array_element).index",
+            detail="schema_error",
+            evidence="index must be an integer",
+        )
 
     def test_validate_op_negative_index_emits_schema_error(self) -> None:
         """Rejection family: a negative integer ``index`` (here ``-1``)
-        emits schema_error with ``index must be >= 0``."""
+        emits ``schema_error`` with ``index must be >= 0``."""
         result, diagnostics = self._run_validate_op(
-            {"op": "remove_array_element", "component": "X", "path": "m_X.Array.data", "index": -1}
+            {
+                "op": "remove_array_element",
+                "component": "X",
+                "path": "m_X.Array.data",
+                "index": -1,
+            }
         )
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertEqual("index must be >= 0", diagnostics[0].evidence)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (remove_array_element).index",
+            detail="schema_error",
+            evidence="index must be >= 0",
+        )
 
     def test_validate_op_missing_value_for_array_insert_emits_schema_error(self) -> None:
         """Rejection family: ``insert_array_element`` without ``value``
-        emits schema_error with ``value is required for insert_array_element``."""
+        emits ``schema_error`` with
+        ``value is required for insert_array_element``."""
         result, diagnostics = self._run_validate_op(
-            {"op": "insert_array_element", "component": "X", "path": "m_X.Array.data", "index": 0}
+            {
+                "op": "insert_array_element",
+                "component": "X",
+                "path": "m_X.Array.data",
+                "index": 0,
+            }
         )
         self.assertIsNone(result)
-        self.assertEqual("schema_error", diagnostics[0].detail)
-        self.assertEqual("value is required for insert_array_element", diagnostics[0].evidence)
+        self._assert_single_diagnostic(
+            diagnostics,
+            location="ops[0] (insert_array_element).value",
+            detail="schema_error",
+            evidence="value is required for insert_array_element",
+        )
 
 
 class PrefabVariantServiceTests(unittest.TestCase):
-    def test_detect_stale_and_compute_effective_values(self) -> None:
+    def test_detect_stale_mixed_categories_returns_pvr001(self) -> None:
+        """Mixed categories (duplicate + array-size) yield the umbrella
+        code ``PVR001`` whose ``categories`` list pins both classifications."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             _create_sample_project(root)
             svc = PrefabVariantService(project_root=root)
-
-            chain = svc.resolve_prefab_chain("Assets/Variant.prefab")
-            self.assertTrue(chain.success)
-            self.assertEqual("PVR_CHAIN_OK", chain.code)
-            self.assertGreaterEqual(len(chain.data["chain"]), 2)
-
-            overrides = svc.list_overrides("Assets/Variant.prefab")
-            self.assertEqual(5, overrides.data["override_count"])
-
-            effective = svc.compute_effective_values("Assets/Variant.prefab")
-            dup_values = [
-                item
-                for item in effective.data["effective_values"]
-                if item["property_path"] == "duplicated.path"
-            ]
-            self.assertEqual(1, len(dup_values))
-            self.assertEqual("second", dup_values[0]["value"])
-
             stale = svc.detect_stale_overrides("Assets/Variant.prefab")
-            self.assertFalse(stale.success)
-            # Mixed categories → umbrella code PVR001
-            self.assertEqual("PVR001", stale.code)
-            details = [diag.detail for diag in stale.diagnostics]
-            self.assertIn("duplicate_override", details)
-            self.assertIn("array_size_mismatch", details)
-            self.assertCountEqual(
-                ["array_size_mismatch", "duplicate_override"],
-                stale.data["categories"],
-            )
+
+        assert_error_envelope(
+            stale,
+            code="PVR001",
+            severity="warning",
+            message_match=r"[Ss]tale",
+            data={
+                "variant_path": "Assets/Variant.prefab",
+                "stale_count": 2,
+                "categories": ["array_size_mismatch", "duplicate_override"],
+                "read_only": True,
+            },
+        )
+        self.assertEqual(2, len(stale.diagnostics))
+        # Diagnostic per category, in deterministic order: duplicate then array.
+        dup_diag = stale.diagnostics[0]
+        self.assertEqual("Assets/Variant.prefab", dup_diag.path)
+        self.assertEqual("16:1..20:1", dup_diag.location)
+        self.assertEqual("duplicate_override", dup_diag.detail)
+        self.assertEqual(
+            f"{BASE_GUID}:100100000 / duplicated.path appears 2 times;"
+            " later entries shadow earlier entries",
+            dup_diag.evidence,
+        )
+        arr_diag = stale.diagnostics[1]
+        self.assertEqual("Assets/Variant.prefab", arr_diag.path)
+        self.assertEqual("array_override", arr_diag.location)
+        self.assertEqual("array_size_mismatch", arr_diag.detail)
+        self.assertEqual(
+            f"{BASE_GUID}:100100000 / mic_obj_extra:"
+            " size=1 but data index 1 exists",
+            arr_diag.evidence,
+        )
 
     def test_detect_stale_duplicate_only_returns_pvr002(self) -> None:
-        """Single-category duplicate_override → PVR002."""
+        """Single-category duplicate_override yields ``PVR002``."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             write_file(
@@ -1189,16 +1576,34 @@ PrefabInstance:
             )
             svc = PrefabVariantService(project_root=root)
             stale = svc.detect_stale_overrides("Assets/Dup.prefab")
-            self.assertFalse(stale.success)
-            self.assertEqual("PVR002", stale.code)
-            self.assertEqual(Severity.WARNING, stale.severity)
-            self.assertEqual(["duplicate_override"], stale.data["categories"])
-            # Location includes both first and last occurrence
-            loc = stale.diagnostics[0].location
-            self.assertIn("..", loc)
+
+        assert_error_envelope(
+            stale,
+            code="PVR002",
+            severity="warning",
+            message_match=r"[Ss]tale",
+            data={
+                "variant_path": "Assets/Dup.prefab",
+                "stale_count": 1,
+                "categories": ["duplicate_override"],
+                "read_only": True,
+            },
+        )
+        self.assertEqual(1, len(stale.diagnostics))
+        diag = stale.diagnostics[0]
+        self.assertEqual("Assets/Dup.prefab", diag.path)
+        self.assertEqual("7:1..11:1", diag.location)
+        self.assertEqual("duplicate_override", diag.detail)
+        self.assertEqual(
+            f"{BASE_GUID}:100100000 / some.path appears 2 times;"
+            " later entries shadow earlier entries",
+            diag.evidence,
+        )
 
     def test_detect_stale_array_mismatch_only_returns_pvr003(self) -> None:
-        """Single-category array_size_mismatch → PVR003."""
+        """Single-category array_size_mismatch yields ``PVR003``."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             write_file(
@@ -1233,16 +1638,34 @@ PrefabInstance:
             )
             svc = PrefabVariantService(project_root=root)
             stale = svc.detect_stale_overrides("Assets/Arr.prefab")
-            self.assertFalse(stale.success)
-            self.assertEqual("PVR003", stale.code)
-            self.assertEqual(Severity.WARNING, stale.severity)
-            self.assertEqual(["array_size_mismatch"], stale.data["categories"])
+
+        assert_error_envelope(
+            stale,
+            code="PVR003",
+            severity="warning",
+            message_match=r"[Ss]tale",
+            data={
+                "variant_path": "Assets/Arr.prefab",
+                "stale_count": 1,
+                "categories": ["array_size_mismatch"],
+                "read_only": True,
+            },
+        )
+        self.assertEqual(1, len(stale.diagnostics))
+        diag = stale.diagnostics[0]
+        self.assertEqual("Assets/Arr.prefab", diag.path)
+        self.assertEqual("array_override", diag.location)
+        self.assertEqual("array_size_mismatch", diag.detail)
+        self.assertEqual(
+            f"{BASE_GUID}:100100000 / items: size=1 but data index 2 exists",
+            diag.evidence,
+        )
 
     def test_detect_stale_clean_variant_returns_pvr_stale_none(self) -> None:
         """Clean family: a variant with one unique scalar override (no
         duplicates, no array-size mismatch) returns ``PVR_STALE_NONE``
-        with ``success=True``, ``severity=INFO``, ``stale_count=0``, and
-        an empty ``diagnostics`` list."""
+        with ``success=True``, ``severity=INFO``, full-payload pinning,
+        and an empty ``diagnostics`` list."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             write_file(
@@ -1273,52 +1696,134 @@ PrefabInstance:
             )
             svc = PrefabVariantService(project_root=root)
             stale = svc.detect_stale_overrides("Assets/Clean.prefab")
-            self.assertTrue(stale.success)
-            self.assertEqual("PVR_STALE_NONE", stale.code)
-            self.assertEqual(Severity.INFO, stale.severity)
-            self.assertEqual(0, stale.data["stale_count"])
-            self.assertEqual([], stale.diagnostics)
+
+        self.assertTrue(stale.success)
+        self.assertEqual("PVR_STALE_NONE", stale.code)
+        self.assertEqual(Severity.INFO, stale.severity)
+        self.assertEqual(
+            {
+                "variant_path": "Assets/Clean.prefab",
+                "stale_count": 0,
+                "read_only": True,
+            },
+            stale.data,
+        )
+        self.assertEqual([], stale.diagnostics)
+
+    # ----- Issue #142: variant load-failure envelopes -----
+
+    def test_variant_load_missing_path_returns_pvr404(self) -> None:
+        """A variant path not present on disk fails with ``PVR404`` and
+        echoes the input path verbatim."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            svc = PrefabVariantService(project_root=root)
+            response = svc.list_overrides("Assets/DoesNotExist.prefab")
+
+        assert_error_envelope(
+            response,
+            code="PVR404",
+            severity="error",
+            message_match=r"does not exist",
+            data={
+                "variant_path": "Assets/DoesNotExist.prefab",
+                "read_only": True,
+            },
+        )
+
+    def test_variant_load_decode_failure_returns_pvr400(self) -> None:
+        """A variant path that exists but cannot be UTF-8 decoded fails
+        with ``PVR400`` and echoes the input path verbatim."""
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            bad = root / "Assets" / "BadBinary.prefab"
+            bad.parent.mkdir(parents=True, exist_ok=True)
+            bad.write_bytes(b"\xff\xfe\xfd\xfc not valid utf-8 \x80\x81\x82")
+            svc = PrefabVariantService(project_root=root)
+            response = svc.list_overrides("Assets/BadBinary.prefab")
+
+        assert_error_envelope(
+            response,
+            code="PVR400",
+            severity="error",
+            message_match=r"could not be decoded",
+            data={
+                "variant_path": "Assets/BadBinary.prefab",
+                "read_only": True,
+            },
+        )
 
     # ----- Issue #142: prefab-variant value-pinning rows -----
 
-    def test_list_overrides_pins_count_and_first_entry_shape(self) -> None:
+    def test_list_overrides_pins_full_payload(self) -> None:
         """Issue #142 row: ``list_overrides`` returns
-        ``PVR_OVERRIDES_OK`` whose ``override_count`` equals 5 for the
-        sample variant and whose first entry carries every documented
-        per-entry field by exact value (``line``, ``target_file_id``,
-        ``target_guid``, ``property_path``, ``value``,
-        ``object_reference``)."""
+        ``PVR_OVERRIDES_OK`` whose full payload (override count, the
+        ordered ``overrides`` list with every per-entry field, and the
+        echoed variant path / read-only flag / component filter) binds
+        by value."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             _create_sample_project(root)
             svc = PrefabVariantService(project_root=root)
-
             response = svc.list_overrides("Assets/Variant.prefab")
 
         self.assertTrue(response.success)
         self.assertEqual("PVR_OVERRIDES_OK", response.code)
         self.assertEqual(Severity.INFO, response.severity)
-        self.assertEqual(5, response.data["override_count"])
-        self.assertEqual("Assets/Variant.prefab", response.data["variant_path"])
-        # First entry pins every per-entry field by value.
-        first = response.data["overrides"][0]
-        self.assertEqual("100100000", first["target_file_id"])
-        self.assertEqual(BASE_GUID, first["target_guid"])
-        self.assertEqual("mic_obj_extra.Array.size", first["property_path"])
-        self.assertEqual("1", first["value"])
-        self.assertEqual("{fileID: 0}", first["object_reference"])
-        # Order is preserved: every property_path appears once and the
-        # full ordered list matches the YAML order.
-        property_paths = [entry["property_path"] for entry in response.data["overrides"]]
         self.assertEqual(
-            [
-                "mic_obj_extra.Array.size",
-                "mic_obj_extra.Array.data[1]",
-                "duplicated.path",
-                "duplicated.path",
-                "missing.asset",
-            ],
-            property_paths,
+            {
+                "variant_path": "Assets/Variant.prefab",
+                "override_count": 5,
+                "component_filter": None,
+                "read_only": True,
+                "overrides": [
+                    {
+                        "line": 8,
+                        "target_file_id": "100100000",
+                        "target_guid": BASE_GUID,
+                        "property_path": "mic_obj_extra.Array.size",
+                        "value": "1",
+                        "object_reference": "{fileID: 0}",
+                    },
+                    {
+                        "line": 12,
+                        "target_file_id": "100100000",
+                        "target_guid": BASE_GUID,
+                        "property_path": "mic_obj_extra.Array.data[1]",
+                        "value": "0",
+                        "object_reference": "{fileID: 0}",
+                    },
+                    {
+                        "line": 16,
+                        "target_file_id": "100100000",
+                        "target_guid": BASE_GUID,
+                        "property_path": "duplicated.path",
+                        "value": "first",
+                        "object_reference": "{fileID: 0}",
+                    },
+                    {
+                        "line": 20,
+                        "target_file_id": "100100000",
+                        "target_guid": BASE_GUID,
+                        "property_path": "duplicated.path",
+                        "value": "second",
+                        "object_reference": "{fileID: 0}",
+                    },
+                    {
+                        "line": 24,
+                        "target_file_id": "100100000",
+                        "target_guid": MISSING_GUID,
+                        "property_path": "missing.asset",
+                        "value": "0",
+                        "object_reference": "{fileID: 0}",
+                    },
+                ],
+            },
+            response.data,
         )
 
     def test_parse_overrides_pins_per_entry_tuple_sequence(self) -> None:
@@ -1357,10 +1862,10 @@ PrefabInstance:
             line_paths,
         )
 
-    def test_resolve_prefab_chain_pins_ordered_chain_identity(self) -> None:
+    def test_resolve_prefab_chain_pins_full_payload(self) -> None:
         """Issue #142 row: ``resolve_prefab_chain`` returns
-        ``PVR_CHAIN_OK`` whose ``chain`` list orders entries from the
-        leaf variant to the root base by exact ``path`` value."""
+        ``PVR_CHAIN_OK`` whose full payload (variant path, leaf-to-root
+        chain list, read-only flag) binds by value."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             _create_sample_project(root)
@@ -1370,20 +1875,24 @@ PrefabInstance:
         self.assertTrue(response.success)
         self.assertEqual("PVR_CHAIN_OK", response.code)
         self.assertEqual(Severity.INFO, response.severity)
-        chain_paths = [entry["path"] for entry in response.data["chain"]]
         self.assertEqual(
-            ["Assets/Variant.prefab", "Assets/Base.prefab"],
-            chain_paths,
+            {
+                "variant_path": "Assets/Variant.prefab",
+                "chain": [
+                    {"path": "Assets/Variant.prefab", "guid": None},
+                    {"path": "Assets/Base.prefab", "guid": None},
+                ],
+                "read_only": True,
+            },
+            response.data,
         )
-        self.assertEqual("Assets/Variant.prefab", response.data["variant_path"])
 
-    def test_resolve_chain_values_with_origin_pins_value_and_origin_per_property(self) -> None:
+    def test_resolve_chain_values_with_origin_pins_full_payload(self) -> None:
         """Issue #142 row: ``resolve_chain_values_with_origin`` returns
-        ``PVR_CHAIN_VALUES_WITH_ORIGIN`` whose per-entry ``values``
-        list carries one ``{property_path, value, origin_path,
-        origin_depth, target_file_id}`` row per resolved property; the
-        origin annotation lets callers tell variant-level overrides
-        from base-prefab values."""
+        ``PVR_CHAIN_VALUES_WITH_ORIGIN`` whose full per-entry origin
+        annotations bind by value (variant-level overrides have
+        ``origin_depth=0`` and the variant path; base values have
+        ``origin_depth=1`` and the base path)."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             _create_sample_project(root)
@@ -1392,23 +1901,118 @@ PrefabInstance:
 
         self.assertTrue(response.success)
         self.assertEqual("PVR_CHAIN_VALUES_WITH_ORIGIN", response.code)
-        values = response.data["values"]
-        # Map property_path -> entry to assert per-property origin
-        # without coupling to list order.
-        by_path = {entry["property_path"]: entry for entry in values}
-        # A variant-level override carries origin_depth=0 and the
-        # variant path under origin_path.
-        self.assertIn("mic_obj_extra.Array.size", by_path)
-        variant_entry = by_path["mic_obj_extra.Array.size"]
-        self.assertEqual("Assets/Variant.prefab", variant_entry["origin_path"])
-        self.assertEqual(0, variant_entry["origin_depth"])
-        self.assertEqual("1", variant_entry["value"])
-        # A base-prefab value (``m_Name``) carries origin_depth=1 and
-        # the base prefab path under origin_path.
-        self.assertIn("m_Name", by_path)
-        base_entry = by_path["m_Name"]
-        self.assertEqual("Assets/Base.prefab", base_entry["origin_path"])
-        self.assertEqual(1, base_entry["origin_depth"])
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {
+                "variant_path": "Assets/Variant.prefab",
+                "value_count": 5,
+                "chain": [
+                    {"path": "Assets/Variant.prefab", "depth": 0},
+                    {"path": "Assets/Base.prefab", "depth": 1},
+                ],
+                "values": [
+                    {
+                        "target_file_id": "100100000",
+                        "property_path": "mic_obj_extra.Array.size",
+                        "value": "1",
+                        "origin_path": "Assets/Variant.prefab",
+                        "origin_depth": 0,
+                    },
+                    {
+                        "target_file_id": "100100000",
+                        "property_path": "mic_obj_extra.Array.data[1]",
+                        "value": "0",
+                        "origin_path": "Assets/Variant.prefab",
+                        "origin_depth": 0,
+                    },
+                    {
+                        "target_file_id": "100100000",
+                        "property_path": "duplicated.path",
+                        "value": "first",
+                        "origin_path": "Assets/Variant.prefab",
+                        "origin_depth": 0,
+                    },
+                    {
+                        "target_file_id": "100100000",
+                        "property_path": "missing.asset",
+                        "value": "0",
+                        "origin_path": "Assets/Variant.prefab",
+                        "origin_depth": 0,
+                    },
+                    {
+                        "target_file_id": "100100000",
+                        "property_path": "m_Name",
+                        "value": "Base",
+                        "origin_path": "Assets/Base.prefab",
+                        "origin_depth": 1,
+                    },
+                ],
+                "read_only": True,
+            },
+            response.data,
+        )
+
+    def test_compute_effective_values_pins_full_payload(self) -> None:
+        """Issue #142 row: ``compute_effective_values`` returns
+        ``PVR_EFFECTIVE_OK`` whose full payload (variant path,
+        component filter, read-only flag, value count, and the
+        last-write-wins ``effective_values`` list) binds by value."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _create_sample_project(root)
+            svc = PrefabVariantService(project_root=root)
+            response = svc.compute_effective_values("Assets/Variant.prefab")
+
+        self.assertTrue(response.success)
+        self.assertEqual("PVR_EFFECTIVE_OK", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {
+                "variant_path": "Assets/Variant.prefab",
+                "value_count": 4,
+                "component_filter": None,
+                "read_only": True,
+                "effective_values": [
+                    {
+                        "target_key": f"{BASE_GUID}:100100000",
+                        "target_guid": BASE_GUID,
+                        "target_file_id": "100100000",
+                        "property_path": "mic_obj_extra.Array.size",
+                        "value": "1",
+                        "object_reference": "{fileID: 0}",
+                        "line": "8",
+                    },
+                    {
+                        "target_key": f"{BASE_GUID}:100100000",
+                        "target_guid": BASE_GUID,
+                        "target_file_id": "100100000",
+                        "property_path": "mic_obj_extra.Array.data[1]",
+                        "value": "0",
+                        "object_reference": "{fileID: 0}",
+                        "line": "12",
+                    },
+                    {
+                        "target_key": f"{BASE_GUID}:100100000",
+                        "target_guid": BASE_GUID,
+                        "target_file_id": "100100000",
+                        "property_path": "duplicated.path",
+                        "value": "second",
+                        "object_reference": "{fileID: 0}",
+                        "line": "20",
+                    },
+                    {
+                        "target_key": f"{MISSING_GUID}:100100000",
+                        "target_guid": MISSING_GUID,
+                        "target_file_id": "100100000",
+                        "property_path": "missing.asset",
+                        "value": "0",
+                        "object_reference": "{fileID: 0}",
+                        "line": "24",
+                    },
+                ],
+            },
+            response.data,
+        )
 
 
 class ModelFileSuffixDiagnosticTests(unittest.TestCase):

--- a/tests/test_services_runtime_validation.py
+++ b/tests/test_services_runtime_validation.py
@@ -97,6 +97,281 @@ class RuntimeValidationClassifyTests(unittest.TestCase):
         self.assertEqual({}, resp.data["count_by_category"])
 
 
+class ClassificationSeverityBoundaryTests(unittest.TestCase):
+    """Issue #145 — value-pinning rows for every documented severity
+    boundary of ``classify_errors`` and the ``assert_no_critical_errors``
+    downgrade boundary, using the structured-envelope helper for failure
+    envelopes and full-payload equality for success envelopes.
+
+    Spec rows: one row per documented log category (BROKEN_PPTR,
+    UDON_NULLREF, VARIANT_OVERRIDE_MISMATCH, DUPLICATE_EVENTSYSTEM,
+    MISSING_COMPONENT), one no-match rollup row, and four assertion-stage
+    rows (critical present / error only / warning disallowed / warning
+    allowed).
+    """
+
+    # --- classify_errors per-category severity boundaries ----------
+
+    def test_broken_pptr_emits_run001_at_severity_error(self) -> None:
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        svc = RuntimeValidationService()
+        resp = svc.classify_errors(["Broken PPtr in file Foo"])
+        assert_error_envelope(
+            resp,
+            code="RUN001",
+            severity="error",
+            message_match=r"error or critical",
+            data={
+                "count_total": 1,
+                "count_by_category": {"BROKEN_PPTR": 1},
+                "categories_by_severity": {
+                    "critical": 0,
+                    "error": 1,
+                    "warning": 0,
+                },
+                "line_count": 1,
+                "returned_diagnostics": 1,
+                "truncated_diagnostics": 0,
+                "read_only": True,
+            },
+        )
+
+    def test_udon_nullref_emits_run001_at_severity_critical(self) -> None:
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        svc = RuntimeValidationService()
+        resp = svc.classify_errors(
+            ["NullReferenceException in UdonBehaviour.MyEvent"]
+        )
+        assert_error_envelope(
+            resp,
+            code="RUN001",
+            severity="critical",
+            message_match=r"error or critical",
+            data={
+                "count_total": 1,
+                "count_by_category": {"UDON_NULLREF": 1},
+                "categories_by_severity": {
+                    "critical": 1,
+                    "error": 0,
+                    "warning": 0,
+                },
+                "line_count": 1,
+                "returned_diagnostics": 1,
+                "truncated_diagnostics": 0,
+                "read_only": True,
+            },
+        )
+
+    def test_variant_override_mismatch_emits_run001_at_severity_error(self) -> None:
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        svc = RuntimeValidationService()
+        resp = svc.classify_errors(["override mismatch detected on Foo"])
+        assert_error_envelope(
+            resp,
+            code="RUN001",
+            severity="error",
+            message_match=r"error or critical",
+            data={
+                "count_total": 1,
+                "count_by_category": {"VARIANT_OVERRIDE_MISMATCH": 1},
+                "categories_by_severity": {
+                    "critical": 0,
+                    "error": 1,
+                    "warning": 0,
+                },
+                "line_count": 1,
+                "returned_diagnostics": 1,
+                "truncated_diagnostics": 0,
+                "read_only": True,
+            },
+        )
+
+    def test_duplicate_eventsystem_emits_run_classify_warn(self) -> None:
+        """Warning band: ``RUN_CLASSIFY_WARN`` is a *success* envelope
+        whose severity is warning; full-payload pinned via direct equality."""
+        svc = RuntimeValidationService()
+        resp = svc.classify_errors(
+            ["There can be only one active EventSystem in the scene"]
+        )
+        self.assertTrue(resp.success)
+        self.assertEqual("RUN_CLASSIFY_WARN", resp.code)
+        self.assertEqual(Severity.WARNING, resp.severity)
+        self.assertEqual(
+            {
+                "count_total": 1,
+                "count_by_category": {"DUPLICATE_EVENTSYSTEM": 1},
+                "categories_by_severity": {
+                    "critical": 0,
+                    "error": 0,
+                    "warning": 1,
+                },
+                "line_count": 1,
+                "returned_diagnostics": 1,
+                "truncated_diagnostics": 0,
+                "read_only": True,
+            },
+            resp.data,
+        )
+
+    def test_missing_component_emits_run001_at_severity_error(self) -> None:
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        svc = RuntimeValidationService()
+        resp = svc.classify_errors(
+            ["The referenced script on this Behaviour is missing!"]
+        )
+        assert_error_envelope(
+            resp,
+            code="RUN001",
+            severity="error",
+            message_match=r"error or critical",
+            data={
+                "count_total": 1,
+                "count_by_category": {"MISSING_COMPONENT": 1},
+                "categories_by_severity": {
+                    "critical": 0,
+                    "error": 1,
+                    "warning": 0,
+                },
+                "line_count": 1,
+                "returned_diagnostics": 1,
+                "truncated_diagnostics": 0,
+                "read_only": True,
+            },
+        )
+
+    def test_no_match_input_rolls_up_to_run_classify_ok_at_info(self) -> None:
+        """No-match rollup: an unrelated log line returns
+        ``RUN_CLASSIFY_OK`` at severity info, ``count_total`` zero, every
+        per-band counter zero, and an empty ``count_by_category``."""
+        svc = RuntimeValidationService()
+        resp = svc.classify_errors(["unrelated runtime log line"])
+        self.assertTrue(resp.success)
+        self.assertEqual("RUN_CLASSIFY_OK", resp.code)
+        self.assertEqual(Severity.INFO, resp.severity)
+        self.assertEqual(
+            {
+                "count_total": 0,
+                "count_by_category": {},
+                "categories_by_severity": {
+                    "critical": 0,
+                    "error": 0,
+                    "warning": 0,
+                },
+                "line_count": 1,
+                "returned_diagnostics": 0,
+                "truncated_diagnostics": 0,
+                "read_only": True,
+            },
+            resp.data,
+        )
+
+    # --- assert_no_critical_errors downgrade boundary --------------
+
+    def test_assert_critical_present_emits_run001_at_severity_critical(self) -> None:
+        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
+            assert_no_critical_errors,
+        )
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        svc = RuntimeValidationService()
+        classification = svc.classify_errors(
+            ["NullReferenceException in UdonBehaviour.X"]
+        )
+        outcome = assert_no_critical_errors(classification)
+        assert_error_envelope(
+            outcome,
+            code="RUN001",
+            severity="critical",
+            message_match=r"critical/error",
+            data={
+                "critical_count": 1,
+                "error_count": 0,
+                "warning_count": 0,
+                "allow_warnings": False,
+                "read_only": True,
+            },
+        )
+
+    def test_assert_error_only_emits_run001_at_severity_error(self) -> None:
+        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
+            assert_no_critical_errors,
+        )
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        svc = RuntimeValidationService()
+        classification = svc.classify_errors(["Broken PPtr in file Foo"])
+        outcome = assert_no_critical_errors(classification)
+        assert_error_envelope(
+            outcome,
+            code="RUN001",
+            severity="error",
+            message_match=r"critical/error",
+            data={
+                "critical_count": 0,
+                "error_count": 1,
+                "warning_count": 0,
+                "allow_warnings": False,
+                "read_only": True,
+            },
+        )
+
+    def test_assert_warning_disallowed_emits_run_warnings(self) -> None:
+        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
+            assert_no_critical_errors,
+        )
+        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
+
+        svc = RuntimeValidationService()
+        classification = svc.classify_errors(
+            ["There can be only one active EventSystem in the scene"]
+        )
+        outcome = assert_no_critical_errors(classification, allow_warnings=False)
+        assert_error_envelope(
+            outcome,
+            code="RUN_WARNINGS",
+            severity="warning",
+            message_match=r"warnings are not allowed",
+            data={
+                "critical_count": 0,
+                "error_count": 0,
+                "warning_count": 1,
+                "allow_warnings": False,
+                "read_only": True,
+            },
+        )
+
+    def test_assert_warning_allowed_emits_run_assert_ok(self) -> None:
+        """Warning bypass: with ``allow_warnings=True`` a warning hit
+        returns ``RUN_ASSERT_OK`` at info; the warning counter is still
+        one (the bypass does not silence the count)."""
+        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
+            assert_no_critical_errors,
+        )
+
+        svc = RuntimeValidationService()
+        classification = svc.classify_errors(
+            ["There can be only one active EventSystem in the scene"]
+        )
+        outcome = assert_no_critical_errors(classification, allow_warnings=True)
+        self.assertTrue(outcome.success)
+        self.assertEqual("RUN_ASSERT_OK", outcome.code)
+        self.assertEqual(Severity.INFO, outcome.severity)
+        self.assertEqual(
+            {
+                "critical_count": 0,
+                "error_count": 0,
+                "warning_count": 1,
+                "allow_warnings": True,
+                "read_only": True,
+            },
+            outcome.data,
+        )
+
+
 class RuntimeClassificationSeverityBandTests(unittest.TestCase):
     """C1 — pin the four severity bands (critical / error / warning / info)
     by value plus the corresponding per-category count by value.


### PR DESCRIPTION
## Summary

Resolve the following 12 GitHub issues in the `tyunta/prefab-sentinel` repository. For every issue listed, run `gh issue view <number> --repo tyunta/prefab-sentinel` and read the full body, labels, and comments before designing or implementing changes. Each issue must be addressed within the scope described below.

## Issues and per-issue scope

### P0 — Mutation testing audit modules (assertion strengthening)

1. **#141 — `prefab_sentinel.services.reference_resolver`**: Strengthen tests so the 522 survived mutants are killed. Use `tests._assertion_helpers.assert_error_envelope` to pin code/severity/field/message values. Scope limited to `reference_resolver`. Follow CLAUDE.md "Mutation testing 運用".

2. **#142 — `prefab_sentinel.services.prefab_variant`**: Strengthen tests on the override-consistency paths (PVR001/PVR002/PVR003) using `assert_error_envelope` to pin error envelope contents. Scope limited to `prefab_variant`.

3. **#143 — `prefab_sentinel.services.serialized_object.patch_validator`**: Add value-pinned asserts on message/field/data contents for SER001/SER002/SER003. Scope limited to `patch_validator`.

### P1 — Mutation testing audit modules

4. **#145 — `prefab_sentinel.services.runtime_validation.classification`**: Add severity boundary-value tests (info/warning/error/critical). Scope limited to `classification`.

5. **#146 — `prefab_sentinel.orchestrator_postcondition` and `prefab_sentinel.orchestrator_validation`**: Eliminate the 565 survived mutants caused by insufficient assertions despite 100% branch coverage, using `assert_error_envelope`-based tests. Scope limited to those two modules.

### Auto-triage / small fixes

6. **#173 — `tests/test_services.py` around line 718**: Replace the `assertGreaterEqual` that produces mutation survivors with value-pinned assertions. Scope limited to the location described in the issue body.

7. **#175 — `PatchValidatorEnvelopeTests` `component_not_found` case**: Add tests pinning code/message/field values. Scope limited to the area described in the issue body.

8. **#176 — `tests/test_orchestrator.py` around line 933**: Consolidate the duplicate `PostconditionSchemaTests` test classes, merging unique coverage into a single class so no coverage is lost.

9. **#172 — `list_overrides` response/spec mismatch (`kind` / `target_key`)**: The user has not yet decided whether to fix the implementation or the spec; see Open Questions. Do not start this issue until the direction is decided. Once decided, reconcile the response and the spec in the chosen direction.

### Spec / documentation alignment

10. **#171 — `spec.md` §9 `detect_stale_overrides` severity description**: Fix the spec to match the implementation (per the issue body, change the documented severity from `error` to `warning`). Spec-only change; do not modify implementation.

11. **#159 — Spec internal contradiction in D4 mutation sampling**: Resolve the contradiction in the spec per the issue body. Spec-only change; do not modify implementation.

### Cross-cutting test infrastructure

12. **#178 — `tests._assertion_helpers.assert_error_envelope`**: Add an option to pin the entire `data` dictionary (or individual keys) to expected values. Backward compatibility is not required — update existing call sites to follow the new signature. Other tasks (#141, #142, #143, #145, #146, #175) depend on this; sequence accordingly.

## Constraints (explicit user statements)

- Issues #171 and #159 are spec/document-only — do not change implementation code.
- Issue #173 is limited to the location indicated in its issue body.
- Issue #175 is limited to the area indicated in its issue body.
- Issue #178 may break existing call sites: backward compatibility is not required, and existing callers must be updated to the new signature.
- Each of issues #141–#146 must remain scoped to the module named in the corresponding pick.

## Open Questions

1. **#172 direction**: The user has not selected among (A) fix the implementation to return `kind` / `target_key` per spec, (B) fix the spec to match the implementation, or (C) a third reconciled approach (e.g., field rename). This must be resolved before implementing #172.
2. **Execution sequencing across the 12 issues**: The user has not specified whether issues should be addressed in a single combined branch/PR, sequentially as separate PRs, or in parallel batches. #178 is a dependency for several test-strengthening issues (#141, #142, #143, #145, #146, #175) and should land before or alongside them regardless of the chosen sequencing.

## Execution Report

Workflow `superpowers-full` completed successfully.