### PR TITLE
fix: use relative-path plugin source in marketplace.json (#1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,7 @@
     {
       "name": "prefab-sentinel",
       "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
-      "source": {
-        "source": "github",
-        "repo": "tyunta/prefab-sentinel"
-      },
+      "source": "./",
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.198",
+  "version": "0.5.199",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.198",
+  "version": "0.5.199",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.198"
+version = "0.5.199"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.5.198"
+current_version = "0.5.199"
 commit = false
 tag = false
 allow_dirty = true

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.198";
+        public const string BridgeVersion = "0.5.199";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118 / #225: ``run_script``, ``editor_recompile_and_wait``,

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.198"
+version = "0.5.199"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 背景

issue #1 の再修正。前回 PR #2 で `github` source に切り替えたが、install 時に別エラーが出た:

> No ED25519 host key is known for github.com and you have requested strict checking. Host key verification failed.

## 根本原因

Claude Code の `github` source はプラグイン本体を SSH（`git@github.com:...`）で別途 clone する。SSH 鍵を GitHub に登録していないマシンでは clone できない。`known_hosts` を直しても、SSH 鍵が無い環境では public リポジトリでも `Permission denied (publickey)` で失敗する。

## 修正

プラグイン本体と marketplace.json は同一リポジトリにあるため、正準形である相対パスに切り替える:

```json
"source": "./"
```

相対パスはプラグインを「既に clone 済みの marketplace リポジトリ」内から解決するため、2回目の clone も SSH も発生しない。鍵セットアップ無しで install できる。

`github` source との比較で、同一リポジトリ構成では相対パスが doc 推奨の正準形（別 clone なし）。`github` source の利点（独立 ref/sha ピン留め・raw-URL 配布耐性・別リポジトリ対応）は現構成では発火しない。

## 検証

- marketplace.json の JSON 妥当性を確認。
- 実 install 確認は merge 後、`/plugin marketplace add tyunta/prefab-sentinel` → `/plugin install prefab-sentinel@tyunta-prefab-sentinel`。相対パスは marketplace を Git 経由で追加した場合に機能する（本リポジトリは GitHub リポジトリとして追加されるため該当）。

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)