### PR TITLE
fix(test): unblock mutmut full run after PR #189 regressions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.159",
+  "version": "0.5.160",
   "description": "Unity Prefab/Scene/Asset の検査・編集・参照修復ツール",
   "author": {
     "name": "tyunta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.159"
+version = "0.5.160"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "tools/unity" = "prefab_sentinel/_bridge_files"
 
 [tool.bumpversion]
-current_version = "0.5.159"
+current_version = "0.5.160"
 commit = false
 tag = false
 allow_dirty = true

--- a/tests/test_mutmut_config.py
+++ b/tests/test_mutmut_config.py
@@ -37,6 +37,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
 GITIGNORE_PATH = PROJECT_ROOT / ".gitignore"
@@ -198,12 +200,20 @@ class MutmutConfigShapeTests(unittest.TestCase):
         )
 
 
+@pytest.mark.source_text_invariant
 class QuarterlyTemplateTests(unittest.TestCase):
     """Issue #170 / #149 — the quarterly mutation-report template exists at
     the documented path and exposes the two structural sections the
     audited cadence relies on.  The README mutation operational-cadence
     subsection cross-references the template so a reader can land on the
     quarterly artefact directly from the operational documentation.
+
+    Marked ``source_text_invariant`` because the assertions read
+    ``docs/quarterly_mutmut_report_template.md`` and ``README.md`` from
+    the repository tree — neither is part of the mutmut ``also_copy``
+    surface (which is restricted to importable Python sources), so the
+    class contributes no mutant-detection signal and would otherwise
+    fail collection inside the ``mutants/`` working tree.
     """
 
     def test_quarterly_template_exists_and_has_suppression_impact_section(
@@ -352,6 +362,14 @@ class MutmutSanityInvocationTests(unittest.TestCase):
         # the surface that matters.
         if os.environ.get("MUTANT_UNDER_TEST"):
             self.skipTest("running inside mutmut; subprocess invocation would recurse")
+        # mutmut's clean-test phase invokes pytest from inside the
+        # ``mutants/`` working tree without ``MUTANT_UNDER_TEST`` set.
+        # Detect that case by checking whether this test file is
+        # itself resident inside a ``mutants/`` directory: if so, we
+        # are being collected by the outer mutmut session and the
+        # subprocess would spawn a nested ``mutants/mutants/`` tree.
+        if "mutants" in PROJECT_ROOT.parts:
+            self.skipTest("collected from inside mutants/; subprocess invocation would recurse")
         # Likewise, if the unit suite is being run by ``mutmut run``
         # from outside this test file — i.e. the working tree already
         # contains a ``mutants/`` artifact directory whose mutated

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.159";
+        public const string BridgeVersion = "0.5.160";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118: ``run_script`` and ``editor_recompile_and_wait``

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.159"
+version = "0.5.160"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

PR #189 で追加された 2 つの新規テストが `uv run mutmut run --max-children 180` のフル走行をブロックしていたため、最小修正で解消する。

- `QuarterlyTemplateTests` を `source_text_invariant` でマーク。`docs/quarterly_mutmut_report_template.md` と `README.md` は mutmut の `also_copy` に含まれない (Python source のみコピー対象)、`mutants/` 内では FileNotFoundError でクラッシュしていた。
- `MutmutSanityInvocationTests::test_single_module_invocation_*` の skip 条件を追加。`PROJECT_ROOT/mutants` チェックは PROJECT_ROOT 自体が `mutants/` に解決されるケース (mutmut clean-test 経路) を検出できず、subprocess `mutmut run` が `mutants/mutants/` を作って再帰し 300 秒タイムアウトしていた。`PROJECT_ROOT.parts` に `"mutants"` が含まれるかでガード。

## 検証

- `uv run pytest tests/test_mutmut_config.py` — 15 passed, 1 skipped
- `uv run mutmut run --max-children 180` — clean test 通過、22737 mutations 完走 (post-PR #189 で初めて成功)

## Test plan

- [x] 通常 pytest で `test_mutmut_config.py` 全 16 ケース pass
- [x] mutmut フル走行が clean test phase を通過
- [x] mutmut score report が監査対象 6 モジュール全て出力可能