### PR TITLE
docs: correct Codex CLI plugin install commands in README (#1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.200",
+  "version": "0.5.201",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.200",
+  "version": "0.5.201",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ read-only 経路（`validate_refs` / `inspect_*` / `find_*` 等）は Unity を�
 /plugin install prefab-sentinel@tyunta-prefab-sentinel
 ```
 
-**Codex CLI**（シェルで実行）:
+**Codex CLI**（Codex CLI 内に入力するスラッシュコマンド）:
 
-```bash
-codex plugin marketplace add tyunta/prefab-sentinel
-codex plugin install prefab-sentinel@tyunta-prefab-sentinel
+```text
+/plugin marketplace add tyunta/prefab-sentinel
+/plugin install prefab-sentinel@tyunta-prefab-sentinel
 ```
 
 導入後、MCP クライアントから `activate_project(scope=..., project_root=...)` で scope と Unity プロジェクトルートを宣言し、`validate_refs(scope="Assets/...")` を呼ぶと broken GUID / fileID が JSON で返る。
@@ -67,7 +67,7 @@ MCP サーバーは Plugin 内部で `uv` / `uvx` 経由でローカル起動さ
 
 ### Codex CLI Plugin
 
-[Quickstart](#quickstart) の 2 コマンドで導入する。MCP サーバーは Plugin 定義（`.codex-plugin/plugin.json`）の `mcpServers` エントリから自動登録され、skill bundle も同時に展開される。Plugin を更新したら Codex CLI セッションを再起動する。登録解除は `codex plugin uninstall prefab-sentinel@tyunta-prefab-sentinel`。
+[Quickstart](#quickstart) の 2 コマンドで導入する。MCP サーバーは Plugin 定義（`.codex-plugin/plugin.json`）の `mcpServers` エントリから自動登録され、skill bundle も同時に展開される。Plugin を更新したら Codex CLI セッションを再起動する。登録解除は Codex CLI 内のスラッシュコマンド `/plugin uninstall prefab-sentinel@tyunta-prefab-sentinel`。
 
 ### スキル
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.200"
+version = "0.5.201"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.5.200"
+current_version = "0.5.201"
 commit = false
 tag = false
 allow_dirty = true

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.200";
+        public const string BridgeVersion = "0.5.201";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118 / #225: ``run_script``, ``editor_recompile_and_wait``,

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.200"
+version = "0.5.201"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 背景

issue #1 の検証中、Codex CLI の install 手順が誤っていることが判明した。README は次を案内していた:

```bash
codex plugin marketplace add tyunta/prefab-sentinel
codex plugin install prefab-sentinel@tyunta-prefab-sentinel
```

実際の `codex plugin --help` では `codex plugin` 配下は `marketplace` と `help` のみで、`install` / `uninstall` サブコマンドは存在しない:

```
error: unrecognized subcommand 'install'
```

## 修正

Codex CLI のプラグイン install は、Claude Code と同じく**ホストセッション内に入力する `/plugin` スラッシュコマンド**で行う:

- Quickstart の Codex 節: シェル実行 `codex plugin ...` → Codex CLI 内のスラッシュコマンド `/plugin marketplace add` + `/plugin install`。ラベルとコードフェンス（`bash`→`text`）も更新。
- Codex CLI Plugin 節: 登録解除 `codex plugin uninstall ...` → `/plugin uninstall ...`。

両ホストでコマンドが同一形式になる。

## 検証

- `codex plugin --help` 出力で `install` 非存在を確認済み。
- リポジトリ全体を grep し、stale な `codex plugin install/uninstall` 記述は README の2箇所のみ（両方修正）。

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)