### PR TITLE
test: pin marketplace plugin source to relative-path string (#1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.199",
+  "version": "0.5.200",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.199",
+  "version": "0.5.200",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.199"
+version = "0.5.200"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.5.199"
+current_version = "0.5.200"
 commit = false
 tag = false
 allow_dirty = true

--- a/tests/test_marketplace_schema.py
+++ b/tests/test_marketplace_schema.py
@@ -1,13 +1,18 @@
-"""Schema pin for the cross-tool marketplace catalog (issue #339).
+"""Schema pin for the cross-tool marketplace catalog (issue #339, #1).
 
-The marketplace catalog must satisfy both installer toolchains: it
-carries Codex-shaped fields (object-form ``source``, ``policy``,
-``category``) for the Codex CLI installer and preserves the Claude
-Code-required identity (``name`` / ``owner``) plus per-plugin
-``name`` / ``description`` for the Claude Code installer. The
-``interface.displayName`` field lives at the marketplace root, not
-inside any ``plugins[]`` entry — premature relocation would couple
-display-name authoring to per-plugin schema.
+The marketplace catalog must satisfy both installer toolchains. The
+plugin ``source`` uses the relative-path string form (``"./"``):
+Claude Code's marketplace schema has no ``local`` source type and
+rejects the object form ``{"source": "local", ...}`` at install
+("source type your Claude Code version does not support" — issue #1),
+while Codex CLI accepts the string shorthand as well — so the string
+satisfies both installers where the object form satisfied only Codex.
+The catalog still carries ``policy`` and ``category`` for the Codex CLI
+installer and preserves the Claude Code-required identity (``name`` /
+``owner``) plus per-plugin ``name`` / ``description`` for the Claude
+Code installer. The ``interface.displayName`` field lives at the
+marketplace root, not inside any ``plugins[]`` entry — premature
+relocation would couple display-name authoring to per-plugin schema.
 """
 
 from __future__ import annotations
@@ -55,15 +60,18 @@ class TestMarketplaceCatalogSchema(unittest.TestCase):
                 f"marketplace root per issue #339.",
             )
 
-    def test_plugin_source_is_object_with_local_discriminator(self) -> None:
+    def test_plugin_source_is_relative_path_string(self) -> None:
         catalog = self._load_catalog()
         entry = catalog["plugins"][0]
         source = entry["source"]
-        # Object-form source per the Codex schema; ``source`` is the
-        # discriminator key and ``path`` is the repo-relative location.
-        self.assertIsInstance(source, dict)
-        self.assertEqual("local", source["source"])
-        self.assertEqual("./", source["path"])
+        # Cross-tool relative-path form. Claude Code's marketplace schema
+        # has no ``local`` source type and rejects the object form
+        # ``{"source": "local", ...}`` at install (issue #1); it requires
+        # the string shorthand starting with ``./``. Codex CLI accepts
+        # the same string shorthand, so the string satisfies both
+        # installers. The plugin and the marketplace share one repo, so
+        # ``"./"`` resolves the plugin from the marketplace root.
+        self.assertEqual("./", source)
 
     def test_plugin_policy_carries_installation_and_authentication(self) -> None:
         catalog = self._load_catalog()

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.199";
+        public const string BridgeVersion = "0.5.200";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118 / #225: ``run_script``, ``editor_recompile_and_wait``,

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.199"
+version = "0.5.200"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 背景

main の CI が PR #2 / PR #3 で2回連続 red になっていた。失敗は1件:

```
test_marketplace_schema.py::test_plugin_source_is_object_with_local_discriminator
AssertionError: './' is not an instance of <class 'dict'>
```

## 根本原因

`test_marketplace_schema` は plugin source を object 形式 `{"source":"local","path":"./"}` に pin していた。だが Claude Code の marketplace スキーマに `local` source type は存在せず、この object 形式は install 時に拒否される（= issue #1 の症状そのもの）。テストは Claude Code installer が受理できない値を固定していた。

issue #1 修正で marketplace.json を正しい `"./"` に直した瞬間、テストが red 化した。pre-commit hook は `ruff` のみでテストを走らせないため commit 時に検出できなかった。

## 修正

Codex CLI は `"./"` 文字列 shorthand も受理する（[Codex Build plugins doc](https://developers.openai.com/codex/plugins/build)）。よって相対パス文字列 `"./"` は Claude Code・Codex 両 installer を満たす。アサーションと docstring を文字列形式に更新。

## 検証

- `uv run pytest tests/test_marketplace_schema.py tests/test_codex_plugin_manifest.py` → 11 passed。
- CI green を確認してから merge する（PR #2/#3 で CI 未確認 merge を繰り返した反省）。

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)