### PR TITLE
implement-12-issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,4 @@
 - survived は critical / trivial / equivalent の三分類で記録する。trivial は `[tool.mutmut].do_not_mutate` に追加し、critical はテストでキルする。
 - 新規テストは `tests._assertion_helpers.assert_error_envelope` で code / severity / field / message を値で固定する。例外発生のみのアサートは禁止。
 - 新規のリポジトリ同期テスト（`tools/unity/` や `knowledge/` の un-mutated tree を読むだけで `prefab_sentinel/` のミューテーションを観測できないテスト）は、`@pytest.mark.source_text_invariant` をモジュールスコープで宣言する。これが mutmut のテスト選択（`-m "not source_text_invariant"` 単一フィルタ）からの除外メカニズム。
+- 数値リテラルがデフォルトパラメータとして truncation cap / size limit / threshold を担う場合、`±1` 境界 3 点（cap-1 / cap / cap+1）のテストを `tests/test_default_parameter_boundaries.py` に追加する（issue #179）。テスト本体ではデフォルトを明示的に渡さず、デフォルトリテラルを必ず発火させること（オーバーライドするとミューテーションが境界条件をすり抜ける）。発見手順は `grep -rnE "def .* = [0-9]+" prefab_sentinel/` を再走行し、ファイル冒頭の docstring に列挙されている既知サイトと差分を取って未カバーを追補する。

--- a/README.md
+++ b/README.md
@@ -421,6 +421,30 @@ Base/Variant/Sceneインスタンスを横断して実効値とoverrideを可視
 - 自動修復不可の場合は`decision_required`として返却
 - 自動修復対象は`safe_fix`として提案と根拠を返却
 
+### `list_overrides` レスポンス形状（issue #172）
+
+`list_overrides` の `data.overrides[]` 各エントリは次の 8 キーを必ず持つ:
+
+| キー | 値 |
+|---|---|
+| `kind` | 4 値の判別文字列 (`array_size` / `array_data` / `object_reference` / `value`) |
+| `target_key` | `<guid>:<fileID>` 複合識別子 |
+| `line` | YAML 中の `- target:` 行番号（1 始まり） |
+| `target_file_id` | override 対象の fileID 文字列 |
+| `target_guid` | override 対象の正規化済み GUID |
+| `property_path` | Unity の SerializedProperty パス |
+| `value` | 平文 value フィールド |
+| `object_reference` | objectReference フィールド (`{fileID: 0}` を含む) |
+
+`kind` の決定規則:
+
+- `array_size`: `property_path` が `*.Array.size` に一致するとき。
+- `array_data`: `property_path` が `*.Array.data[<index>]` に一致するとき。
+- `object_reference`: `object_reference` が空でも `{fileID: 0}` でもないとき。
+- `value`: 上記以外（`object_reference` が空または `{fileID: 0}`、もしくは `objectReference` フィールドが無いケースを含む）。
+
+`target_key` は `OverrideEntry.target_key` プロパティと同一値で、`target_guid` と `target_file_id` の `<guid>:<fileID>` 連結文字列。下流コンシューマは個別フィールドを再連結せず `target_key` を識別子として使う。
+
 ---
 
 ### 4.3 reference-resolver
@@ -843,6 +867,8 @@ uv run python -m pytest tests/ -v
 
 ### テストファイル配置
 
+D3 オーケストレータのスナップショット試験（issue #148）はファイル名 `tests/test_d3_orchestrator_snapshots.py` を正本とする（issue #161）。`tests/test_orchestrator.py` と `tests/test_orchestrator_patch.py` は既に高ボリュームの MagicMock 駆動テストおよび missing-GUID コントラクトテストで占有されており、スナップショットテスト一式を移植する利得がない。新しい inspect / wiring / patch オーケストレータのスナップショットを追加する場合は同ファイルへ追記する。
+
 | ソースモジュール | テストファイル |
 |---|---|
 | `prefab_sentinel/unity_assets.py` | `tests/test_unity_assets.py` |
@@ -921,6 +947,25 @@ uv run mutmut results
 - trivial-class パターンは `[tool.mutmut].do_not_mutate` に追加する（証跡をコミットメッセージに残す）。
 - critical-class survivors はテストでキルする（このテストは通常 PR 単位で追加され、四半期走行の入力になる）。
 - `[tool.mutmut].do_not_mutate` の追加と削除は四半期レポートに before/after の survived 件数差分を記録する（issue #149/#170 option A）。
+
+#### スコア集計（`scripts/mutmut_score_report.py`）
+
+四半期走行直後の `mutmut results` 出力をモジュール単位で集計するための専用スクリプト（issue #169）。`mutmut run --max-children 180` 完了後に走らせ、Markdown 表 / CSV / JSON のいずれかでスコアを出力する。
+
+```bash
+# 監査対象 6 モジュールのみで集計し Markdown 表を出力
+uv run python scripts/mutmut_score_report.py --audited-only --format markdown
+
+# 1 モジュールを掘り下げる
+uv run python scripts/mutmut_score_report.py \
+  --module prefab_sentinel.services.reference_resolver \
+  --format json
+
+# 四半期推移の累積追記用
+uv run python scripts/mutmut_score_report.py --format csv >> reports/mutmut_history.csv
+```
+
+CSV ヘッダには走行日 (`run_date`) / mutmut version / `parallelism` が含まれ、四半期推移を時系列で蓄積する設計。スコアは `(killed + timeout) / (killed + survived + timeout)` で計算する（`not_checked` は分母から除外する）。`mutmut results` 自体が非ゼロ終了した場合、スクリプトは exit code 4（`MUTMUT_SUBPROCESS_FAILURE_EXIT_CODE`）で停止し、stderr をそのまま透過する。
 
 #### テスト書き方ガイド (envelope value-pinning)
 

--- a/prefab_sentinel/services/prefab_variant/overrides.py
+++ b/prefab_sentinel/services/prefab_variant/overrides.py
@@ -40,6 +40,25 @@ class OverrideEntry:
     def target_key(self) -> str:
         return f"{self.target_guid}:{self.target_file_id}"
 
+    @property
+    def kind(self) -> str:
+        """Discriminant string identifying the shape of this override.
+
+        Why a derived property instead of a stored field: the four kinds
+        are deterministic functions of the already-parsed
+        ``property_path`` and ``object_reference`` fields, so a stored
+        discriminant would either duplicate the parser logic or risk
+        drift between the field and the underlying values.
+        """
+        if ARRAY_SIZE_PATH_PATTERN.match(self.property_path):
+            return "array_size"
+        if ARRAY_DATA_PATH_PATTERN.match(self.property_path):
+            return "array_data"
+        ref = self.object_reference
+        if ref and ref != "{fileID: 0}":
+            return "object_reference"
+        return "value"
+
 
 def effective_value(entry: OverrideEntry) -> str:
     """Return the effective value of an override entry.

--- a/prefab_sentinel/services/prefab_variant/service.py
+++ b/prefab_sentinel/services/prefab_variant/service.py
@@ -160,6 +160,8 @@ class PrefabVariantService:
 
         payload = [
             {
+                "kind": entry.kind,
+                "target_key": entry.target_key,
                 "line": entry.line,
                 "target_file_id": entry.target_file_id,
                 "target_guid": entry.target_guid,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,16 @@ do_not_mutate = [
     "*log.critical*",
     '*"""*',
     "*'''*",
+    # Issue #182: three semantically-equivalent mutation patterns over
+    # ``ReferenceResolverService`` internal cache state.  Skipping the
+    # cache fetch (``_text_cache.get`` returning None instead of the
+    # cached value) re-enters the slow path; mutating the GUID-index
+    # cache backing field triggers a fresh ``collect_project_guid_index``
+    # walk; mutating the cache-invalidation helpers leaves stale entries
+    # the next read clears anyway — none of these strengthen the suite.
+    "*_text_cache.get*",
+    "*_guid_map*",
+    "*invalidate_*_cache*",
 ]
 # Test collection in the mutated working directory imports modules from
 # ``scripts/`` and ``tools/``; without ``also_copy`` mutmut runs with only

--- a/scripts/mutmut_score_report.py
+++ b/scripts/mutmut_score_report.py
@@ -1,0 +1,348 @@
+"""Aggregate ``mutmut results`` output into per-module score records.
+
+The parser is the unit-testable seam: ``parse_mutmut_results`` consumes
+the ``mutmut results --all=true`` text and returns a dict keyed by
+module dotted-path with ``killed`` / ``survived`` / ``timeout`` /
+``not_checked`` integer counts and a derived ``score`` percentage.
+
+The CLI is a thin subprocess wrapper that runs ``mutmut results
+--all=true`` and emits Markdown / CSV / JSON.
+
+Score formula (from issue #169):
+
+    score = (killed + timeout) / (killed + survived + timeout)
+
+``not_checked`` mutants are reported but excluded from the denominator.
+
+Audited-only mode restricts output to the README §14.5 audited list.
+``--module <dotted.path>`` mode restricts output to that one module.
+
+Distinct exit codes (issue #169 / spec):
+
+* 0 — success
+* 4 — the ``mutmut results`` subprocess returned non-zero
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as _dt
+import io
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+
+MUTMUT_SUBPROCESS_FAILURE_EXIT_CODE = 4
+
+# README §14.5 audited modules.  Kept in one place so the audited-only
+# filter and the test suite both read from the same source of truth.
+AUDITED_MODULES: tuple[str, ...] = (
+    "prefab_sentinel.services.reference_resolver",
+    "prefab_sentinel.services.prefab_variant",
+    "prefab_sentinel.services.serialized_object.patch_validator",
+    "prefab_sentinel.services.runtime_validation.classification",
+    "prefab_sentinel.orchestrator_postcondition",
+    "prefab_sentinel.orchestrator_validation",
+)
+
+# A mutant line looks like one of:
+#   <module>.<function>__mutmut_<N>: <status>
+#   <module>.xǁ<Class>ǁ<method>__mutmut_<N>: <status>
+# The leading ``<index>) `` numbering some mutmut versions emit is
+# tolerated by the relaxed leading-anchor pattern below.
+_LINE_RE = re.compile(
+    r"""
+    ^\s*
+    (?:\d+\)\s+)?                # optional ``<idx>) `` prefix
+    (?P<name>[A-Za-z_][\w.ǁ]*?__mutmut_\d+)
+    \s*:\s*
+    (?P<status>[A-Za-z_]+)
+    \s*$
+    """,
+    re.VERBOSE,
+)
+
+_KNOWN_STATUSES = ("killed", "survived", "timeout", "not_checked")
+
+
+@dataclass
+class ModuleRecord:
+    """Per-module aggregate counts and the derived score."""
+
+    module: str
+    killed: int = 0
+    survived: int = 0
+    timeout: int = 0
+    not_checked: int = 0
+
+    @property
+    def total(self) -> int:
+        # ``not_checked`` is intentionally excluded from the denominator
+        # so the score reflects mutants that actually ran.
+        return self.killed + self.survived + self.timeout
+
+    @property
+    def score(self) -> float:
+        if self.total == 0:
+            return 0.0
+        return (self.killed + self.timeout) / self.total * 100.0
+
+
+def _normalize_status(raw: str) -> str | None:
+    """Map a raw status token to one of ``_KNOWN_STATUSES`` or None."""
+    token = raw.strip().lower()
+    if token in _KNOWN_STATUSES:
+        return token
+    if token in ("not", "skipped"):
+        return "not_checked"
+    return None
+
+
+def _extract_module(mutant_name: str) -> str:
+    """Return the module dotted-path of *mutant_name*.
+
+    A mutant name encodes the module, an optional class wrapper, the
+    function/method, and a ``__mutmut_<N>`` suffix.  The module is the
+    longest dotted-path prefix that does not include the class wrapper
+    marker ``xǁ`` or the function-name segment.
+    """
+    base = re.sub(r"__mutmut_\d+$", "", mutant_name)
+    parts = base.split(".")
+    for index, part in enumerate(parts):
+        # ``ǁ`` (U+01C1) marks the class wrapper segment in mutmut's
+        # name scheme (concretely ``xǁ<Class>ǁ<method>``); the segment
+        # containing this character is where the module path ends.
+        if "ǁ" in part:
+            return ".".join(parts[:index])
+    # No class wrapper: the last segment is the function.  Drop it.
+    if len(parts) <= 1:
+        return base
+    return ".".join(parts[:-1])
+
+
+def parse_mutmut_results(
+    text: str,
+    *,
+    module_filter: str | None = None,
+) -> dict[str, ModuleRecord]:
+    """Parse *text* (captured ``mutmut results`` stdout) into per-module records.
+
+    Lines that do not parse are skipped silently — never raises.
+    *module_filter*, when supplied, restricts output to the named module
+    (and its sub-modules whose dotted-path starts with ``module_filter.``).
+    """
+    records: dict[str, ModuleRecord] = {}
+    for line in text.splitlines():
+        match = _LINE_RE.match(line)
+        if match is None:
+            continue
+        status = _normalize_status(match.group("status"))
+        if status is None:
+            continue
+        module = _extract_module(match.group("name"))
+        if not module:
+            continue
+        if module_filter is not None and not (
+            module == module_filter
+            or module.startswith(module_filter + ".")
+        ):
+            continue
+        record = records.setdefault(module, ModuleRecord(module=module))
+        setattr(record, status, getattr(record, status) + 1)
+    return records
+
+
+def filter_audited(records: dict[str, ModuleRecord]) -> dict[str, ModuleRecord]:
+    """Restrict *records* to the README §14.5 audited module list."""
+    audited = set(AUDITED_MODULES)
+    return {
+        module: record
+        for module, record in records.items()
+        if any(
+            module == name or module.startswith(name + ".")
+            for name in audited
+        )
+    }
+
+
+def format_markdown(records: dict[str, ModuleRecord]) -> str:
+    """Render *records* as a Markdown table with a fixed column order."""
+    header = (
+        "| module | killed | survived | timeout | not_checked | total | score |\n"
+        "|---|---:|---:|---:|---:|---:|---:|\n"
+    )
+    if not records:
+        return header.rstrip() + "\n"
+    rows = []
+    for module in sorted(records.keys()):
+        record = records[module]
+        rows.append(
+            f"| {module} "
+            f"| {record.killed} "
+            f"| {record.survived} "
+            f"| {record.timeout} "
+            f"| {record.not_checked} "
+            f"| {record.total} "
+            f"| {record.score:.1f}% |"
+        )
+    return header + "\n".join(rows) + "\n"
+
+
+@dataclass
+class RunMetadata:
+    """Run-context columns surfaced in the CSV output."""
+
+    run_date: str
+    mutmut_version: str
+    parallelism: str
+
+    @classmethod
+    def from_now(cls, mutmut_version: str, parallelism: str) -> RunMetadata:
+        return cls(
+            run_date=_dt.datetime.now(tz=_dt.UTC).date().isoformat(),
+            mutmut_version=mutmut_version,
+            parallelism=parallelism,
+        )
+
+
+def format_csv(
+    records: dict[str, ModuleRecord],
+    metadata: RunMetadata,
+) -> str:
+    """Render *records* as CSV including run-date, mutmut version, parallelism."""
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(
+        [
+            "run_date",
+            "mutmut_version",
+            "parallelism",
+            "module",
+            "killed",
+            "survived",
+            "timeout",
+            "not_checked",
+            "total",
+            "score",
+        ]
+    )
+    for module in sorted(records.keys()):
+        record = records[module]
+        writer.writerow(
+            [
+                metadata.run_date,
+                metadata.mutmut_version,
+                metadata.parallelism,
+                module,
+                record.killed,
+                record.survived,
+                record.timeout,
+                record.not_checked,
+                record.total,
+                f"{record.score:.1f}",
+            ]
+        )
+    return buffer.getvalue()
+
+
+def format_json(records: dict[str, ModuleRecord]) -> str:
+    """Render *records* as a deterministic JSON document."""
+    payload = []
+    for module in sorted(records.keys()):
+        record = records[module]
+        entry = asdict(record)
+        entry["total"] = record.total
+        entry["score"] = round(record.score, 4)
+        payload.append(entry)
+    return json.dumps({"records": payload}, indent=2, sort_keys=True) + "\n"
+
+
+@dataclass
+class SubprocessOutcome:
+    """Captured result of running ``mutmut results --all=true``."""
+
+    returncode: int
+    stdout: str
+    stderr: str = ""
+    metadata: RunMetadata = field(
+        default_factory=lambda: RunMetadata.from_now("unknown", "unknown")
+    )
+
+
+def run_mutmut_results() -> SubprocessOutcome:
+    """Invoke ``mutmut results --all=true`` and return the captured outcome.
+
+    Why a thin wrapper: tests stub this function at its import site to
+    avoid spawning the real CLI; the parser itself is pure.
+    """
+    completed = subprocess.run(
+        ["mutmut", "results", "--all=true"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return SubprocessOutcome(
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        metadata=RunMetadata.from_now("unknown", "unknown"),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mutmut_score_report",
+        description=(
+            "Aggregate `mutmut results` output into per-module score records."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--module",
+        dest="module",
+        help="restrict output to the named dotted-path module",
+    )
+    group.add_argument(
+        "--audited-only",
+        dest="audited_only",
+        action="store_true",
+        help="restrict output to the README §14.5 audited module list",
+    )
+    parser.add_argument(
+        "--format",
+        dest="output_format",
+        choices=("markdown", "csv", "json"),
+        default="markdown",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    outcome = run_mutmut_results()
+    if outcome.returncode != 0:
+        if outcome.stderr:
+            sys.stderr.write(outcome.stderr)
+        return MUTMUT_SUBPROCESS_FAILURE_EXIT_CODE
+
+    records = parse_mutmut_results(outcome.stdout, module_filter=args.module)
+    if args.audited_only:
+        records = filter_audited(records)
+
+    if args.output_format == "markdown":
+        sys.stdout.write(format_markdown(records))
+    elif args.output_format == "csv":
+        sys.stdout.write(format_csv(records, outcome.metadata))
+    else:
+        sys.stdout.write(format_json(records))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_unit_tests.py
+++ b/scripts/run_unit_tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,12 +10,60 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 
 DEFAULT_ARGS = ["-s", "tests", "-t", ".", "-v", "-j", "0"]
 
+# Distinct exit codes per failure mode so CI can disambiguate them.
+# 0  — tests passed
+# 1  — at least one test failed (unittest_parallel default)
+# 2  — unittest_parallel is not installed
+# 3  — stale ``mutants/`` artifact tree aborts the preflight (issue #174)
+MISSING_PARALLEL_RUNNER_EXIT_CODE = 2
+STALE_MUTANTS_EXIT_CODE = 3
+
+# mutmut sets this env var inside its forked child invocations of
+# ``pytest``; when present, the runner is itself executing inside an
+# active mutmut session and the ``mutants/`` directory is intentional
+# rather than stale.  The preflight passes through silently in that case.
+_MUTMUT_CHILD_INDICATOR = "MUTANT_UNDER_TEST"
+_STALE_MUTANTS_DIR_NAME = "mutants"
+
 
 def _build_command(argv: list[str]) -> list[str]:
     return [sys.executable, "-m", "unittest_parallel", *(argv or DEFAULT_ARGS)]
 
 
+def _stale_mutants_message(root: Path) -> str | None:
+    """Return the abort message when the stale-mutants preflight should fire.
+
+    Returns ``None`` when the preflight passes through (no ``mutants/``
+    directory at the repository root, or ``MUTANT_UNDER_TEST`` is set).
+
+    Why a separate helper: mutmut copies the audited tree into
+    ``ROOT_DIR / mutants/`` at run start.  Pytest collection over the
+    working tree imports modules from that copy and silently shadows the
+    package under test, producing impossible-to-debug failures.  The
+    abort message names the offending directory and includes the literal
+    ``rm -rf mutants/`` cleanup string so the operator can recover
+    without guessing.
+    """
+    if os.environ.get(_MUTMUT_CHILD_INDICATOR):
+        return None
+    stale_dir = root / _STALE_MUTANTS_DIR_NAME
+    if not stale_dir.exists():
+        return None
+    return (
+        f"Stale mutmut working tree detected at '{_STALE_MUTANTS_DIR_NAME}/' "
+        f"(absolute path: {stale_dir}). "
+        f"Pytest collection imports modules out of that tree and shadows "
+        f"the package under test. "
+        f"Clean it up before re-running: rm -rf mutants/"
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
+    abort_message = _stale_mutants_message(ROOT_DIR)
+    if abort_message is not None:
+        print(abort_message, file=sys.stderr)
+        return STALE_MUTANTS_EXIT_CODE
+
     if importlib.util.find_spec("unittest_parallel") is None:
         print(
             (
@@ -24,7 +73,7 @@ def main(argv: list[str] | None = None) -> int:
             ),
             file=sys.stderr,
         )
-        return 2
+        return MISSING_PARALLEL_RUNNER_EXIT_CODE
 
     command = _build_command(list(argv or sys.argv[1:]))
     return subprocess.run(command, cwd=ROOT_DIR, check=False).returncode

--- a/tests/fixtures/orchestrator_postcondition/expected/asset_exists_ok.json
+++ b/tests/fixtures/orchestrator_postcondition/expected/asset_exists_ok.json
@@ -1,0 +1,14 @@
+{
+  "success": true,
+  "severity": "info",
+  "code": "POST_ASSET_EXISTS_OK",
+  "message": "asset_exists postcondition passed.",
+  "data": {
+    "type": "asset_exists",
+    "resource": null,
+    "path": "<TMP>/Assets/Created.asset",
+    "exists": true,
+    "read_only": true,
+    "executed": true
+  }
+}

--- a/tests/fixtures/orchestrator_postcondition/expected/broken_refs_ok.json
+++ b/tests/fixtures/orchestrator_postcondition/expected/broken_refs_ok.json
@@ -1,0 +1,15 @@
+{
+  "success": true,
+  "severity": "info",
+  "code": "POST_BROKEN_REFS_OK",
+  "message": "broken_refs postcondition passed.",
+  "data": {
+    "type": "broken_refs",
+    "scope": "Assets",
+    "expected_count": 0,
+    "actual_count": 0,
+    "scan_code": "REF_SCAN_OK",
+    "read_only": true,
+    "executed": true
+  }
+}

--- a/tests/test_d3_orchestrator_snapshots.py
+++ b/tests/test_d3_orchestrator_snapshots.py
@@ -295,29 +295,80 @@ class TestPatchOrchestratorSnapshots:
 
 class TestSnapshotRegenerationAnchor:
     """Single anchor row exercising the ``--regenerate-snapshots`` write
-    branch (issue #148 — D3 acceptance).  The regeneration branch must
-    produce a fresh fixture file from the live response payload."""
+    branch (issue #148 — D3 acceptance, issue #162 — CI exercise).  The
+    regeneration branch must produce a fresh fixture file from the live
+    orchestrator payload.
 
-    def test_regeneration_overwrites_anchor_fixture(
-        self, tmp_path: Path
+    Why the test routes through the production ``_assert_snapshot``
+    helper rather than emulating the write in-line: emulating the write
+    bypasses the very branch the test is meant to cover, so a mutation
+    inside the helper's ``regenerate or not fixture_path.exists()``
+    arm would survive the suite.  The anchor here patches
+    ``FIXTURES_ROOT`` onto a temporary directory so the helper's real
+    write executes against a private path without racing the shared
+    snapshot files.
+    """
+
+    def test_regeneration_overwrites_stale_fixture_with_live_payload(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Use a private throwaway fixture path so the test does not race
-        # with the shared snapshot files.
-        anchor_path = tmp_path / "anchor.json"
-        payload = {"code": "INSPECT_VARIANT_RESULT", "severity": "info"}
-        # Pre-write a stale fixture so the regeneration branch's overwrite
-        # behaviour is observable.
-        anchor_path.write_text(json.dumps({"code": "STALE"}), encoding="utf-8")
-
-        # Direct write through the helper would target the shared
-        # FIXTURES_ROOT, so emulate the regeneration branch in-place
-        # against the anchor file.
-        anchor_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
+        # Pre-write a stale fixture under the temporary fixture root so
+        # the regenerate branch's *overwrite* behaviour is observable
+        # (the ``not fixture_path.exists()`` arm is a separate path).
+        sub_dir = "inspect"
+        quadrant = "single"
+        stale_path = tmp_path / sub_dir / f"{quadrant}.json"
+        stale_path.parent.mkdir(parents=True, exist_ok=True)
+        stale_path.write_text(
+            json.dumps({"code": "STALE"}) + "\n", encoding="utf-8"
         )
-        on_disk = json.loads(anchor_path.read_text(encoding="utf-8"))
-        assert on_disk == payload
+
+        monkeypatch.setattr(
+            "tests.test_d3_orchestrator_snapshots.FIXTURES_ROOT", tmp_path
+        )
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = _write_single_override_variant(root)
+            svc = PrefabVariantService(project_root=root)
+            response = inspect_variant(svc, target)
+        live_payload = _stable_inspect_snapshot(response)
+
+        _assert_snapshot(sub_dir, quadrant, live_payload, regenerate=True)
+
+        on_disk = json.loads(stale_path.read_text(encoding="utf-8"))
+        assert on_disk == live_payload, (
+            f"regenerate branch did not overwrite the stale fixture: "
+            f"on_disk={on_disk!r} live_payload={live_payload!r}"
+        )
+
+    def test_regeneration_creates_missing_fixture_with_live_payload(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The ``not fixture_path.exists()`` arm of the helper writes the
+        # fixture even when ``regenerate=False``.  Anchoring this arm
+        # ensures the test runner does not silently fall through to the
+        # equality assertion when a fixture has gone missing.
+        monkeypatch.setattr(
+            "tests.test_d3_orchestrator_snapshots.FIXTURES_ROOT", tmp_path
+        )
+        sub_dir = "wiring"
+        quadrant = "empty"
+        fixture_path = tmp_path / sub_dir / f"{quadrant}.json"
+        assert not fixture_path.exists()
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = _write_empty_project(root)
+            pv_svc = PrefabVariantService(project_root=root)
+            ref_svc = ReferenceResolverService(project_root=root)
+            response = inspect_wiring(pv_svc, ref_svc, target)
+        live_payload = _stable_wiring_snapshot(response)
+
+        _assert_snapshot(sub_dir, quadrant, live_payload, regenerate=False)
+
+        on_disk = json.loads(fixture_path.read_text(encoding="utf-8"))
+        assert on_disk == live_payload
 
 
 if __name__ == "__main__":

--- a/tests/test_default_parameter_boundaries.py
+++ b/tests/test_default_parameter_boundaries.py
@@ -1,0 +1,142 @@
+"""±1 boundary triplets for numeric default parameter values acting as
+caps in the audited package (issue #179).
+
+Audit method (re-runnable by a future surveyor):
+
+    grep -rnE "def .* = [0-9]+" prefab_sentinel/
+
+Filter rule applied to the result set: keep defaults that act as
+truncation caps, size limits, or thresholds; exclude defaults that
+function as flags or sentinel counts.
+
+Discovered set for the current ``prefab_sentinel/`` tree (exactly two
+sites):
+
+* ``prefab_sentinel.services.runtime_validation.classification.classify_errors``
+  — ``max_diagnostics: int = 200`` (truncation cap on the diagnostics
+  list).
+* ``prefab_sentinel.services.reference_resolver.ReferenceResolverService.scan_broken_references``
+  — ``top_guid_limit: int = 10`` (size limit on the
+  ``top_missing_asset_guids`` report).
+
+Per-site triplets:
+
+* Classification cap: for 199 / 200 / 201 input lines the diagnostics
+  length is capped at 200 and ``count_total`` reflects every hit.
+* Top-GUID limit: for 9 / 10 / 11 distinct missing GUIDs the top list
+  length is capped at 10.
+
+Boundary triplets fire ``classify_errors`` and ``scan_broken_references``
+**without an explicit override**, so a mutation that flips the default
+literal (e.g. 200 to 201, or 10 to 9) breaks the equality assertion.
+
+If a future audit surfaces additional default-parameter cap sites, they
+fall under issue #179's follow-up scope rather than this batch.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from prefab_sentinel.services.reference_resolver import ReferenceResolverService
+from prefab_sentinel.services.runtime_validation import RuntimeValidationService
+
+_DEFAULT_CLASSIFICATION_CAP = 200
+_DEFAULT_TOP_GUID_LIMIT = 10
+
+
+class ClassificationDiagnosticCapBoundaryTests(unittest.TestCase):
+    """Triplet for ``classify_errors``'s ``max_diagnostics: int = 200``."""
+
+    def _classify(self, line_count: int):
+        svc = RuntimeValidationService()
+        log_lines = [f"Broken PPtr in file_{n}" for n in range(line_count)]
+        # Intentionally invoked without an explicit ``max_diagnostics``
+        # so the default literal participates in the boundary check.
+        return svc.classify_errors(log_lines)
+
+    def test_input_one_below_cap_does_not_truncate(self) -> None:
+        below = _DEFAULT_CLASSIFICATION_CAP - 1
+        resp = self._classify(below)
+        self.assertEqual(below, resp.data["count_total"])
+        self.assertEqual(below, len(resp.diagnostics))
+        self.assertEqual(below, resp.data["returned_diagnostics"])
+        self.assertEqual(0, resp.data["truncated_diagnostics"])
+
+    def test_input_at_cap_returns_exactly_cap_diagnostics(self) -> None:
+        at = _DEFAULT_CLASSIFICATION_CAP
+        resp = self._classify(at)
+        self.assertEqual(at, resp.data["count_total"])
+        self.assertEqual(at, len(resp.diagnostics))
+        self.assertEqual(at, resp.data["returned_diagnostics"])
+        self.assertEqual(0, resp.data["truncated_diagnostics"])
+
+    def test_input_one_above_cap_truncates_diagnostics(self) -> None:
+        above = _DEFAULT_CLASSIFICATION_CAP + 1
+        resp = self._classify(above)
+        self.assertEqual(above, resp.data["count_total"])
+        self.assertEqual(_DEFAULT_CLASSIFICATION_CAP, len(resp.diagnostics))
+        self.assertEqual(
+            _DEFAULT_CLASSIFICATION_CAP,
+            resp.data["returned_diagnostics"],
+        )
+        self.assertEqual(1, resp.data["truncated_diagnostics"])
+
+
+class TopMissingGuidLimitBoundaryTests(unittest.TestCase):
+    """Triplet for ``scan_broken_references``'s ``top_guid_limit: int = 10``.
+
+    Each missing GUID appears once in a single source asset; the scan
+    reports them via ``top_missing_asset_guids`` ranked by occurrence.
+    """
+
+    def _build_project(self, root: Path, missing_guid_count: int) -> None:
+        (root / "Assets").mkdir(parents=True, exist_ok=True)
+        # Seed one source asset that references ``missing_guid_count``
+        # distinct GUIDs that have no corresponding ``.meta`` file.
+        body_lines = ["%YAML 1.1", "--- !u!114 &11400000", "MonoBehaviour:"]
+        for index in range(missing_guid_count):
+            guid = f"{index:032x}"
+            body_lines.append(
+                f"  m_Ref{index}: {{fileID: 11400000, guid: {guid}, type: 2}}"
+            )
+        (root / "Assets" / "Source.asset").write_text(
+            "\n".join(body_lines) + "\n", encoding="utf-8"
+        )
+        (root / "Assets" / "Source.asset.meta").write_text(
+            "fileFormatVersion: 2\nguid: 9999999999999999999999999999aaaa\n",
+            encoding="utf-8",
+        )
+
+    def _scan(self, missing_guid_count: int):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self._build_project(root, missing_guid_count)
+            svc = ReferenceResolverService(project_root=root)
+            # Intentionally invoked without an explicit
+            # ``top_guid_limit`` so the default literal participates.
+            return svc.scan_broken_references("Assets")
+
+    def test_below_limit_emits_all_distinct_guids(self) -> None:
+        below = _DEFAULT_TOP_GUID_LIMIT - 1
+        response = self._scan(below)
+        self.assertEqual(below, len(response.data["top_missing_asset_guids"]))
+
+    def test_at_limit_emits_exactly_limit_guids(self) -> None:
+        at = _DEFAULT_TOP_GUID_LIMIT
+        response = self._scan(at)
+        self.assertEqual(at, len(response.data["top_missing_asset_guids"]))
+
+    def test_above_limit_truncates_to_limit(self) -> None:
+        above = _DEFAULT_TOP_GUID_LIMIT + 1
+        response = self._scan(above)
+        self.assertEqual(
+            _DEFAULT_TOP_GUID_LIMIT,
+            len(response.data["top_missing_asset_guids"]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mid_tier_assert_strengthening.py
+++ b/tests/test_mid_tier_assert_strengthening.py
@@ -1,0 +1,325 @@
+"""Value-pinned assertions for mid-tier mutmut survived modules (issue #158).
+
+Scope: the six mid-tier survived modules listed below; ``serialized_object``
+modules are explicitly excluded so this file does not overlap with the
+issue #151 coverage file.  Editor-bridge coverage is intentionally
+deferred (Non-Goals §): the dependency on a live Unity Editor places it
+outside unit-test scope.
+
+Modules in scope:
+
+* ``prefab_sentinel.mcp_helpers``
+* ``prefab_sentinel.services.runtime_validation.service``
+* ``prefab_sentinel.material_inspector_variant``
+* ``prefab_sentinel.symbol_tree_builder``  (the ``StructureResult``
+  duplicate-fileID diagnostic surfaced by ``structure_validator``,
+  which is what the symbol-tree walk relies on)
+* ``prefab_sentinel.csharp_fields_resolve``
+* ``prefab_sentinel.smoke_batch_runner``  (filter parsing in
+  ``smoke_batch_case``, shared by the runner)
+
+Modules excluded by this batch:
+
+* ``services.serialized_object.*`` — covered by issue #151.
+* ``editor_bridge`` — Editor-dependent; intentionally deferred.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from prefab_sentinel.mcp_helpers import read_asset, resolve_component_name
+from prefab_sentinel.services.runtime_validation import RuntimeValidationService
+from prefab_sentinel.services.runtime_validation.classification import (
+    assert_no_critical_errors,
+    classify_errors,
+)
+from prefab_sentinel.structure_validator import validate_structure
+from prefab_sentinel.symbol_tree import SymbolKind, SymbolNode
+from prefab_sentinel.unity_yaml_parser import CLASS_ID_MONOBEHAVIOUR
+
+
+class McpHelpersReadAssetTests(unittest.TestCase):
+    """``read_asset`` raises documented exception types with the input path
+    embedded in the message."""
+
+    def test_missing_path_raises_filenotfounderror_with_input_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            # Use an absolute path inside the temp project root so the
+            # containment guard accepts it; ``is_file()`` is False so
+            # ``read_asset`` raises FileNotFoundError.
+            missing_abs = str(root / "Assets" / "Missing.asset")
+            with self.assertRaises(FileNotFoundError) as ctx:
+                read_asset(missing_abs, root)
+            self.assertIn("Missing.asset", str(ctx.exception))
+
+    def test_undecodable_path_raises_unicodedecodeerror(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            target = root / "Assets" / "Bin.asset"
+            target.write_bytes(b"\xff\xfe binary \x80\x90")
+            # ``decode_text_file`` raises UnicodeDecodeError on this
+            # input; ``read_asset`` propagates it without wrapping.
+            with self.assertRaises(UnicodeDecodeError) as ctx:
+                read_asset(str(target), root)
+            # Pin the exception's encoding name so a regression that
+            # swallowed the original exception and re-raised a generic
+            # one would be caught.
+            self.assertEqual("utf-8", ctx.exception.encoding)
+
+
+class McpHelpersResolveComponentNameTests(unittest.TestCase):
+    """``resolve_component_name`` raises with a documented diagnostic
+    message for MonoBehaviours missing ``script_name`` and passes
+    through the type name otherwise."""
+
+    def test_monobehaviour_missing_script_name_raises_value_error(self) -> None:
+        node = SymbolNode(
+            kind=SymbolKind.COMPONENT,
+            name="Component",
+            file_id="11400000",
+            class_id=CLASS_ID_MONOBEHAVIOUR,
+            script_name="",
+        )
+        with self.assertRaises(ValueError) as ctx:
+            resolve_component_name(node)
+        message = str(ctx.exception)
+        self.assertIn("MonoBehaviour", message)
+        self.assertIn("11400000", message)
+        self.assertIn("--project-root", message)
+
+    def test_monobehaviour_with_script_name_returns_script_name(self) -> None:
+        node = SymbolNode(
+            kind=SymbolKind.COMPONENT,
+            name="Component",
+            file_id="11400000",
+            class_id=CLASS_ID_MONOBEHAVIOUR,
+            script_name="MyController",
+        )
+        self.assertEqual("MyController", resolve_component_name(node))
+
+    def test_non_monobehaviour_passes_node_name_through(self) -> None:
+        # A Transform component (class_id "4") returns the node name
+        # rather than the script_name (which is empty for builtin types).
+        node = SymbolNode(
+            kind=SymbolKind.COMPONENT,
+            name="Transform",
+            file_id="11400000",
+            class_id="4",
+        )
+        self.assertEqual("Transform", resolve_component_name(node))
+
+
+class RuntimeValidationServiceWrapperPassthroughTests(unittest.TestCase):
+    """The service-level ``classify_errors`` and ``assert_no_critical_errors``
+    delegate to the pure functions; the wrapper output equals the pure
+    function output by full equality (including data payload and
+    severity)."""
+
+    def test_classify_errors_wrapper_equals_pure_function(self) -> None:
+        svc = RuntimeValidationService()
+        log_lines = [
+            "Broken PPtr in file Foo",
+            "NullReferenceException in UdonBehaviour.X",
+        ]
+        wrapped = svc.classify_errors(log_lines)
+        pure = classify_errors(log_lines)
+        self.assertEqual(pure.code, wrapped.code)
+        self.assertEqual(pure.severity, wrapped.severity)
+        self.assertEqual(pure.success, wrapped.success)
+        self.assertEqual(pure.message, wrapped.message)
+        self.assertEqual(pure.data, wrapped.data)
+
+    def test_assert_no_critical_errors_wrapper_equals_pure_function(self) -> None:
+        svc = RuntimeValidationService()
+        classification = svc.classify_errors(
+            ["NullReferenceException in UdonBehaviour.X"]
+        )
+        wrapped = svc.assert_no_critical_errors(classification)
+        pure = assert_no_critical_errors(classification)
+        self.assertEqual(pure.code, wrapped.code)
+        self.assertEqual(pure.severity, wrapped.severity)
+        self.assertEqual(pure.success, wrapped.success)
+        self.assertEqual(pure.data, wrapped.data)
+
+
+class MaterialInspectorVariantParserTests(unittest.TestCase):
+    """``_iter_modifications`` produces documented per-slot mappings.
+    A multi-block YAML carrying material slot overrides plus an inherited
+    slot proves the parser distinguishes overridden vs inherited."""
+
+    def test_iter_modifications_pins_per_slot_mapping(self) -> None:
+        from prefab_sentinel.material_inspector_variant import (  # noqa: PLC0415
+            _iter_modifications,
+            _parse_material_overrides,
+        )
+
+        text = (
+            "%YAML 1.1\n"
+            "--- !u!1001 &123\n"
+            "PrefabInstance:\n"
+            "  m_Modification:\n"
+            "    m_Modifications:\n"
+            "    - target: {fileID: 100100000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n"
+            "      propertyPath: m_Materials.Array.data[0]\n"
+            "      value:\n"
+            "      objectReference: {fileID: 21300000, guid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, type: 2}\n"
+            "    - target: {fileID: 100100000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n"
+            "      propertyPath: m_Name\n"
+            "      value: Renamed\n"
+            "      objectReference: {fileID: 0}\n"
+        )
+
+        entries = _iter_modifications(text)
+        self.assertEqual(2, len(entries))
+        slot_entry = next(
+            e for e in entries if e.property_path.startswith("m_Materials.")
+        )
+        self.assertEqual("100100000", slot_entry.target_file_id)
+        self.assertEqual(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            slot_entry.object_reference_guid,
+        )
+
+        # ``_parse_material_overrides`` populates the (target, slot) map
+        # only for entries whose path matches the slot pattern; the
+        # ``m_Name`` entry must be skipped (inherited slot semantics).
+        overrides: dict[tuple[str, int], str] = {}
+        _parse_material_overrides(text, overrides)
+        self.assertEqual(
+            {
+                ("100100000", 0): "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            },
+            overrides,
+        )
+
+
+class StructureValidatorDuplicateFileIdTests(unittest.TestCase):
+    """``validate_structure`` reports duplicate fileIDs with the
+    documented diagnostic shape (path / location / detail / evidence)."""
+
+    def test_duplicate_file_id_emits_documented_diagnostic(self) -> None:
+        text = (
+            "--- !u!1 &100100000\nGameObject:\n  m_Name: A\n"
+            "--- !u!1 &100100000\nGameObject:\n  m_Name: B\n"
+        )
+        result = validate_structure(text, "Assets/Foo.prefab")
+        self.assertEqual(1, len(result.duplicate_file_ids))
+        diag = result.duplicate_file_ids[0]
+        self.assertEqual("Assets/Foo.prefab", diag.path)
+        self.assertEqual("fileID:100100000", diag.location)
+        self.assertIn("Duplicate fileID", diag.detail)
+        self.assertIn("100100000", diag.detail)
+        self.assertEqual("{fileID: 100100000}", diag.evidence)
+
+    def test_unique_file_ids_emit_no_duplicate_diagnostic(self) -> None:
+        text = (
+            "--- !u!1 &100100000\nGameObject:\n  m_Name: A\n"
+            "--- !u!1 &100100001\nGameObject:\n  m_Name: B\n"
+        )
+        result = validate_structure(text, "Assets/Foo.prefab")
+        self.assertEqual([], result.duplicate_file_ids)
+
+
+class CSharpFieldsInheritanceTests(unittest.TestCase):
+    """``resolve_inherited_fields`` returns a unioned field set with
+    ``source_class`` set per origin class (base before derived)."""
+
+    def test_inheritance_union_pins_source_class_per_field(self) -> None:
+        from prefab_sentinel.csharp_fields_resolve import (  # noqa: PLC0415
+            resolve_inherited_fields,
+        )
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            base_cs = root / "Assets" / "Base.cs"
+            base_cs.write_text(
+                "using UnityEngine;\n"
+                "public class Base : MonoBehaviour {\n"
+                "    [SerializeField] private int baseField = 0;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            (root / "Assets" / "Base.cs.meta").write_text(
+                "fileFormatVersion: 2\nguid: 1111111111111111111111111111aaaa\n",
+                encoding="utf-8",
+            )
+            derived_cs = root / "Assets" / "Derived.cs"
+            derived_cs.write_text(
+                "using UnityEngine;\n"
+                "public class Derived : Base {\n"
+                "    [SerializeField] private int derivedField = 0;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            (root / "Assets" / "Derived.cs.meta").write_text(
+                "fileFormatVersion: 2\nguid: 2222222222222222222222222222bbbb\n",
+                encoding="utf-8",
+            )
+            (root / "Assets").mkdir(exist_ok=True)
+
+            fields = resolve_inherited_fields(
+                "2222222222222222222222222222bbbb",
+                project_root=root,
+            )
+
+        names = [(f.name, f.source_class) for f in fields]
+        self.assertIn(("baseField", "Base"), names)
+        self.assertIn(("derivedField", "Derived"), names)
+        # Base fields appear before derived fields in the result.
+        base_index = names.index(("baseField", "Base"))
+        derived_index = names.index(("derivedField", "Derived"))
+        self.assertLess(base_index, derived_index)
+
+
+class SmokeBatchTargetFilterParsingTests(unittest.TestCase):
+    """``_resolve_targets`` parses each documented filter expression."""
+
+    def test_all_expands_to_avatar_then_world(self) -> None:
+        from prefab_sentinel.smoke_batch_case import _resolve_targets  # noqa: PLC0415
+
+        self.assertEqual(["avatar", "world"], _resolve_targets(["all"]))
+
+    def test_explicit_targets_pass_through_in_order(self) -> None:
+        from prefab_sentinel.smoke_batch_case import _resolve_targets  # noqa: PLC0415
+
+        self.assertEqual(["avatar"], _resolve_targets(["avatar"]))
+        self.assertEqual(["world"], _resolve_targets(["world"]))
+        self.assertEqual(
+            ["world", "avatar"], _resolve_targets(["world", "avatar"])
+        )
+
+    def test_duplicate_targets_collapse_with_first_occurrence_winning(
+        self,
+    ) -> None:
+        from prefab_sentinel.smoke_batch_case import _resolve_targets  # noqa: PLC0415
+
+        self.assertEqual(
+            ["avatar", "world"],
+            _resolve_targets(["avatar", "world", "avatar"]),
+        )
+
+    def test_all_followed_by_explicit_does_not_re_add(self) -> None:
+        from prefab_sentinel.smoke_batch_case import _resolve_targets  # noqa: PLC0415
+
+        # ``all`` expands to ``[avatar, world]``; subsequent ``avatar``
+        # is deduped.
+        self.assertEqual(
+            ["avatar", "world"],
+            _resolve_targets(["all", "avatar"]),
+        )
+
+    def test_empty_list_returns_empty(self) -> None:
+        from prefab_sentinel.smoke_batch_case import _resolve_targets  # noqa: PLC0415
+
+        self.assertEqual([], _resolve_targets([]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mutmut_config.py
+++ b/tests/test_mutmut_config.py
@@ -27,9 +27,11 @@ the operational contract documented in ``README.md`` §14.5:
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import tomllib
 import unittest
 from pathlib import Path
@@ -98,6 +100,29 @@ class MutmutConfigShapeTests(unittest.TestCase):
             f"missing triple-single-quote pattern: {patterns}",
         )
 
+    def test_do_not_mutate_extends_with_documented_equivalent_patterns(
+        self,
+    ) -> None:
+        """Issue #182 — three documented equivalent-mutation patterns
+        appear verbatim in ``[tool.mutmut].do_not_mutate``.  The patterns
+        target internal cache state in ``ReferenceResolverService`` whose
+        mutations are semantically equivalent (cache hit/miss skip,
+        guid-index re-read, cache invalidation) and would not strengthen
+        the suite if mutated.
+        """
+        section = _load_mutmut_section()
+        patterns = section["do_not_mutate"]
+        for required in (
+            "*_text_cache.get*",
+            "*_guid_map*",
+            "*invalidate_*_cache*",
+        ):
+            self.assertIn(
+                required,
+                patterns,
+                f"missing equivalent-mutation pattern '{required}': {patterns}",
+            )
+
     def test_pytest_selection_uses_single_marker_filter(self) -> None:
         # The selection list must consist of the test root, a ``-m``
         # flag, and the marker expression — exactly three entries — and
@@ -154,6 +179,34 @@ class MutmutConfigShapeTests(unittest.TestCase):
 
 
 class MutmutSanityInvocationTests(unittest.TestCase):
+    """Per-module mutmut sanity invocation against ``contracts.py``.
+
+    The test calls ``mutmut run`` on the smallest audited leaf module
+    and asserts that none of the four documented historical regression
+    strings (issue #165) appears in the combined stdout/stderr capture.
+
+    Skip conditions (issue #144 — these are the conditions a developer
+    reading a ``pytest --skipped`` summary can map back here without
+    opening the test body):
+
+    1. **Stale ``mutants/`` directory present at the repository root.**
+       When the working tree already contains a ``mutants/`` artifact
+       tree, a mutmut session is in progress (or was abandoned without
+       cleanup) and re-entering ``mutmut run`` here would tangle with
+       it.  The recovery is ``rm -rf mutants/`` from the repository
+       root.
+    2. **Upstream ``multiprocessing.set_start_method('fork')`` double-call
+       ``RuntimeError`` is detected** in the combined output.  This
+       indicates the mutmut runtime hit the upstream double-init bug
+       (``context has already been set``); the failure is unrelated to
+       the regression strings the test pins.
+    3. **The ``mutmut`` binary is unavailable on PATH.**  In that case
+       the configuration-shape assertions in
+       :class:`MutmutConfigShapeTests` already cover the static surface
+       of ``[tool.mutmut]``; the per-module sanity invocation has no
+       runtime to drive.
+    """
+
     # Four documented historical regression strings (issue #165):
     # * ``MUTANT_UNDER_TEST`` — the missing-state-variable identifier
     #   that mutmut's runtime raises when the test environment is not
@@ -257,6 +310,111 @@ class MutmutSanityInvocationTests(unittest.TestCase):
                 combined.lower(),
                 f"mutmut output surfaced a documented regression string '{needle}': {combined}",
             )
+
+
+class MutmutSanityDocstringTests(unittest.TestCase):
+    """Issue #144 — the sanity test class's docstring enumerates each
+    documented skip condition so a developer reading a
+    ``pytest --skipped`` summary can locate the cause without reading
+    the test body.
+    """
+
+    def test_class_docstring_lists_three_skip_conditions(self) -> None:
+        docstring = MutmutSanityInvocationTests.__doc__ or ""
+        # Skip condition 1: stale ``mutants/`` directory at repo root.
+        self.assertIn("mutants/", docstring)
+        self.assertRegex(
+            docstring,
+            r"(?is)stale.*mutants.*(repository|repo).*root",
+        )
+        # Skip condition 2: upstream multiprocessing double-call.
+        self.assertIn("set_start_method", docstring)
+        self.assertIn("fork", docstring)
+        self.assertIn("RuntimeError", docstring)
+        # Skip condition 3: mutmut binary unavailable on PATH.
+        self.assertRegex(docstring, r"(?is)mutmut.*PATH")
+        # Cleanup string: literal recovery instruction.
+        self.assertIn("rm -rf mutants/", docstring)
+
+
+class RunUnitTestsStaleMutantsPreflightTests(unittest.TestCase):
+    """Issue #174 — ``scripts/run_unit_tests.py`` aborts with a distinct
+    exit code when a stale ``mutants/`` directory is present at the
+    repository root and the mutmut child indicator is unset; passes
+    through to the parallel-runner dispatch when the indicator is set.
+    """
+
+    _STALE_MUTANTS_EXIT_CODE = 3
+    _MISSING_RUNNER_EXIT_CODE = 2
+
+    def _import_entrypoint(self):
+        from scripts import run_unit_tests  # noqa: PLC0415
+
+        return run_unit_tests
+
+    def test_stale_mutants_directory_aborts_runner(self) -> None:
+        from unittest import mock  # noqa: PLC0415
+
+        run_unit_tests = self._import_entrypoint()
+        captured_stderr: list[str] = []
+
+        def fake_print(*args: object, **kwargs: object) -> None:
+            captured_stderr.append(" ".join(str(arg) for arg in args))
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "mutants").mkdir()
+            (root / "tests").mkdir()
+            with (
+                mock.patch.dict(os.environ, {}, clear=False),
+                mock.patch.object(run_unit_tests, "ROOT_DIR", root),
+                mock.patch.object(run_unit_tests, "print", fake_print),
+            ):
+                os.environ.pop("MUTANT_UNDER_TEST", None)
+                rc = run_unit_tests.main([])
+        self.assertEqual(self._STALE_MUTANTS_EXIT_CODE, rc)
+        self.assertNotEqual(self._MISSING_RUNNER_EXIT_CODE, rc)
+        self.assertNotEqual(0, rc)
+        self.assertNotEqual(1, rc)
+        joined = "\n".join(captured_stderr)
+        self.assertIn("mutants", joined)
+        self.assertIn("rm -rf mutants/", joined)
+
+    def test_mutmut_child_indicator_allows_runner_passthrough(self) -> None:
+        from unittest import mock  # noqa: PLC0415
+
+        run_unit_tests = self._import_entrypoint()
+        sentinel_returncode = 17
+
+        class _FakeCompletedProcess:
+            returncode = sentinel_returncode
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "mutants").mkdir()
+            (root / "tests").mkdir()
+            with (
+                mock.patch.dict(
+                    os.environ, {"MUTANT_UNDER_TEST": "yes"}, clear=False
+                ),
+                mock.patch.object(run_unit_tests, "ROOT_DIR", root),
+                # ``find_spec`` returns ``None`` when ``unittest_parallel`` is
+                # not installed.  The passthrough path under test runs *after*
+                # that guard, so the test must short-circuit it with a truthy
+                # spec object before reaching the mocked subprocess dispatch.
+                mock.patch.object(
+                    run_unit_tests.importlib.util,
+                    "find_spec",
+                    return_value=object(),
+                ),
+                mock.patch.object(
+                    run_unit_tests.subprocess,
+                    "run",
+                    return_value=_FakeCompletedProcess(),
+                ),
+            ):
+                rc = run_unit_tests.main([])
+        self.assertEqual(sentinel_returncode, rc)
 
 
 if __name__ == "__main__":

--- a/tests/test_mutmut_score_report.py
+++ b/tests/test_mutmut_score_report.py
@@ -1,0 +1,339 @@
+"""Tests for ``scripts/mutmut_score_report.py`` (issue #169).
+
+The parser is the unit-testable seam (string-in / record-out); the
+formatter rows pin Markdown, CSV, and JSON shapes; the audited-only
+and ``--module`` filter rows pin the restriction logic; the
+subprocess-failure row pins the distinct exit code (``4``) and stderr
+passthrough.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+# Make ``scripts/mutmut_score_report.py`` importable as
+# ``mutmut_score_report`` from the test process.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import mutmut_score_report  # noqa: E402
+
+
+def _parse_records_from_json(
+    text: str,
+) -> dict[str, mutmut_score_report.ModuleRecord]:
+    """Reverse of :func:`mutmut_score_report.format_json` for round-trip tests.
+
+    The production script does not need this inverse; it lives here so
+    the JSON formatter test can assert structural fidelity without
+    polluting the script's public surface.
+    """
+    payload = json.loads(text)
+    records: dict[str, mutmut_score_report.ModuleRecord] = {}
+    for entry in payload["records"]:
+        records[entry["module"]] = mutmut_score_report.ModuleRecord(
+            module=entry["module"],
+            killed=entry["killed"],
+            survived=entry["survived"],
+            timeout=entry["timeout"],
+            not_checked=entry["not_checked"],
+        )
+    return records
+
+
+_SAMPLE_MULTI_MODULE_RESULTS = """\
+prefab_sentinel.services.reference_resolver.xǁReferenceResolverServiceǁread_text__mutmut_1: killed
+prefab_sentinel.services.reference_resolver.xǁReferenceResolverServiceǁread_text__mutmut_2: survived
+prefab_sentinel.services.reference_resolver.xǁReferenceResolverServiceǁread_text__mutmut_3: timeout
+prefab_sentinel.services.reference_resolver.xǁReferenceResolverServiceǁread_text__mutmut_4: not_checked
+prefab_sentinel.services.prefab_variant.overrides.parse_overrides__mutmut_1: killed
+prefab_sentinel.services.prefab_variant.overrides.parse_overrides__mutmut_2: killed
+prefab_sentinel.services.prefab_variant.overrides.parse_overrides__mutmut_3: survived
+prefab_sentinel.orchestrator_postcondition._validate_postcondition_schema__mutmut_1: killed
+"""
+
+
+class MutmutResultsParserTests(unittest.TestCase):
+    """Pure parser rows: string in, record out."""
+
+    def test_multi_module_input_produces_per_module_record(self) -> None:
+        records = mutmut_score_report.parse_mutmut_results(
+            _SAMPLE_MULTI_MODULE_RESULTS
+        )
+        self.assertIn(
+            "prefab_sentinel.services.reference_resolver", records
+        )
+        self.assertIn(
+            "prefab_sentinel.services.prefab_variant.overrides", records
+        )
+        self.assertIn(
+            "prefab_sentinel.orchestrator_postcondition", records
+        )
+        ref = records["prefab_sentinel.services.reference_resolver"]
+        self.assertEqual(1, ref.killed)
+        self.assertEqual(1, ref.survived)
+        self.assertEqual(1, ref.timeout)
+        self.assertEqual(1, ref.not_checked)
+        self.assertEqual(3, ref.total)  # not_checked excluded from denominator
+        # killed (1) + timeout (1) over total (3) = 66.6...%
+        self.assertAlmostEqual(2 / 3 * 100.0, ref.score, places=2)
+        variant = records[
+            "prefab_sentinel.services.prefab_variant.overrides"
+        ]
+        self.assertEqual(2, variant.killed)
+        self.assertEqual(1, variant.survived)
+        self.assertEqual(0, variant.timeout)
+
+    def test_empty_input_returns_empty_record(self) -> None:
+        self.assertEqual(
+            {}, mutmut_score_report.parse_mutmut_results("")
+        )
+
+    def test_malformed_lines_are_skipped_silently(self) -> None:
+        text = (
+            "garbage line\n"
+            "another nonsense\n"
+            "prefab_sentinel.services.reference_resolver.xǁRǁread__mutmut_1: killed\n"
+            "incomplete:\n"
+            ": killed\n"
+        )
+        records = mutmut_score_report.parse_mutmut_results(text)
+        self.assertEqual(1, len(records))
+        self.assertEqual(
+            1,
+            records[
+                "prefab_sentinel.services.reference_resolver"
+            ].killed,
+        )
+
+    def test_module_filter_restricts_to_named_module(self) -> None:
+        records = mutmut_score_report.parse_mutmut_results(
+            _SAMPLE_MULTI_MODULE_RESULTS,
+            module_filter="prefab_sentinel.orchestrator_postcondition",
+        )
+        self.assertEqual(
+            ["prefab_sentinel.orchestrator_postcondition"],
+            list(records.keys()),
+        )
+
+
+class MutmutResultsFormatterTests(unittest.TestCase):
+    """Markdown / CSV / JSON formatter pins."""
+
+    def _records(self) -> dict[str, mutmut_score_report.ModuleRecord]:
+        return mutmut_score_report.parse_mutmut_results(
+            _SAMPLE_MULTI_MODULE_RESULTS
+        )
+
+    def test_markdown_table_renders_one_header_and_one_row_per_module(self) -> None:
+        text = mutmut_score_report.format_markdown(self._records())
+        lines = text.strip().splitlines()
+        # 1 header + 1 separator + 3 data rows
+        self.assertEqual(5, len(lines))
+        self.assertTrue(lines[0].startswith("| module |"))
+        self.assertTrue(lines[1].startswith("|---|"))
+        # Score column matches derived value to one decimal place.
+        ref_row = next(
+            line
+            for line in lines
+            if "reference_resolver" in line
+        )
+        self.assertIn("66.7%", ref_row)
+
+    def test_csv_format_carries_run_metadata_and_columns(self) -> None:
+        metadata = mutmut_score_report.RunMetadata(
+            run_date="2026-05-05",
+            mutmut_version="3.5.0",
+            parallelism="180",
+        )
+        text = mutmut_score_report.format_csv(self._records(), metadata)
+        lines = text.strip().splitlines()
+        header = lines[0].split(",")
+        for column in (
+            "run_date",
+            "mutmut_version",
+            "parallelism",
+            "module",
+            "killed",
+            "survived",
+            "timeout",
+            "not_checked",
+            "total",
+            "score",
+        ):
+            self.assertIn(column, header)
+        for data_line in lines[1:]:
+            self.assertIn("2026-05-05", data_line)
+            self.assertIn("3.5.0", data_line)
+            self.assertIn("180", data_line)
+
+    def test_json_round_trips_through_parse_records_from_json(self) -> None:
+        records = self._records()
+        text = mutmut_score_report.format_json(records)
+        round_tripped = _parse_records_from_json(text)
+        self.assertEqual(set(records.keys()), set(round_tripped.keys()))
+        for module, record in records.items():
+            other = round_tripped[module]
+            self.assertEqual(record.killed, other.killed)
+            self.assertEqual(record.survived, other.survived)
+            self.assertEqual(record.timeout, other.timeout)
+            self.assertEqual(record.not_checked, other.not_checked)
+
+
+class MutmutResultsAuditedFilterTests(unittest.TestCase):
+    """``filter_audited`` restricts the record set to README §14.5."""
+
+    def test_audited_only_filter_restricts_to_audited_module_list(self) -> None:
+        # The sample contains an off-list module added solely to test
+        # the filter (a fictional ``prefab_sentinel.unrelated``).
+        text = (
+            _SAMPLE_MULTI_MODULE_RESULTS
+            + "prefab_sentinel.unrelated.module.func__mutmut_1: killed\n"
+        )
+        records = mutmut_score_report.parse_mutmut_results(text)
+        filtered = mutmut_score_report.filter_audited(records)
+        for module in filtered:
+            self.assertTrue(
+                any(
+                    module == name or module.startswith(name + ".")
+                    for name in mutmut_score_report.AUDITED_MODULES
+                ),
+                f"module {module!r} leaked through the audited filter",
+            )
+        self.assertNotIn(
+            "prefab_sentinel.unrelated.module", filtered
+        )
+
+
+class MutmutResultsSubprocessFailureTests(unittest.TestCase):
+    """Subprocess-failure row: distinct exit code and stderr passthrough."""
+
+    def test_non_zero_subprocess_returncode_yields_distinct_exit_code(
+        self,
+    ) -> None:
+        outcome = mutmut_score_report.SubprocessOutcome(
+            returncode=2,
+            stdout="",
+            stderr="mutmut: fatal error reading working tree\n",
+        )
+        captured_stderr = io.StringIO()
+        with (
+            mock.patch.object(
+                mutmut_score_report,
+                "run_mutmut_results",
+                return_value=outcome,
+            ),
+            redirect_stderr(captured_stderr),
+        ):
+            rc = mutmut_score_report.main(["--format", "markdown"])
+        self.assertEqual(
+            mutmut_score_report.MUTMUT_SUBPROCESS_FAILURE_EXIT_CODE, rc
+        )
+        # Distinct from zero, from the test-failure code (1), and from
+        # the missing-runner code (2) used elsewhere.
+        self.assertNotEqual(0, rc)
+        self.assertNotEqual(1, rc)
+        self.assertNotEqual(2, rc)
+        self.assertIn(
+            "mutmut: fatal error reading working tree",
+            captured_stderr.getvalue(),
+        )
+
+    def test_empty_parse_yields_zero_exit_with_empty_table(self) -> None:
+        outcome = mutmut_score_report.SubprocessOutcome(
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        captured_stdout = io.StringIO()
+        with (
+            mock.patch.object(
+                mutmut_score_report,
+                "run_mutmut_results",
+                return_value=outcome,
+            ),
+            redirect_stdout(captured_stdout),
+        ):
+            rc = mutmut_score_report.main(["--format", "markdown"])
+        self.assertEqual(0, rc)
+        self.assertIn("| module |", captured_stdout.getvalue())
+
+
+class MutmutResultsCliEndToEndTests(unittest.TestCase):
+    """End-to-end CLI rows for ``--module`` and ``--audited-only``."""
+
+    def test_cli_module_filter_emits_only_named_module(self) -> None:
+        outcome = mutmut_score_report.SubprocessOutcome(
+            returncode=0,
+            stdout=_SAMPLE_MULTI_MODULE_RESULTS,
+            stderr="",
+        )
+        captured = io.StringIO()
+        with (
+            mock.patch.object(
+                mutmut_score_report,
+                "run_mutmut_results",
+                return_value=outcome,
+            ),
+            redirect_stdout(captured),
+        ):
+            rc = mutmut_score_report.main(
+                [
+                    "--module",
+                    "prefab_sentinel.orchestrator_postcondition",
+                    "--format",
+                    "json",
+                ]
+            )
+        self.assertEqual(0, rc)
+        payload = json.loads(captured.getvalue())
+        self.assertEqual(1, len(payload["records"]))
+        self.assertEqual(
+            "prefab_sentinel.orchestrator_postcondition",
+            payload["records"][0]["module"],
+        )
+
+    def test_cli_audited_only_strips_off_list_modules(self) -> None:
+        text = (
+            _SAMPLE_MULTI_MODULE_RESULTS
+            + "prefab_sentinel.unrelated.module.func__mutmut_1: killed\n"
+        )
+        outcome = mutmut_score_report.SubprocessOutcome(
+            returncode=0,
+            stdout=text,
+            stderr="",
+        )
+        captured = io.StringIO()
+        with (
+            mock.patch.object(
+                mutmut_score_report,
+                "run_mutmut_results",
+                return_value=outcome,
+            ),
+            redirect_stdout(captured),
+        ):
+            rc = mutmut_score_report.main(
+                ["--audited-only", "--format", "json"]
+            )
+        self.assertEqual(0, rc)
+        payload = json.loads(captured.getvalue())
+        modules = [entry["module"] for entry in payload["records"]]
+        self.assertNotIn("prefab_sentinel.unrelated.module", modules)
+        for module in modules:
+            self.assertTrue(
+                any(
+                    module == name or module.startswith(name + ".")
+                    for name in mutmut_score_report.AUDITED_MODULES
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orchestrator_postcondition.py
+++ b/tests/test_orchestrator_postcondition.py
@@ -1,0 +1,627 @@
+"""Direct tests for ``prefab_sentinel.orchestrator_postcondition`` (issue #168).
+
+The module exposes two underscored functions consumed cross-module by the
+orchestrator and the patch orchestrator:
+
+* ``_validate_postcondition_schema(postcondition, *, resource_ids)`` —
+  shape-only validation; never evaluates resources.
+* ``_evaluate_postcondition(serialized_object, reference_resolver,
+  postcondition, *, resource_map)`` — evaluates an asset-exists or
+  broken-refs postcondition against the live services.
+
+The tests pin every documented schema-error and evaluation envelope by
+code, severity, and full-payload equality.  Two snapshot anchors guard
+the success-shape envelopes against drift.
+
+Mocking model: the asset-exists rows mock ``SerializedObjectService``'s
+target-path resolver via ``unittest.mock.patch.object``; the
+broken-refs rows mock ``ReferenceResolverService.scan_broken_references``
+the same way.  The schema rows call ``_validate_postcondition_schema``
+directly with no service objects.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from prefab_sentinel.contracts import (
+    Diagnostic,
+    Severity,
+    ToolResponse,
+    error_response,
+    success_response,
+)
+from prefab_sentinel.orchestrator_postcondition import (
+    _evaluate_postcondition,
+    _validate_postcondition_schema,
+)
+from prefab_sentinel.services.reference_resolver import ReferenceResolverService
+from prefab_sentinel.services.serialized_object import SerializedObjectService
+from tests._assertion_helpers import assert_error_envelope
+
+_FIXTURE_ROOT = (
+    Path(__file__).parent / "fixtures" / "orchestrator_postcondition" / "expected"
+)
+
+
+def _read_only_executed_false(extra: dict | None = None) -> dict:
+    """Common envelope-data shape for schema-error rows."""
+    payload = {"read_only": True, "executed": False}
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _make_services(
+    root: Path,
+) -> tuple[SerializedObjectService, ReferenceResolverService]:
+    """Construct the two services rooted at *root* for evaluation rows."""
+    return (
+        SerializedObjectService(project_root=root),
+        ReferenceResolverService(project_root=root),
+    )
+
+
+class PostconditionSchemaErrorRowsTests(unittest.TestCase):
+    """Schema-error envelopes pinned by code, severity, and full
+    data-payload equality.  Each row corresponds to one documented
+    invalid-input condition in the spec's Error Handling §Postcondition.
+    """
+
+    def test_postcondition_not_object_returns_post_schema_error(self) -> None:
+        response = _validate_postcondition_schema("not-a-dict", resource_ids=set())
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(),
+        )
+
+    def test_missing_type_returns_post_schema_error(self) -> None:
+        response = _validate_postcondition_schema({}, resource_ids=set())
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(),
+        )
+
+    def test_asset_exists_with_both_resource_and_path_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "asset_exists", "resource": "r1", "path": "Assets/Foo"},
+            resource_ids={"r1"},
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false({"type": "asset_exists"}),
+        )
+
+    def test_asset_exists_with_neither_resource_nor_path_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "asset_exists"}, resource_ids=set()
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false({"type": "asset_exists"}),
+        )
+
+    def test_asset_exists_unknown_resource_returns_post_schema_error(self) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "asset_exists", "resource": "unknown"},
+            resource_ids={"r1"},
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "asset_exists", "resource": "unknown"}
+            ),
+        )
+
+    def test_broken_refs_missing_scope_returns_post_schema_error(self) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "broken_refs"}, resource_ids=set()
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false({"type": "broken_refs"}),
+        )
+
+    def test_broken_refs_negative_expected_count_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "broken_refs", "scope": "Assets", "expected_count": -1},
+            resource_ids=set(),
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "broken_refs", "scope": "Assets"}
+            ),
+        )
+
+    def test_broken_refs_non_integer_expected_count_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "broken_refs", "scope": "Assets", "expected_count": "many"},
+            resource_ids=set(),
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "broken_refs", "scope": "Assets"}
+            ),
+        )
+
+    def test_broken_refs_non_list_exclude_patterns_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "exclude_patterns": "not-a-list",
+            },
+            resource_ids=set(),
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "broken_refs", "scope": "Assets"}
+            ),
+        )
+
+    def test_broken_refs_non_string_exclude_pattern_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "exclude_patterns": ["valid", 7],
+            },
+            resource_ids=set(),
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "broken_refs", "scope": "Assets"}
+            ),
+        )
+
+    def test_broken_refs_non_list_ignore_asset_guids_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "ignore_asset_guids": "not-a-list",
+            },
+            resource_ids=set(),
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "broken_refs", "scope": "Assets"}
+            ),
+        )
+
+    def test_broken_refs_non_string_ignore_asset_guid_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "ignore_asset_guids": ["good", 9],
+            },
+            resource_ids=set(),
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "broken_refs", "scope": "Assets"}
+            ),
+        )
+
+    def test_broken_refs_negative_max_diagnostics_returns_post_schema_error(
+        self,
+    ) -> None:
+        response = _validate_postcondition_schema(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "max_diagnostics": -5,
+            },
+            resource_ids=set(),
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false(
+                {"type": "broken_refs", "scope": "Assets"}
+            ),
+        )
+
+    def test_unknown_postcondition_type_returns_post_schema_error(self) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "WhoKnows"}, resource_ids=set()
+        )
+        assert_error_envelope(
+            response,
+            code="POST_SCHEMA_ERROR",
+            severity="error",
+            data=_read_only_executed_false({"type": "WhoKnows"}),
+        )
+
+
+class PostconditionSchemaSuccessRowsTests(unittest.TestCase):
+    """Schema-OK envelopes for the documented success scenarios."""
+
+    def test_asset_exists_by_resource_returns_post_schema_ok(self) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "asset_exists", "resource": "r1"},
+            resource_ids={"r1"},
+        )
+        self.assertTrue(response.success)
+        self.assertEqual("POST_SCHEMA_OK", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {"type": "asset_exists", "read_only": True, "executed": False},
+            response.data,
+        )
+
+    def test_asset_exists_by_path_returns_post_schema_ok(self) -> None:
+        response = _validate_postcondition_schema(
+            {"type": "asset_exists", "path": "Assets/Foo"},
+            resource_ids=set(),
+        )
+        self.assertTrue(response.success)
+        self.assertEqual("POST_SCHEMA_OK", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {"type": "asset_exists", "read_only": True, "executed": False},
+            response.data,
+        )
+
+    def test_broken_refs_returns_post_schema_ok(self) -> None:
+        response = _validate_postcondition_schema(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "expected_count": 0,
+            },
+            resource_ids=set(),
+        )
+        self.assertTrue(response.success)
+        self.assertEqual("POST_SCHEMA_OK", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "read_only": True,
+                "executed": False,
+            },
+            response.data,
+        )
+
+
+class PostconditionEvaluateAssetExistsTests(unittest.TestCase):
+    """``_evaluate_postcondition`` ``asset_exists`` evaluation rows.
+    The serialized-object service's path resolver is mocked at the
+    module's import site so the test does not require a live project
+    tree.
+    """
+
+    def test_asset_exists_pass_returns_post_asset_exists_ok(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            present = root / "Assets" / "Created.asset"
+            present.write_text("body\n", encoding="utf-8")
+            so_svc, ref_svc = _make_services(root)
+            with mock.patch.object(
+                SerializedObjectService,
+                "_resolve_target_path",
+                return_value=present,
+            ):
+                response = _evaluate_postcondition(
+                    so_svc,
+                    ref_svc,
+                    {"type": "asset_exists", "path": "Assets/Created.asset"},
+                    resource_map={},
+                )
+        self.assertTrue(response.success)
+        self.assertEqual("POST_ASSET_EXISTS_OK", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {
+                "type": "asset_exists",
+                "resource": None,
+                "path": str(present),
+                "exists": True,
+                "read_only": True,
+                "executed": True,
+            },
+            response.data,
+        )
+
+    def test_asset_exists_fail_returns_post_asset_exists_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            absent = root / "Assets" / "NeverCreated.asset"
+            so_svc, ref_svc = _make_services(root)
+            with mock.patch.object(
+                SerializedObjectService,
+                "_resolve_target_path",
+                return_value=absent,
+            ):
+                response = _evaluate_postcondition(
+                    so_svc,
+                    ref_svc,
+                    {"type": "asset_exists", "path": "Assets/NeverCreated.asset"},
+                    resource_map={},
+                )
+        assert_error_envelope(
+            response,
+            code="POST_ASSET_EXISTS_FAILED",
+            severity="error",
+            data={
+                "type": "asset_exists",
+                "resource": None,
+                "path": str(absent),
+                "exists": False,
+                "read_only": True,
+                "executed": True,
+            },
+        )
+
+
+class PostconditionEvaluateBrokenRefsTests(unittest.TestCase):
+    """``_evaluate_postcondition`` ``broken_refs`` evaluation rows.
+    The reference resolver's scan is mocked at the module's import site.
+    """
+
+    def test_broken_refs_upstream_error_returns_post_broken_refs_error(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            so_svc, ref_svc = _make_services(root)
+            upstream = error_response(
+                "REF404",
+                "Scope path does not exist.",
+                data={"scope": "Assets/Missing", "read_only": True},
+                diagnostics=[
+                    Diagnostic(
+                        path="Assets/Missing",
+                        location="",
+                        detail="missing_scope",
+                        evidence="scope path does not exist",
+                    )
+                ],
+            )
+            with mock.patch.object(
+                ReferenceResolverService,
+                "scan_broken_references",
+                return_value=upstream,
+            ):
+                response = _evaluate_postcondition(
+                    so_svc,
+                    ref_svc,
+                    {
+                        "type": "broken_refs",
+                        "scope": "Assets/Missing",
+                        "expected_count": 0,
+                    },
+                    resource_map={},
+                )
+        assert_error_envelope(
+            response,
+            code="POST_BROKEN_REFS_ERROR",
+            severity="error",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets/Missing",
+                "expected_count": 0,
+                "read_only": True,
+                "executed": True,
+                "scan_code": "REF404",
+            },
+        )
+        self.assertEqual(1, len(response.diagnostics))
+
+    def test_broken_refs_count_mismatch_returns_post_broken_refs_failed(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            so_svc, ref_svc = _make_services(root)
+            upstream = error_response(
+                "REF_SCAN_BROKEN",
+                "Broken references were detected in scope.",
+                data={"broken_count": 3, "read_only": True},
+            )
+            with mock.patch.object(
+                ReferenceResolverService,
+                "scan_broken_references",
+                return_value=upstream,
+            ):
+                response = _evaluate_postcondition(
+                    so_svc,
+                    ref_svc,
+                    {
+                        "type": "broken_refs",
+                        "scope": "Assets",
+                        "expected_count": 0,
+                    },
+                    resource_map={},
+                )
+        assert_error_envelope(
+            response,
+            code="POST_BROKEN_REFS_FAILED",
+            severity="error",
+            data={
+                "type": "broken_refs",
+                "scope": "Assets",
+                "expected_count": 0,
+                "actual_count": 3,
+                "scan_code": "REF_SCAN_BROKEN",
+                "read_only": True,
+                "executed": True,
+            },
+        )
+
+    def test_broken_refs_count_match_returns_post_broken_refs_ok(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            so_svc, ref_svc = _make_services(root)
+            upstream = success_response(
+                "REF_SCAN_OK",
+                "No broken references were detected in scope.",
+                data={"broken_count": 0, "read_only": True},
+            )
+            with mock.patch.object(
+                ReferenceResolverService,
+                "scan_broken_references",
+                return_value=upstream,
+            ):
+                response = _evaluate_postcondition(
+                    so_svc,
+                    ref_svc,
+                    {
+                        "type": "broken_refs",
+                        "scope": "Assets",
+                        "expected_count": 0,
+                    },
+                    resource_map={},
+                )
+        self.assertTrue(response.success)
+        self.assertEqual("POST_BROKEN_REFS_OK", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(
+            {
+                "type": "broken_refs",
+                "scope": "Assets",
+                "expected_count": 0,
+                "actual_count": 0,
+                "scan_code": "REF_SCAN_OK",
+                "read_only": True,
+                "executed": True,
+            },
+            response.data,
+        )
+
+
+def _to_snapshot(response: ToolResponse) -> dict:
+    """Project a ToolResponse onto a stable, JSON-serializable shape."""
+    return {
+        "success": response.success,
+        "severity": response.severity.value,
+        "code": response.code,
+        "message": response.message,
+        "data": response.data,
+    }
+
+
+class PostconditionSnapshotAnchorTests(unittest.TestCase):
+    """Snapshot anchors for the two documented success-shape envelopes
+    pin the message text and full data payload against drift.  The
+    fixtures live under ``tests/fixtures/orchestrator_postcondition/``.
+    """
+
+    def test_asset_exists_ok_snapshot_matches_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            present = root / "Assets" / "Created.asset"
+            present.write_text("body\n", encoding="utf-8")
+            so_svc = SerializedObjectService(project_root=root)
+            ref_svc = ReferenceResolverService(project_root=root)
+            with mock.patch.object(
+                SerializedObjectService,
+                "_resolve_target_path",
+                return_value=present,
+            ):
+                response = _evaluate_postcondition(
+                    so_svc,
+                    ref_svc,
+                    {"type": "asset_exists", "path": "Assets/Created.asset"},
+                    resource_map={},
+                )
+        # Replace the absolute path with a stable token so the fixture
+        # is project-tree independent.
+        snapshot = _to_snapshot(response)
+        snapshot["data"]["path"] = "<TMP>/Assets/Created.asset"
+        fixture_path = _FIXTURE_ROOT / "asset_exists_ok.json"
+        expected = json.loads(fixture_path.read_text(encoding="utf-8"))
+        self.assertEqual(expected, snapshot)
+
+    def test_broken_refs_ok_snapshot_matches_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir()
+            so_svc = SerializedObjectService(project_root=root)
+            ref_svc = ReferenceResolverService(project_root=root)
+            upstream = success_response(
+                "REF_SCAN_OK",
+                "No broken references were detected in scope.",
+                data={"broken_count": 0, "read_only": True},
+            )
+            with mock.patch.object(
+                ReferenceResolverService,
+                "scan_broken_references",
+                return_value=upstream,
+            ):
+                response = _evaluate_postcondition(
+                    so_svc,
+                    ref_svc,
+                    {
+                        "type": "broken_refs",
+                        "scope": "Assets",
+                        "expected_count": 0,
+                    },
+                    resource_map={},
+                )
+        snapshot = _to_snapshot(response)
+        fixture_path = _FIXTURE_ROOT / "broken_refs_ok.json"
+        expected = json.loads(fixture_path.read_text(encoding="utf-8"))
+        self.assertEqual(expected, snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prefab_variant_package.py
+++ b/tests/test_prefab_variant_package.py
@@ -1,19 +1,92 @@
-"""Structural test guarding the prefab_variant package import surface (#75).
+"""Prefab-variant package tests: import surface plus override response shape.
+
+Two responsibilities live here per the spec's File Structure:
+
+* The package's import-surface invariant (#75).
+* The discriminant rows and existing-keys-preserved row for
+  ``PrefabVariantService.list_overrides`` (#172).  Each override entry in
+  the response payload must carry the keys ``kind``, ``target_key``,
+  ``line``, ``target_file_id``, ``target_guid``, ``property_path``,
+  ``value``, ``object_reference``.  ``kind`` is one of four discriminant
+  strings:
+
+  * ``array_size`` — the property path ends in ``.Array.size``.
+  * ``array_data`` — the property path matches ``*.Array.data[<index>]``.
+  * ``object_reference`` — the entry carries a non-empty, non-zero
+    ``objectReference`` value.
+  * ``value`` — every other case, including an explicit ``{fileID: 0}``
+    reference and an entry without an ``objectReference`` field.
+
+  ``target_key`` mirrors the dataclass property: the GUID-and-fileID
+  composite ``"<guid>:<fileID>"``.
 
 The line-count invariant for files under this package is enforced by the
-CI-side static gate ``scripts/check_module_line_limits.py``; this file
-holds only the package's import-surface invariant.
+CI-side static gate ``scripts/check_module_line_limits.py``.
 """
 
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
 
 import prefab_sentinel.services.prefab_variant as prefab_variant_pkg
 from prefab_sentinel.services.prefab_variant import PrefabVariantService
+from prefab_sentinel.services.prefab_variant.overrides import OverrideEntry
 from prefab_sentinel.services.prefab_variant.service import (
     PrefabVariantService as _ServicePrefabVariantService,
 )
+from tests._assertion_helpers import assert_error_envelope
+from tests.bridge_test_helpers import write_file
+
+_BASE_GUID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_VARIANT_GUID = "cccccccccccccccccccccccccccccccc"
+_REF_GUID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+_REQUIRED_KEYS = {
+    "kind",
+    "target_key",
+    "line",
+    "target_file_id",
+    "target_guid",
+    "property_path",
+    "value",
+    "object_reference",
+}
+
+
+def _write_base(root: Path) -> None:
+    write_file(
+        root / "Assets" / "Base.prefab",
+        """%YAML 1.1
+--- !u!1 &100100000
+GameObject:
+  m_Name: Base
+""",
+    )
+    write_file(
+        root / "Assets" / "Base.prefab.meta",
+        f"fileFormatVersion: 2\nguid: {_BASE_GUID}\n",
+    )
+
+
+def _write_variant(root: Path, modifications: str) -> str:
+    _write_base(root)
+    write_file(
+        root / "Assets" / "Variant.prefab",
+        f"""%YAML 1.1
+--- !u!1001 &100100000
+PrefabInstance:
+  m_SourcePrefab: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+  m_Modification:
+    m_Modifications:
+{modifications}""",
+    )
+    write_file(
+        root / "Assets" / "Variant.prefab.meta",
+        f"fileFormatVersion: 2\nguid: {_VARIANT_GUID}\n",
+    )
+    return "Assets/Variant.prefab"
 
 
 class PrefabVariantPackageImportTests(unittest.TestCase):
@@ -21,6 +94,191 @@ class PrefabVariantPackageImportTests(unittest.TestCase):
         """Legacy import path ``from prefab_sentinel.services.prefab_variant import PrefabVariantService`` resolves to the post-split implementation."""
         self.assertIs(PrefabVariantService, _ServicePrefabVariantService)
         self.assertIn("PrefabVariantService", prefab_variant_pkg.__all__)
+
+
+class OverrideEntryDiscriminantTests(unittest.TestCase):
+    """Pure unit tests on the dataclass property's classification rules."""
+
+    def _entry(
+        self,
+        property_path: str,
+        object_reference: str = "",
+    ) -> OverrideEntry:
+        return OverrideEntry(
+            target_file_id="100100000",
+            target_guid=_BASE_GUID,
+            target_type="3",
+            target_raw="",
+            property_path=property_path,
+            value="",
+            object_reference=object_reference,
+            line=1,
+        )
+
+    def test_array_size_path_returns_array_size(self) -> None:
+        entry = self._entry("items.Array.size")
+        self.assertEqual("array_size", entry.kind)
+
+    def test_array_data_path_returns_array_data(self) -> None:
+        entry = self._entry("items.Array.data[3]")
+        self.assertEqual("array_data", entry.kind)
+
+    def test_non_empty_non_zero_object_reference_returns_object_reference(self) -> None:
+        entry = self._entry(
+            "m_Sprite",
+            object_reference=f"{{fileID: 21300000, guid: {_REF_GUID}, type: 3}}",
+        )
+        self.assertEqual("object_reference", entry.kind)
+
+    def test_explicit_zero_object_reference_returns_value(self) -> None:
+        entry = self._entry("m_Name", object_reference="{fileID: 0}")
+        self.assertEqual("value", entry.kind)
+
+    def test_no_object_reference_returns_value(self) -> None:
+        entry = self._entry("m_Name", object_reference="")
+        self.assertEqual("value", entry.kind)
+
+    def test_target_key_is_guid_colon_fileid_composite(self) -> None:
+        entry = self._entry("m_Name")
+        self.assertEqual(f"{_BASE_GUID}:100100000", entry.target_key)
+
+
+class ListOverridesResponseShapeTests(unittest.TestCase):
+    """End-to-end pinning of the override entry payload returned by ``list_overrides``."""
+
+    def _list_overrides_payload(self, modifications: str) -> list[dict]:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = _write_variant(root, modifications)
+            svc = PrefabVariantService(project_root=root)
+            response = svc.list_overrides(target)
+        self.assertTrue(response.success, response)
+        return response.data["overrides"]
+
+    def test_array_size_entry_carries_array_size_kind(self) -> None:
+        payload = self._list_overrides_payload(
+            f"""    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: items.Array.size
+      value: 4
+      objectReference: {{fileID: 0}}
+"""
+        )
+        self.assertEqual(1, len(payload))
+        self.assertEqual("array_size", payload[0]["kind"])
+        self.assertEqual(f"{_BASE_GUID}:100100000", payload[0]["target_key"])
+
+    def test_array_data_entry_carries_array_data_kind(self) -> None:
+        payload = self._list_overrides_payload(
+            f"""    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: items.Array.data[2]
+      value: hello
+      objectReference: {{fileID: 0}}
+"""
+        )
+        self.assertEqual("array_data", payload[0]["kind"])
+
+    def test_object_reference_entry_carries_object_reference_kind(self) -> None:
+        payload = self._list_overrides_payload(
+            f"""    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: m_Sprite
+      value:
+      objectReference: {{fileID: 21300000, guid: {_REF_GUID}, type: 3}}
+"""
+        )
+        self.assertEqual("object_reference", payload[0]["kind"])
+
+    def test_value_entry_with_explicit_zero_reference_carries_value_kind(self) -> None:
+        payload = self._list_overrides_payload(
+            f"""    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: m_Name
+      value: NewName
+      objectReference: {{fileID: 0}}
+"""
+        )
+        self.assertEqual("value", payload[0]["kind"])
+
+    def test_value_entry_with_no_reference_field_carries_value_kind(self) -> None:
+        payload = self._list_overrides_payload(
+            f"""    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: m_Name
+      value: NewName
+"""
+        )
+        self.assertEqual("value", payload[0]["kind"])
+
+    def test_existing_keys_preserved_across_entries(self) -> None:
+        """Regression: every documented key remains on each entry."""
+        payload = self._list_overrides_payload(
+            f"""    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: items.Array.size
+      value: 1
+      objectReference: {{fileID: 0}}
+    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: items.Array.data[0]
+      value: alpha
+      objectReference: {{fileID: 0}}
+    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: m_Sprite
+      value:
+      objectReference: {{fileID: 21300000, guid: {_REF_GUID}, type: 3}}
+    - target: {{fileID: 100100000, guid: {_BASE_GUID}, type: 3}}
+      propertyPath: m_Name
+      value: Renamed
+      objectReference: {{fileID: 0}}
+"""
+        )
+        kinds = {entry["kind"] for entry in payload}
+        self.assertEqual(
+            {"array_size", "array_data", "object_reference", "value"},
+            kinds,
+        )
+        for entry in payload:
+            self.assertEqual(_REQUIRED_KEYS, set(entry.keys()))
+            self.assertEqual(f"{_BASE_GUID}:100100000", entry["target_key"])
+
+
+class ListOverridesErrorPathTests(unittest.TestCase):
+    """Error-envelope regressions: the additive payload keys are present
+    only on success envelopes; the documented error codes remain.
+    """
+
+    def test_missing_variant_path_returns_pvr404(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir(parents=True, exist_ok=True)
+            svc = PrefabVariantService(project_root=root)
+            response = svc.list_overrides("Assets/DoesNotExist.prefab")
+        assert_error_envelope(
+            response,
+            code="PVR404",
+            severity="error",
+            data={
+                "variant_path": "Assets/DoesNotExist.prefab",
+                "read_only": True,
+            },
+        )
+
+    def test_undecodable_variant_returns_pvr400(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "Assets").mkdir(parents=True, exist_ok=True)
+            variant_path = root / "Assets" / "Binary.prefab"
+            variant_path.write_bytes(b"\xff\xfe\x00\x80\x90 binary garbage")
+            (root / "Assets" / "Binary.prefab.meta").write_text(
+                f"fileFormatVersion: 2\nguid: {_VARIANT_GUID}\n",
+                encoding="utf-8",
+            )
+            svc = PrefabVariantService(project_root=root)
+            response = svc.list_overrides("Assets/Binary.prefab")
+        assert_error_envelope(
+            response,
+            code="PVR400",
+            severity="error",
+            data={
+                "variant_path": "Assets/Binary.prefab",
+                "read_only": True,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_reference_resolver_coverage.py
+++ b/tests/test_reference_resolver_coverage.py
@@ -1,0 +1,220 @@
+"""Coverage rows for the two gap blocks in
+``prefab_sentinel/services/reference_resolver.py`` (issue #181).
+
+Block 1 — broken-reference scan: external prefab/asset target whose
+fileID is absent from the target's local-IDs (``missing_local_id``
+record with the external classification key).
+
+Block 2 — ``where_used`` path-form lookup: every documented error code
+path of the path-form input (non-existent, meta missing, meta
+undecodable, meta GUID malformed) and the path-form success row.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from prefab_sentinel.contracts import Severity
+from prefab_sentinel.services.reference_resolver import ReferenceResolverService
+from tests._assertion_helpers import assert_error_envelope
+from tests.bridge_test_helpers import write_file
+
+_TARGET_GUID = "1111111111111111111111111111aaaa"
+_SOURCE_GUID = "2222222222222222222222222222bbbb"
+_OTHER_GUID = "3333333333333333333333333333cccc"
+
+
+def _seed_minimal_project(root: Path) -> None:
+    (root / "Assets").mkdir(parents=True, exist_ok=True)
+
+
+class ScanBrokenReferencesExternalAssetTests(unittest.TestCase):
+    """Block 1 — ``scan_broken_references`` ``missing_local_id_external``
+    arm fires when the source references a non-prefab target by GUID and
+    the target's local-IDs do not contain the requested fileID.
+    """
+
+    def test_external_asset_missing_fileid_reports_missing_local_id(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _seed_minimal_project(root)
+            # Target is a non-prefab text asset (``.asset`` here so the
+            # ``_should_validate_external_file_id`` predicate returns
+            # True; ``.prefab`` targets are skipped by design).
+            target_text = (
+                "%YAML 1.1\n"
+                "--- !u!114 &11400000\n"
+                "MonoBehaviour:\n"
+                "  m_Name: Anchored\n"
+                "--- !u!114 &22200000\n"
+                "MonoBehaviour:\n"
+                "  m_Name: Other\n"
+            )
+            write_file(root / "Assets" / "Target.asset", target_text)
+            write_file(
+                root / "Assets" / "Target.asset.meta",
+                f"fileFormatVersion: 2\nguid: {_TARGET_GUID}\n",
+            )
+            # Source references fileID 99999999 which is NOT present in
+            # the target's local IDs (11400000, 22200000).
+            source_text = (
+                "%YAML 1.1\n"
+                "--- !u!114 &33300000\n"
+                "MonoBehaviour:\n"
+                "  m_Reference: {fileID: 99999999, guid: "
+                f"{_TARGET_GUID}, type: 2}}\n"
+            )
+            write_file(root / "Assets" / "Source.asset", source_text)
+            write_file(
+                root / "Assets" / "Source.asset.meta",
+                f"fileFormatVersion: 2\nguid: {_SOURCE_GUID}\n",
+            )
+
+            svc = ReferenceResolverService(project_root=root)
+            response = svc.scan_broken_references(
+                "Assets",
+                include_diagnostics=True,
+            )
+
+        assert_error_envelope(response, code="REF_SCAN_BROKEN", severity="error")
+        self.assertEqual(1, response.data["broken_count"])
+        self.assertEqual(1, response.data["categories"]["missing_local_id"])
+        self.assertEqual(0, response.data["categories"]["missing_asset"])
+        # The diagnostic surfaces the missing fileID and the target's
+        # repository-relative path so the operator can correlate
+        # source <-> target without re-scanning.
+        diag = next(
+            d
+            for d in response.diagnostics
+            if d.detail == "missing_local_id"
+        )
+        self.assertIn("99999999", diag.evidence)
+        self.assertIn("Assets/Target.asset", diag.evidence)
+
+
+class WhereUsedPathFormErrorPathTests(unittest.TestCase):
+    """Block 2 — every documented error code path of the path-form
+    ``where_used`` lookup."""
+
+    def test_non_existent_path_returns_ref404(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _seed_minimal_project(root)
+            svc = ReferenceResolverService(project_root=root)
+            response = svc.where_used("Assets/Missing.asset")
+        assert_error_envelope(
+            response,
+            code="REF404",
+            severity="error",
+            data={
+                "asset_or_guid": "Assets/Missing.asset",
+                "read_only": True,
+            },
+        )
+
+    def test_meta_file_missing_returns_ref001(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _seed_minimal_project(root)
+            write_file(root / "Assets" / "Orphan.asset", "ignored body\n")
+            svc = ReferenceResolverService(project_root=root)
+            response = svc.where_used("Assets/Orphan.asset")
+        assert_error_envelope(
+            response,
+            code="REF001",
+            severity="error",
+            data={
+                "asset_or_guid": "Assets/Orphan.asset",
+                "read_only": True,
+            },
+        )
+
+    def test_meta_undecodable_returns_ref001(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _seed_minimal_project(root)
+            asset = root / "Assets" / "Binary.asset"
+            asset.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("body\n", encoding="utf-8")
+            (root / "Assets" / "Binary.asset.meta").write_bytes(
+                b"\xff\xfe\xfd\xfc not utf-8 \x80\x81"
+            )
+            svc = ReferenceResolverService(project_root=root)
+            response = svc.where_used("Assets/Binary.asset")
+        assert_error_envelope(
+            response,
+            code="REF001",
+            severity="error",
+            data={
+                "asset_or_guid": "Assets/Binary.asset",
+                "read_only": True,
+            },
+        )
+
+    def test_meta_guid_malformed_returns_ref001(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _seed_minimal_project(root)
+            asset = root / "Assets" / "Bad.asset"
+            asset.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("body\n", encoding="utf-8")
+            (root / "Assets" / "Bad.asset.meta").write_text(
+                "fileFormatVersion: 2\nguid: NOT-A-VALID-GUID\n",
+                encoding="utf-8",
+            )
+            svc = ReferenceResolverService(project_root=root)
+            response = svc.where_used("Assets/Bad.asset")
+        assert_error_envelope(
+            response,
+            code="REF001",
+            severity="error",
+            data={
+                "asset_or_guid": "Assets/Bad.asset",
+                "read_only": True,
+            },
+        )
+
+    def test_path_form_success_lists_referencing_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _seed_minimal_project(root)
+            target_path = root / "Assets" / "Target.asset"
+            write_file(
+                target_path,
+                "%YAML 1.1\n--- !u!114 &11400000\nMonoBehaviour:\n  m_Name: T\n",
+            )
+            write_file(
+                root / "Assets" / "Target.asset.meta",
+                f"fileFormatVersion: 2\nguid: {_TARGET_GUID}\n",
+            )
+            referrer_text = (
+                "%YAML 1.1\n"
+                "--- !u!114 &22200000\n"
+                "MonoBehaviour:\n"
+                "  m_Reference: {fileID: 11400000, guid: "
+                f"{_TARGET_GUID}, type: 2}}\n"
+            )
+            write_file(root / "Assets" / "Referrer.asset", referrer_text)
+            write_file(
+                root / "Assets" / "Referrer.asset.meta",
+                f"fileFormatVersion: 2\nguid: {_OTHER_GUID}\n",
+            )
+
+            svc = ReferenceResolverService(project_root=root)
+            response = svc.where_used("Assets/Target.asset")
+
+        self.assertTrue(response.success)
+        self.assertEqual("REF_WHERE_USED", response.code)
+        self.assertEqual(Severity.INFO, response.severity)
+        self.assertEqual(_TARGET_GUID, response.data["guid"])
+        self.assertEqual("Assets/Target.asset", response.data["asset_path"])
+        self.assertEqual(1, response.data["usage_count"])
+        self.assertEqual(1, response.data["returned_usages"])
+        usage_paths = [usage["path"] for usage in response.data["usages"]]
+        self.assertIn("Assets/Referrer.asset", usage_paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serialized_object_coverage.py
+++ b/tests/test_serialized_object_coverage.py
@@ -1,0 +1,925 @@
+"""Coverage strengthening for the seven low-coverage serialized-object
+modules (issue #151).
+
+Modules in scope:
+
+* ``services.serialized_object.scene_values``
+* ``services.serialized_object.scene_object_ops``
+* ``services.serialized_object.asset_open_ops``
+* ``services.serialized_object.patch_executor``
+* ``services.serialized_object.prefab_create_structure``
+* ``services.serialized_object.asset_create_writers``
+* ``services.serialized_object.patch_json_apply``
+
+Each test class drives one module via its public-facing entry point
+(typically the dispatcher or the service facade) and pins one or more
+representative branches by full envelope / diagnostic equality.
+
+Why short integration tests instead of unit tests on private helpers:
+the validators all funnel into ``(diagnostics, preview)`` tuples whose
+contract is observable only at the dispatcher boundary; testing the
+helper functions directly would re-state their internals.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from prefab_sentinel.contracts import Diagnostic
+from prefab_sentinel.services.serialized_object.asset_open_ops import (
+    validate_asset_open_ops,
+)
+from prefab_sentinel.services.serialized_object.patch_executor import apply_op
+from prefab_sentinel.services.serialized_object.patch_json_apply import (
+    apply_json_target,
+    propagate_dry_run_failure,
+)
+from prefab_sentinel.services.serialized_object.scene_dispatch import (
+    validate_scene_ops,
+)
+
+
+def _diagnostic_evidence_set(diagnostics: list[Diagnostic]) -> list[str]:
+    return [d.evidence for d in diagnostics]
+
+
+class SceneValuesCoverageTests(unittest.TestCase):
+    """``scene_values`` — set / insert / save validators."""
+
+    def test_set_op_missing_value_emits_schema_error(self) -> None:
+        diagnostics, _preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {
+                    "op": "create_game_object",
+                    "parent": "$scene",
+                    "name": "Foo",
+                    "result": "$go",
+                },
+                {
+                    "op": "add_component",
+                    "target": "$go",
+                    "type": "T",
+                    "result": "$c",
+                },
+                {"op": "set", "target": "$c", "path": "m_Foo"},
+                {"op": "save_scene"},
+            ],
+        )
+        # ``set`` with no ``value`` adds a schema error; preview drops
+        # the value row.
+        self.assertIn(
+            "value is required for set",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_save_scene_must_be_last_op(self) -> None:
+        diagnostics, _ = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {"op": "save_scene"},
+                {"op": "add_component", "target": "$scene", "type": "T", "result": "$c"},
+            ],
+        )
+        self.assertIn(
+            "save_scene must be the final operation in scene mode",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_save_scene_without_init_emits_schema_error(self) -> None:
+        # Two-op plan where the first op is something other than the
+        # mode-specific init.  validate_scene_init_op rejects the first
+        # op without flipping ``scene_initialized``, then
+        # validate_scene_save_op fires the "requires an opened scene"
+        # branch on op[1].
+        diagnostics, _ = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "rename_object", "target": "$scene", "name": "n"},
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertIn(
+            "save_scene requires an opened scene first",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+
+class SceneObjectOpsCoverageTests(unittest.TestCase):
+    """``scene_object_ops`` — init / create / duplicate-init / reparent."""
+
+    def test_first_op_must_match_mode(self) -> None:
+        diagnostics, _ = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="create",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertIn(
+            "scene create mode must start with create_scene",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_duplicate_init_after_first_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {"op": "open_scene", "result": "$scene_again"},
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertIn(
+            "open_scene may appear only as the first operation",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_create_game_object_requires_name(self) -> None:
+        diagnostics, _ = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {"op": "create_game_object", "parent": "$scene", "result": "$g"},
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertIn(
+            "name is required for create_game_object",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+
+class AssetOpenOpsCoverageTests(unittest.TestCase):
+    """``asset_open_ops`` — schema-error paths + set preview row."""
+
+    def test_missing_target_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="",
+            kind="asset",
+            ops=[{"op": "set", "target": "$asset", "path": "x", "value": 1}],
+        )
+        self.assertIn(
+            "target path is required for asset open mode",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_wrong_extension_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.prefab",
+            kind="asset",
+            ops=[{"op": "set", "target": "$asset", "path": "x", "value": 1}],
+        )
+        self.assertIn(
+            "asset open mode requires a .asset target path",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_unsupported_op_name_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[
+                {"op": "WhoKnows", "target": "$asset", "path": "x", "value": 1},
+            ],
+        )
+        self.assertIn(
+            "unsupported asset open op 'WhoKnows'",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_set_op_emits_preview_row(self) -> None:
+        diagnostics, preview = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[
+                {"op": "set", "target": "$asset", "path": "x", "value": 42},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        self.assertEqual(1, len(preview))
+        self.assertEqual("set", preview[0]["op"])
+        self.assertEqual(42, preview[0]["after"]["value"])
+
+
+class PatchExecutorCoverageTests(unittest.TestCase):
+    """``patch_executor.apply_op`` — short-circuit / value / array branches."""
+
+    def test_set_with_existing_key_returns_diff_row(self) -> None:
+        payload = {"a": 1}
+        row = apply_op(payload, {"op": "set", "path": "a", "value": 2})
+        self.assertEqual(1, row["before"])
+        self.assertEqual(2, row["after"])
+        self.assertEqual(2, payload["a"])
+
+    def test_set_with_missing_key_raises_keyerror(self) -> None:
+        with self.assertRaises(KeyError):
+            apply_op({}, {"op": "set", "path": "a", "value": 2})
+
+    def test_array_size_set_grows_then_shrinks(self) -> None:
+        payload = {"items": [1, 2]}
+        row = apply_op(
+            payload,
+            {"op": "set", "path": "items.Array.size", "value": 4},
+        )
+        self.assertEqual(2, row["before"])
+        self.assertEqual(4, row["after"])
+        self.assertEqual([1, 2, None, None], payload["items"])
+
+    def test_array_size_set_negative_raises_valueerror(self) -> None:
+        with self.assertRaises(ValueError):
+            apply_op(
+                {"items": [1, 2]},
+                {"op": "set", "path": "items.Array.size", "value": -1},
+            )
+
+    def test_insert_array_element_out_of_bounds_raises_indexerror(self) -> None:
+        with self.assertRaises(IndexError):
+            apply_op(
+                {"items": [1]},
+                {
+                    "op": "insert_array_element",
+                    "path": "items.Array.data",
+                    "index": 99,
+                    "value": 0,
+                },
+            )
+
+    def test_unsupported_op_raises_valueerror(self) -> None:
+        with self.assertRaises(ValueError):
+            apply_op({}, {"op": "WhoKnows"})
+
+
+class PrefabCreateStructureCoverageTests(unittest.TestCase):
+    """``prefab_create_structure`` — root creation schema-error rows."""
+
+    def test_create_root_missing_name_emits_schema_error(self) -> None:
+        from prefab_sentinel.services.serialized_object.prefab_create_dispatch import (  # noqa: PLC0415
+            validate_prefab_create_ops,
+        )
+
+        diagnostics, _ = validate_prefab_create_ops(
+            target="Assets/Foo.prefab",
+            ops=[{"op": "create_root"}, {"op": "save"}],
+        )
+        self.assertIn(
+            "name is required for create_root",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_double_create_root_emits_schema_error(self) -> None:
+        from prefab_sentinel.services.serialized_object.prefab_create_dispatch import (  # noqa: PLC0415
+            validate_prefab_create_ops,
+        )
+
+        diagnostics, _ = validate_prefab_create_ops(
+            target="Assets/Foo.prefab",
+            ops=[
+                {"op": "create_root", "name": "Root"},
+                {"op": "create_root", "name": "AlsoRoot"},
+                {"op": "save"},
+            ],
+        )
+        self.assertIn(
+            "prefab root may be created only once",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+
+class AssetCreateWritersCoverageTests(unittest.TestCase):
+    """``asset_create_writers`` — material vs asset create paths."""
+
+    def test_material_create_requires_shader(self) -> None:
+        from prefab_sentinel.services.serialized_object.asset_create_ops import (  # noqa: PLC0415
+            validate_asset_create_ops,
+        )
+
+        diagnostics, _ = validate_asset_create_ops(
+            target="Assets/Foo.mat",
+            kind="material",
+            ops=[
+                {"op": "create_asset", "name": "Foo"},
+                {"op": "save"},
+            ],
+        )
+        self.assertIn(
+            "shader is required for create_asset on material resources",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_asset_create_requires_type(self) -> None:
+        from prefab_sentinel.services.serialized_object.asset_create_ops import (  # noqa: PLC0415
+            validate_asset_create_ops,
+        )
+
+        diagnostics, _ = validate_asset_create_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[
+                {"op": "create_asset", "name": "Foo"},
+                {"op": "save"},
+            ],
+        )
+        joined = " | ".join(_diagnostic_evidence_set(diagnostics))
+        self.assertIn("type", joined)
+
+    def test_double_create_asset_emits_schema_error(self) -> None:
+        from prefab_sentinel.services.serialized_object.asset_create_ops import (  # noqa: PLC0415
+            validate_asset_create_ops,
+        )
+
+        diagnostics, _ = validate_asset_create_ops(
+            target="Assets/Foo.mat",
+            kind="material",
+            ops=[
+                {"op": "create_asset", "name": "Foo", "shader": "Standard"},
+                {"op": "create_asset", "name": "Bar", "shader": "Standard"},
+                {"op": "save"},
+            ],
+        )
+        self.assertIn(
+            "asset root may be created only once",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+
+class SceneValuesAdditionalCoverageTests(unittest.TestCase):
+    """Additional rows for ``scene_values`` covering set / insert / remove preview rows."""
+
+    def _ops_with_value_set(
+        self,
+        *,
+        with_value: bool = True,
+        path: str = "m_Foo",
+        index_value: object | None = None,
+        op_kind: str = "set",
+        value: object = 1,
+    ) -> list[dict]:
+        body: list[dict] = [
+            {"op": "open_scene", "result": "$scene"},
+            {
+                "op": "create_game_object",
+                "parent": "$scene",
+                "name": "Foo",
+                "result": "$go",
+            },
+            {
+                "op": "add_component",
+                "target": "$go",
+                "type": "T",
+                "result": "$c",
+            },
+        ]
+        op: dict = {"op": op_kind, "target": "$c", "path": path}
+        if with_value:
+            op["value"] = value
+        if index_value is not None:
+            op["index"] = index_value
+        body.append(op)
+        body.append({"op": "save_scene"})
+        return body
+
+    def test_set_op_with_value_emits_preview_row(self) -> None:
+        diagnostics, preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=self._ops_with_value_set(with_value=True, value=42),
+        )
+        # No schema errors against the set op; preview includes the
+        # set row carrying the deep-copied value.
+        self.assertEqual([], diagnostics)
+        set_rows = [row for row in preview if row.get("op") == "set"]
+        self.assertEqual(1, len(set_rows))
+        self.assertEqual(42, set_rows[0]["after"]["value"])
+
+    def test_set_op_with_empty_path_emits_schema_error(self) -> None:
+        diagnostics, _preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=self._ops_with_value_set(path="", with_value=True),
+        )
+        self.assertIn("path is required", _diagnostic_evidence_set(diagnostics))
+
+    def test_insert_array_element_emits_preview_row(self) -> None:
+        diagnostics, preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=self._ops_with_value_set(
+                op_kind="insert_array_element",
+                index_value=0,
+                value="hello",
+            ),
+        )
+        self.assertEqual([], diagnostics)
+        insert_rows = [
+            row for row in preview if row.get("op") == "insert_array_element"
+        ]
+        self.assertEqual(1, len(insert_rows))
+        self.assertEqual(0, insert_rows[0]["after"]["index"])
+        self.assertEqual("hello", insert_rows[0]["after"]["value"])
+
+    def test_array_op_without_index_emits_schema_error(self) -> None:
+        diagnostics, _preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=self._ops_with_value_set(
+                op_kind="insert_array_element",
+                index_value=None,
+                with_value=False,
+            ),
+        )
+        self.assertIn(
+            "index must be an integer",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_save_scene_already_saved_emits_schema_error(self) -> None:
+        diagnostics, _preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {"op": "save_scene"},
+                {"op": "save_scene"},
+            ],
+        )
+        joined = " | ".join(_diagnostic_evidence_set(diagnostics))
+        self.assertIn("save_scene", joined)
+
+
+class SceneObjectOpsAdditionalCoverageTests(unittest.TestCase):
+    """``scene_object_ops`` — instantiate_prefab / rename / reparent / no-init."""
+
+    def test_create_game_object_without_init_emits_schema_error(self) -> None:
+        # Force the dispatcher to skip init by making op[0] a non-init
+        # operation; subsequent create_game_object then hits the
+        # "requires an opened scene first" branch.
+        diagnostics, _ = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "rename_object", "target": "$scene", "name": "n"},
+                {
+                    "op": "create_game_object",
+                    "parent": "$scene",
+                    "name": "Foo",
+                    "result": "$go",
+                },
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertIn(
+            "create_game_object requires an opened scene first",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_instantiate_prefab_emits_preview_row(self) -> None:
+        diagnostics, preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {
+                    "op": "instantiate_prefab",
+                    "parent": "$scene",
+                    "prefab": "Assets/Foo.prefab",
+                    "result": "$inst",
+                },
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        rows = [row for row in preview if row.get("op") == "instantiate_prefab"]
+        self.assertEqual(1, len(rows))
+
+    def test_rename_object_emits_preview_row(self) -> None:
+        diagnostics, preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {
+                    "op": "create_game_object",
+                    "parent": "$scene",
+                    "name": "Foo",
+                    "result": "$go",
+                },
+                {"op": "rename_object", "target": "$go", "name": "Bar"},
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        rows = [row for row in preview if row.get("op") == "rename_object"]
+        self.assertEqual(1, len(rows))
+
+    def test_reparent_emits_preview_row(self) -> None:
+        diagnostics, preview = validate_scene_ops(
+            target="Assets/A.unity",
+            mode="open",
+            ops=[
+                {"op": "open_scene", "result": "$scene"},
+                {
+                    "op": "create_game_object",
+                    "parent": "$scene",
+                    "name": "Foo",
+                    "result": "$go",
+                },
+                {
+                    "op": "create_game_object",
+                    "parent": "$scene",
+                    "name": "Bar",
+                    "result": "$go2",
+                },
+                {"op": "reparent", "target": "$go2", "parent": "$go"},
+                {"op": "save_scene"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        rows = [row for row in preview if row.get("op") == "reparent"]
+        self.assertEqual(1, len(rows))
+
+
+class AssetOpenOpsAdditionalCoverageTests(unittest.TestCase):
+    """``asset_open_ops`` — empty ops / non-dict op / array element / path."""
+
+    def test_empty_ops_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.asset", kind="asset", ops=[]
+        )
+        self.assertIn(
+            "ops must contain at least one operation",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_non_dict_op_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=["not a dict"],
+        )
+        self.assertIn(
+            "operation must be an object",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_set_missing_path_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[{"op": "set", "target": "$asset", "value": 1}],
+        )
+        self.assertIn(
+            "path is required",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_set_missing_value_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[{"op": "set", "target": "$asset", "path": "x"}],
+        )
+        self.assertIn(
+            "value is required for set",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_insert_array_element_emits_preview_row(self) -> None:
+        diagnostics, preview = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[
+                {
+                    "op": "insert_array_element",
+                    "target": "$asset",
+                    "path": "items",
+                    "index": 0,
+                    "value": "alpha",
+                }
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        self.assertEqual("insert_array_element", preview[0]["op"])
+        self.assertEqual(0, preview[0]["after"]["index"])
+        self.assertEqual("alpha", preview[0]["after"]["value"])
+
+    def test_array_element_without_index_emits_schema_error(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[
+                {
+                    "op": "insert_array_element",
+                    "target": "$asset",
+                    "path": "items",
+                }
+            ],
+        )
+        self.assertIn(
+            "index must be an integer",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_material_kind_requires_mat_extension(self) -> None:
+        diagnostics, _ = validate_asset_open_ops(
+            target="Assets/Foo.asset",
+            kind="material",
+            ops=[
+                {"op": "set", "target": "$asset", "path": "x", "value": 1},
+            ],
+        )
+        self.assertIn(
+            "material open mode requires a .mat target path",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+
+class AssetCreateWritersAdditionalCoverageTests(unittest.TestCase):
+    """``asset_create_writers`` — non-material asset and value/save ops."""
+
+    def test_asset_create_emits_preview_row(self) -> None:
+        from prefab_sentinel.services.serialized_object.asset_create_ops import (  # noqa: PLC0415
+            validate_asset_create_ops,
+        )
+
+        diagnostics, preview = validate_asset_create_ops(
+            target="Assets/Foo.asset",
+            kind="asset",
+            ops=[
+                {
+                    "op": "create_asset",
+                    "name": "Foo",
+                    "type": "MyType",
+                },
+                {
+                    "op": "set",
+                    "target": "$asset",
+                    "path": "x",
+                    "value": 1,
+                },
+                {"op": "save"},
+            ],
+        )
+        # Some non-set diagnostics may exist depending on schema, but
+        # the create_asset row is emitted.
+        rows = [row for row in preview if row.get("op") == "create_asset"]
+        self.assertEqual(1, len(rows))
+        del diagnostics  # we only care that the structure is rendered
+
+    def test_material_create_with_invalid_name_emits_schema_error(self) -> None:
+        from prefab_sentinel.services.serialized_object.asset_create_ops import (  # noqa: PLC0415
+            validate_asset_create_ops,
+        )
+
+        diagnostics, _ = validate_asset_create_ops(
+            target="Assets/Foo.mat",
+            kind="material",
+            ops=[
+                {
+                    "op": "create_asset",
+                    "name": "   ",
+                    "shader": "Standard",
+                },
+                {"op": "save"},
+            ],
+        )
+        self.assertIn(
+            "name must be a non-empty string when provided",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_material_create_with_invalid_type_emits_schema_error(self) -> None:
+        from prefab_sentinel.services.serialized_object.asset_create_ops import (  # noqa: PLC0415
+            validate_asset_create_ops,
+        )
+
+        diagnostics, _ = validate_asset_create_ops(
+            target="Assets/Foo.mat",
+            kind="material",
+            ops=[
+                {
+                    "op": "create_asset",
+                    "shader": "Standard",
+                    "type": "   ",
+                },
+                {"op": "save"},
+            ],
+        )
+        self.assertIn(
+            "type must be a non-empty string when provided",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+    def test_material_create_uses_default_type_when_omitted(self) -> None:
+        from prefab_sentinel.services.serialized_object.asset_create_ops import (  # noqa: PLC0415
+            validate_asset_create_ops,
+        )
+
+        diagnostics, preview = validate_asset_create_ops(
+            target="Assets/Foo.mat",
+            kind="material",
+            ops=[
+                {"op": "create_asset", "shader": "Standard"},
+                {"op": "save"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        create_rows = [row for row in preview if row.get("op") == "create_asset"]
+        self.assertEqual("UnityEngine.Material", create_rows[0]["after"]["type"])
+
+
+class PrefabCreateStructureAdditionalCoverageTests(unittest.TestCase):
+    """``prefab_create_structure`` — game object / component / reparent / rename."""
+
+    def _create_root_prelude(self) -> list[dict]:
+        return [{"op": "create_root", "name": "Root"}]
+
+    def test_create_game_object_emits_preview_row(self) -> None:
+        from prefab_sentinel.services.serialized_object.prefab_create_dispatch import (  # noqa: PLC0415
+            validate_prefab_create_ops,
+        )
+
+        diagnostics, preview = validate_prefab_create_ops(
+            target="Assets/Foo.prefab",
+            ops=[
+                *self._create_root_prelude(),
+                {
+                    "op": "create_game_object",
+                    "parent": "$root",
+                    "name": "Child",
+                    "result": "$child",
+                },
+                {"op": "save"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        rows = [row for row in preview if row.get("op") == "create_game_object"]
+        self.assertEqual(1, len(rows))
+
+    def test_add_component_emits_preview_row(self) -> None:
+        from prefab_sentinel.services.serialized_object.prefab_create_dispatch import (  # noqa: PLC0415
+            validate_prefab_create_ops,
+        )
+
+        diagnostics, preview = validate_prefab_create_ops(
+            target="Assets/Foo.prefab",
+            ops=[
+                *self._create_root_prelude(),
+                {
+                    "op": "add_component",
+                    "target": "$root",
+                    "type": "MyComponent",
+                    "result": "$comp",
+                },
+                {"op": "save"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        rows = [row for row in preview if row.get("op") == "add_component"]
+        self.assertEqual(1, len(rows))
+
+    def test_remove_component_emits_preview_row(self) -> None:
+        from prefab_sentinel.services.serialized_object.prefab_create_dispatch import (  # noqa: PLC0415
+            validate_prefab_create_ops,
+        )
+
+        diagnostics, preview = validate_prefab_create_ops(
+            target="Assets/Foo.prefab",
+            ops=[
+                *self._create_root_prelude(),
+                {
+                    "op": "add_component",
+                    "target": "$root",
+                    "type": "MyComponent",
+                    "result": "$comp",
+                },
+                {"op": "remove_component", "target": "$comp"},
+                {"op": "save"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        rows = [row for row in preview if row.get("op") == "remove_component"]
+        self.assertEqual(1, len(rows))
+
+    def test_rename_object_emits_preview_row(self) -> None:
+        from prefab_sentinel.services.serialized_object.prefab_create_dispatch import (  # noqa: PLC0415
+            validate_prefab_create_ops,
+        )
+
+        diagnostics, preview = validate_prefab_create_ops(
+            target="Assets/Foo.prefab",
+            ops=[
+                *self._create_root_prelude(),
+                {"op": "rename_object", "target": "$root", "name": "Renamed"},
+                {"op": "save"},
+            ],
+        )
+        self.assertEqual([], diagnostics)
+        rows = [row for row in preview if row.get("op") == "rename_object"]
+        self.assertEqual(1, len(rows))
+
+    def test_create_game_object_without_root_emits_schema_error(self) -> None:
+        from prefab_sentinel.services.serialized_object.prefab_create_dispatch import (  # noqa: PLC0415
+            validate_prefab_create_ops,
+        )
+
+        diagnostics, _ = validate_prefab_create_ops(
+            target="Assets/Foo.prefab",
+            ops=[
+                {
+                    "op": "create_game_object",
+                    "parent": "$root",
+                    "name": "Child",
+                    "result": "$child",
+                },
+                {"op": "save"},
+            ],
+        )
+        self.assertIn(
+            "create_game_object requires a prefab root first",
+            _diagnostic_evidence_set(diagnostics),
+        )
+
+
+class PatchJsonApplyCoverageTests(unittest.TestCase):
+    """``patch_json_apply`` — failure envelope shapes + dry-run propagation."""
+
+    def test_missing_target_returns_ser_target_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            response = apply_json_target(
+                root / "missing.json",
+                [{"op": "set", "path": "a", "value": 1}],
+            )
+        self.assertFalse(response.success)
+        self.assertEqual("SER_TARGET_MISSING", response.code)
+        self.assertEqual(0, response.data["applied"])
+
+    def test_invalid_json_target_returns_ser_target_format(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            target = Path(raw) / "bad.json"
+            target.write_text("not json", encoding="utf-8")
+            response = apply_json_target(
+                target, [{"op": "set", "path": "a", "value": 1}]
+            )
+        self.assertFalse(response.success)
+        self.assertEqual("SER_TARGET_FORMAT", response.code)
+
+    def test_apply_failure_returns_ser_apply_failed_without_writing(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            target = Path(raw) / "good.json"
+            target.write_text('{"a": 1}', encoding="utf-8")
+            response = apply_json_target(
+                target,
+                [{"op": "set", "path": "missing", "value": 9}],
+            )
+            # File is unmodified — assert before the temp dir is cleaned up.
+            self.assertEqual('{"a": 1}', target.read_text(encoding="utf-8"))
+        self.assertFalse(response.success)
+        self.assertEqual("SER_APPLY_FAILED", response.code)
+
+    def test_apply_success_writes_diff_and_returns_ser_apply_ok(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            target = Path(raw) / "good.json"
+            target.write_text('{"a": 1}', encoding="utf-8")
+            response = apply_json_target(
+                target, [{"op": "set", "path": "a", "value": 2}]
+            )
+        self.assertTrue(response.success)
+        self.assertEqual("SER_APPLY_OK", response.code)
+        self.assertEqual(1, response.data["applied"])
+
+    def test_propagate_dry_run_failure_short_circuits_with_apply_flags(
+        self,
+    ) -> None:
+        from prefab_sentinel.contracts import error_response  # noqa: PLC0415
+
+        upstream = error_response(
+            "SER_PLAN_INVALID",
+            "schema validation failed",
+            data={"target": "x", "op_count": 0},
+        )
+        propagated = propagate_dry_run_failure(
+            "x", [{"op": "set"}], upstream
+        )
+        self.assertFalse(propagated.success)
+        self.assertEqual("SER_PLAN_INVALID", propagated.code)
+        self.assertEqual(0, propagated.data["applied"])
+        self.assertFalse(propagated.data["read_only"])
+        self.assertFalse(propagated.data["executed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1782,6 +1782,8 @@ PrefabInstance:
                 "read_only": True,
                 "overrides": [
                     {
+                        "kind": "array_size",
+                        "target_key": f"{BASE_GUID}:100100000",
                         "line": 8,
                         "target_file_id": "100100000",
                         "target_guid": BASE_GUID,
@@ -1790,6 +1792,8 @@ PrefabInstance:
                         "object_reference": "{fileID: 0}",
                     },
                     {
+                        "kind": "array_data",
+                        "target_key": f"{BASE_GUID}:100100000",
                         "line": 12,
                         "target_file_id": "100100000",
                         "target_guid": BASE_GUID,
@@ -1798,6 +1802,8 @@ PrefabInstance:
                         "object_reference": "{fileID: 0}",
                     },
                     {
+                        "kind": "value",
+                        "target_key": f"{BASE_GUID}:100100000",
                         "line": 16,
                         "target_file_id": "100100000",
                         "target_guid": BASE_GUID,
@@ -1806,6 +1812,8 @@ PrefabInstance:
                         "object_reference": "{fileID: 0}",
                     },
                     {
+                        "kind": "value",
+                        "target_key": f"{BASE_GUID}:100100000",
                         "line": 20,
                         "target_file_id": "100100000",
                         "target_guid": BASE_GUID,
@@ -1814,6 +1822,8 @@ PrefabInstance:
                         "object_reference": "{fileID: 0}",
                     },
                     {
+                        "kind": "value",
+                        "target_key": f"{MISSING_GUID}:100100000",
                         "line": 24,
                         "target_file_id": "100100000",
                         "target_guid": MISSING_GUID,

--- a/tests/test_services_runtime_validation.py
+++ b/tests/test_services_runtime_validation.py
@@ -103,11 +103,19 @@ class ClassificationSeverityBoundaryTests(unittest.TestCase):
     downgrade boundary, using the structured-envelope helper for failure
     envelopes and full-payload equality for success envelopes.
 
+    Issue #183 consolidation: this class is the single canonical home
+    for all severity-band rows.  Each per-category severity-band
+    scenario, the info no-match rollup, the mixed-band rollup, the
+    truncation cap, the four assertion-stage outcomes, and the clean
+    classification all live here.  Sibling classes that previously
+    duplicated these rows have been removed.
+
     Spec rows: one row per documented log category (BROKEN_PPTR,
     UDON_NULLREF, VARIANT_OVERRIDE_MISMATCH, DUPLICATE_EVENTSYSTEM,
-    MISSING_COMPONENT), one no-match rollup row, and four assertion-stage
-    rows (critical present / error only / warning disallowed / warning
-    allowed).
+    MISSING_COMPONENT), one no-match rollup row, the mixed-band rollup
+    row, the truncation row, four assertion-stage rows (critical
+    present / error only / warning disallowed / warning allowed), and
+    the clean-classification row.
     """
 
     # --- classify_errors per-category severity boundaries ----------
@@ -371,59 +379,7 @@ class ClassificationSeverityBoundaryTests(unittest.TestCase):
             outcome.data,
         )
 
-
-class RuntimeClassificationSeverityBandTests(unittest.TestCase):
-    """C1 — pin the four severity bands (critical / error / warning / info)
-    by value plus the corresponding per-category count by value.
-
-    Issue #145: every distinct severity band must produce a deterministic
-    severity value and a deterministic per-category count so a downgrade
-    mutation (e.g. CRITICAL -> ERROR) fails an equality assertion.
-    """
-
-    def test_critical_band_pins_severity_and_udon_nullref_count(self) -> None:
-        svc = RuntimeValidationService()
-        resp = svc.classify_errors(
-            ["NullReferenceException in UdonBehaviour.MyEvent"],
-        )
-        self.assertEqual(Severity.CRITICAL, resp.severity)
-        self.assertEqual(1, resp.data["count_by_category"]["UDON_NULLREF"])
-        self.assertEqual(1, resp.data["categories_by_severity"]["critical"])
-
-    def test_error_band_pins_severity_and_broken_pptr_count(self) -> None:
-        svc = RuntimeValidationService()
-        resp = svc.classify_errors(["Broken PPtr in file Foo"])
-        self.assertEqual(Severity.ERROR, resp.severity)
-        self.assertEqual(1, resp.data["count_by_category"]["BROKEN_PPTR"])
-        self.assertEqual(1, resp.data["categories_by_severity"]["error"])
-
-    def test_warning_band_pins_severity_and_eventsystem_count(self) -> None:
-        svc = RuntimeValidationService()
-        resp = svc.classify_errors(
-            ["There can be only one active EventSystem in the scene"],
-        )
-        self.assertEqual(Severity.WARNING, resp.severity)
-        self.assertEqual(
-            1, resp.data["count_by_category"]["DUPLICATE_EVENTSYSTEM"]
-        )
-        self.assertEqual(
-            1, resp.data["categories_by_severity"]["warning"]
-        )
-
-    def test_info_band_pins_severity_and_zero_total_for_unmatched_input(self) -> None:
-        """Issue #160 documents this row: unmatched input rolls up to
-        the informational band with ``count_total == 0`` because the
-        info band has no associated log pattern."""
-        svc = RuntimeValidationService()
-        resp = svc.classify_errors(["unrelated runtime log line"])
-        # No pattern matches; severity rolls up to INFO and count_total = 0.
-        self.assertEqual(Severity.INFO, resp.severity)
-        self.assertEqual(0, resp.data["count_total"])
-        self.assertEqual({}, resp.data["count_by_category"])
-        # No category was incremented in any band.
-        self.assertEqual(0, resp.data["categories_by_severity"]["critical"])
-        self.assertEqual(0, resp.data["categories_by_severity"]["error"])
-        self.assertEqual(0, resp.data["categories_by_severity"]["warning"])
+    # --- mixed-band, truncation, clean rows (issue #183 consolidation) ---
 
     def test_mixed_band_rolls_up_to_maximum_severity(self) -> None:
         """Issue #145 mixed-band row: when a single log buffer contains
@@ -445,7 +401,6 @@ class RuntimeClassificationSeverityBandTests(unittest.TestCase):
         self.assertEqual(1, resp.data["categories_by_severity"]["critical"])
         self.assertEqual(2, resp.data["categories_by_severity"]["error"])
         self.assertEqual(1, resp.data["categories_by_severity"]["warning"])
-        # ``count_by_category`` carries each pattern's hits.
         self.assertEqual(2, resp.data["count_by_category"]["BROKEN_PPTR"])
         self.assertEqual(1, resp.data["count_by_category"]["UDON_NULLREF"])
         self.assertEqual(1, resp.data["count_by_category"]["DUPLICATE_EVENTSYSTEM"])
@@ -465,100 +420,21 @@ class RuntimeClassificationSeverityBandTests(unittest.TestCase):
         self.assertEqual(3, resp.data["returned_diagnostics"])
         self.assertEqual(4, resp.data["truncated_diagnostics"])
 
+    def test_assert_clean_classification_returns_run_assert_ok(self) -> None:
+        """Clean (no-hit) classification returns ``RUN_ASSERT_OK`` with
+        all per-band counters at zero."""
+        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
+            assert_no_critical_errors,
+        )
 
-class RuntimeAssertNoCriticalErrorsTests(unittest.TestCase):
-    """Issue #145 — pin every outcome of
-    ``assert_no_critical_errors`` by code, severity, and exact
-    per-band counts."""
-
-    def _classify(
-        self,
-        log_lines: list[str],
-    ) -> object:
         svc = RuntimeValidationService()
-        return svc.classify_errors(log_lines)
-
-    def test_clean_classification_returns_run_assert_ok(self) -> None:
-        """No hits returns ``RUN_ASSERT_OK`` with all bands at zero."""
-        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
-            assert_no_critical_errors,
-        )
-
-        classification = self._classify([])
+        classification = svc.classify_errors([])
         outcome = assert_no_critical_errors(classification)
         self.assertTrue(outcome.success)
         self.assertEqual("RUN_ASSERT_OK", outcome.code)
         self.assertEqual(0, outcome.data["critical_count"])
         self.assertEqual(0, outcome.data["error_count"])
         self.assertEqual(0, outcome.data["warning_count"])
-
-    def test_warnings_not_allowed_returns_run_warnings(self) -> None:
-        """A warning hit with ``allow_warnings=False`` returns
-        ``RUN_WARNINGS`` at ``severity=warning`` and the warning
-        counter at one."""
-        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
-            assert_no_critical_errors,
-        )
-        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
-
-        classification = self._classify(
-            ["There can be only one active EventSystem in the scene"]
-        )
-        outcome = assert_no_critical_errors(classification, allow_warnings=False)
-        assert_error_envelope(outcome, code="RUN_WARNINGS", severity="warning")
-        self.assertEqual(0, outcome.data["critical_count"])
-        self.assertEqual(0, outcome.data["error_count"])
-        self.assertEqual(1, outcome.data["warning_count"])
-        self.assertFalse(outcome.data["allow_warnings"])
-
-    def test_warnings_allowed_returns_run_assert_ok(self) -> None:
-        """A warning hit with ``allow_warnings=True`` returns
-        ``RUN_ASSERT_OK`` and the warning counter still at one (the
-        assertion bypass does not silence the count)."""
-        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
-            assert_no_critical_errors,
-        )
-
-        classification = self._classify(
-            ["There can be only one active EventSystem in the scene"]
-        )
-        outcome = assert_no_critical_errors(classification, allow_warnings=True)
-        self.assertTrue(outcome.success)
-        self.assertEqual("RUN_ASSERT_OK", outcome.code)
-        self.assertEqual(1, outcome.data["warning_count"])
-        self.assertTrue(outcome.data["allow_warnings"])
-
-    def test_error_band_returns_run001_at_severity_error(self) -> None:
-        """An error hit (no critical) returns ``RUN001`` at
-        ``severity=error`` with the error counter at one."""
-        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
-            assert_no_critical_errors,
-        )
-        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
-
-        classification = self._classify(["Broken PPtr in file Foo"])
-        outcome = assert_no_critical_errors(classification)
-        assert_error_envelope(outcome, code="RUN001", severity="error")
-        self.assertEqual(0, outcome.data["critical_count"])
-        self.assertEqual(1, outcome.data["error_count"])
-        self.assertEqual(0, outcome.data["warning_count"])
-
-    def test_critical_band_returns_run001_at_severity_critical(self) -> None:
-        """A critical hit returns ``RUN001`` at ``severity=critical``
-        with the critical counter at one (the highest failing band
-        wins the severity assignment)."""
-        from prefab_sentinel.services.runtime_validation.classification import (  # noqa: PLC0415
-            assert_no_critical_errors,
-        )
-        from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
-
-        classification = self._classify(
-            ["NullReferenceException in UdonBehaviour.MyEvent"]
-        )
-        outcome = assert_no_critical_errors(classification)
-        assert_error_envelope(outcome, code="RUN001", severity="critical")
-        self.assertEqual(1, outcome.data["critical_count"])
-        self.assertEqual(0, outcome.data["error_count"])
 
 
 def _make_project_root(base: Path, name: str = "projA") -> Path:


### PR DESCRIPTION
## Summary

Implement the following 12 GitHub issues from the `tyunta/prefab-sentinel` repository in a single run. For each issue, read the full body via `gh issue view <number> --repo tyunta/prefab-sentinel` (title alone is insufficient) and satisfy its acceptance criteria.

## Target issues

1. **#172** — `list_overrides` response missing spec-described `kind` / `target_key`. **Decision: Approach B** — modify the implementation to add a `kind` discriminant field and `target_key` to the response (this is an API change). Do NOT take Approach A (modifying spec prose to match current implementation).

2. **#161** — D3 snapshot test file placement diverges from spec File Structure. **Decision delegated to Plan**: Plan agent decides whether to move tests to match the spec's File Structure or to update the spec to match the actual placement, based on existing test placement conventions and structural soundness. Document the rationale in the spec.

3. **#162** — `_assert_snapshot` `regenerate=True` path is not exercised in CI. Add coverage for the regenerate path.

4. **#174** — Stale `mutants/` directory residue after mutmut runs interferes with pytest collection. Fix the operational issue.

5. **#182** — Add equivalent-mutation patterns to `[tool.mutmut].do_not_mutate` in `pyproject.toml`.

6. **#181** — Fill the two coverage gap blocks in `prefab_sentinel/services/reference_resolver.py`.

7. **#168** — Add direct tests for `orchestrator_postcondition` to resolve branch coverage 100% / mutation 35% gap.

8. **#183** — Consolidate `RuntimeClassificationSeverityBandTests` and `RuntimeAssertNoCriticalErrorsTests` into `ClassificationSeverityBoundaryTests`.

9. **#169** — Add a mutmut score aggregation report script.

10. **#179** — Add boundary-value mutation kills for default parameter values (cross-cutting but limited to default-parameter boundary scope).

11. **#151** — Raise coverage for `serialized_object.scene_*` and `asset_create_writers` modules currently in the 50–60% range.

12. **#158** — Strengthen asserts for mid-tier survived mutmut modules (P2 cross-cutting). **Scope adjustment**: explicitly exclude `serialized_object` modules from #158's scope to avoid overlap with #151. Document in the spec that #158 covers mid-tier survived modules other than `serialized_object.*` (which is handled by #151).

## Constraints

- All 12 issues run in a single run; design the work so file-level edits do not collide between issues.
- For #158, scope must be adjusted so it does not overlap with #151's `serialized_object.scene_*` / `asset_create_writers` work.
- Follow the project's existing testing conventions (mutmut, `tests._assertion_helpers.assert_error_envelope`, etc.) as defined in `CLAUDE.md` and `README.md`.

## Open Questions

- For #158's "mid-tier survived modules" scope: which specific modules constitute the mid-tier survived set after excluding `serialized_object.*`? Plan should determine this by inspecting current mutmut survived results or the issue body's enumeration.

## Execution Report

Workflow `superpowers-full` completed successfully.