### PR TITLE
fix: use github plugin source in marketplace.json (#1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
       "name": "prefab-sentinel",
       "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
       "source": {
-        "source": "local",
-        "path": "./"
+        "source": "github",
+        "repo": "tyunta/prefab-sentinel"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.197",
+  "version": "0.5.198",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.197",
+  "version": "0.5.198",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.197"
+version = "0.5.198"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.5.197"
+current_version = "0.5.198"
 commit = false
 tag = false
 allow_dirty = true

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.197";
+        public const string BridgeVersion = "0.5.198";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118 / #225: ``run_script``, ``editor_recompile_and_wait``,

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.197"
+version = "0.5.198"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 背景

issue #1: MarketPlace からの install が次のエラーで失敗する。

> Failed to install: This plugin uses a source type your Claude Code version does not support. Update Claude Code and try again.

## 根本原因

`.claude-plugin/marketplace.json` の plugin entry が未対応の source 指定を使っていた:

```json
"source": { "source": "local", "path": "./" }
```

Claude Code の marketplace スキーマに `local` という source type は存在しない（有効なのは 相対パス文字列 / `github` / `url` / `git-subdir` / `npm` の5種）。未対応 type のため install が弾かれていた。「Claude Code を更新しろ」は誤誘導で、`local` はどの版にも無いため更新では直らない。

## 修正

`github` source へ切り替え:

```json
"source": { "source": "github", "repo": "tyunta/prefab-sentinel" }
```

`github` source は git 経由・直 URL 経由どちらの marketplace 配布でも機能する。

## 検証

- marketplace.json の JSON 妥当性を確認。
- 実 install 確認は merge 後、`/plugin marketplace add tyunta/prefab-sentinel` → `/plugin install prefab-sentinel@tyunta-prefab-sentinel` で行う。`github` source は GitHub からリポジトリを取得するため、merge して default ブランチに入ってからでないと正しくテストできない。

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)