### PR TITLE
feat: add Codex marketplace catalog at .agents/plugins/ (#1)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "tyunta-prefab-sentinel",
+  "owner": {
+    "name": "tyunta"
+  },
+  "interface": {
+    "displayName": "Prefab Sentinel"
+  },
+  "plugins": [
+    {
+      "name": "prefab-sentinel",
+      "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tyunta/prefab-sentinel.git"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.201",
+  "version": "0.5.202",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.201",
+  "version": "0.5.202",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.201"
+version = "0.5.202"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.5.201"
+current_version = "0.5.202"
 commit = false
 tag = false
 allow_dirty = true

--- a/tests/test_marketplace_schema.py
+++ b/tests/test_marketplace_schema.py
@@ -1,22 +1,27 @@
-"""Schema pin for the cross-tool marketplace catalog (issue #339, #1).
+"""Schema pin for the cross-tool marketplace catalogs (issue #339, #1).
 
-The marketplace catalog must satisfy both installer toolchains. The
-plugin ``source`` uses the relative-path string form (``"./"``):
-Claude Code's marketplace schema has no ``local`` source type and
-rejects the object form ``{"source": "local", ...}`` at install
-("source type your Claude Code version does not support" — issue #1),
-while Codex CLI accepts the string shorthand as well — so the string
-satisfies both installers where the object form satisfied only Codex.
-The catalog still carries ``policy`` and ``category`` for the Codex CLI
-installer and preserves the Claude Code-required identity (``name`` /
-``owner``) plus per-plugin ``name`` / ``description`` for the Claude
-Code installer. The ``interface.displayName`` field lives at the
-marketplace root, not inside any ``plugins[]`` entry — premature
-relocation would couple display-name authoring to per-plugin schema.
+Two marketplace catalogs ship, one per installer toolchain, because the
+plugin sits at the repo root and the two installers need different
+``source`` forms there:
+
+- ``.claude-plugin/marketplace.json`` — Claude Code. Uses the relative
+  path ``"./"``; Claude Code resolves the plugin from the marketplace
+  clone (verified install). It has no ``local`` source type and its
+  ``github`` source clones over SSH (issue #1).
+- ``.agents/plugins/marketplace.json`` — Codex CLI, on its canonical
+  repo-scoped path. Uses the ``url`` source: a relative path resolving
+  to the repo root is rejected by Codex CLI (openai/codex#17066), so
+  the plugin is fetched as an ``https://`` repo clone whose root is the
+  plugin root.
+
+The two catalogs are otherwise identical — same identity, ``interface``,
+and per-plugin fields. ``test_catalogs_differ_only_in_plugin_source``
+guards against drift between the files.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 import unittest
 from pathlib import Path
@@ -26,15 +31,23 @@ import pytest
 pytestmark = pytest.mark.source_text_invariant
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
-_MARKETPLACE_PATH = _PROJECT_ROOT / ".claude-plugin" / "marketplace.json"
+_CLAUDE_MARKETPLACE_PATH = _PROJECT_ROOT / ".claude-plugin" / "marketplace.json"
+_CODEX_MARKETPLACE_PATH = (
+    _PROJECT_ROOT / ".agents" / "plugins" / "marketplace.json"
+)
 
 
-class TestMarketplaceCatalogSchema(unittest.TestCase):
-    """Marketplace catalog carries the Codex-shaped fields and the
-    marketplace-level ``interface.displayName``."""
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestClaudeMarketplaceCatalogSchema(unittest.TestCase):
+    """The Claude Code catalog (``.claude-plugin/marketplace.json``)
+    carries the documented fields and the marketplace-level
+    ``interface.displayName``."""
 
     def _load_catalog(self) -> dict:
-        return json.loads(_MARKETPLACE_PATH.read_text(encoding="utf-8"))
+        return _load(_CLAUDE_MARKETPLACE_PATH)
 
     def test_root_carries_marketplace_identity_and_owner(self) -> None:
         catalog = self._load_catalog()
@@ -46,8 +59,7 @@ class TestMarketplaceCatalogSchema(unittest.TestCase):
         # marketplace root, not inside any plugin entry. Pin both the
         # placement and the documented value.
         catalog = self._load_catalog()
-        interface = catalog["interface"]
-        self.assertEqual("Prefab Sentinel", interface["displayName"])
+        self.assertEqual("Prefab Sentinel", catalog["interface"]["displayName"])
 
     def test_no_plugin_entry_carries_an_interface_block(self) -> None:
         catalog = self._load_catalog()
@@ -62,38 +74,80 @@ class TestMarketplaceCatalogSchema(unittest.TestCase):
 
     def test_plugin_source_is_relative_path_string(self) -> None:
         catalog = self._load_catalog()
-        entry = catalog["plugins"][0]
-        source = entry["source"]
-        # Cross-tool relative-path form. Claude Code's marketplace schema
-        # has no ``local`` source type and rejects the object form
-        # ``{"source": "local", ...}`` at install (issue #1); it requires
-        # the string shorthand starting with ``./``. Codex CLI accepts
-        # the same string shorthand, so the string satisfies both
-        # installers. The plugin and the marketplace share one repo, so
-        # ``"./"`` resolves the plugin from the marketplace root.
+        source = catalog["plugins"][0]["source"]
+        # Claude Code resolves the plugin from the marketplace clone via
+        # the ``"./"`` relative path (verified install). The object form
+        # ``{"source": "local", ...}`` is rejected — Claude Code has no
+        # ``local`` source type (issue #1).
         self.assertEqual("./", source)
 
-    def test_plugin_policy_carries_installation_and_authentication(self) -> None:
-        catalog = self._load_catalog()
-        entry = catalog["plugins"][0]
-        policy = entry["policy"]
+    def test_plugin_policy_carries_installation_and_authentication(
+        self,
+    ) -> None:
+        policy = self._load_catalog()["plugins"][0]["policy"]
         self.assertEqual("AVAILABLE", policy["installation"])
         self.assertEqual("ON_INSTALL", policy["authentication"])
 
     def test_plugin_category_equals_coding(self) -> None:
-        catalog = self._load_catalog()
-        entry = catalog["plugins"][0]
+        entry = self._load_catalog()["plugins"][0]
         self.assertEqual("Coding", entry["category"])
 
-    def test_plugin_preserves_claude_code_identity_and_description(self) -> None:
-        catalog = self._load_catalog()
-        entry = catalog["plugins"][0]
+    def test_plugin_preserves_claude_code_identity_and_description(
+        self,
+    ) -> None:
+        entry = self._load_catalog()["plugins"][0]
         # Claude Code installer requires ``name`` and ``description``
         # on each plugin entry; their absence would break the Claude
-        # Code install path even though Codex would accept the catalog.
+        # Code install path.
         self.assertEqual("prefab-sentinel", entry["name"])
         self.assertIsInstance(entry["description"], str)
         self.assertNotEqual("", entry["description"])
+
+
+class TestCodexMarketplaceCatalogSchema(unittest.TestCase):
+    """The Codex catalog (``.agents/plugins/marketplace.json``) uses the
+    ``url`` plugin source so Codex CLI can install a repo-root plugin
+    (openai/codex#17066)."""
+
+    def _load_catalog(self) -> dict:
+        return _load(_CODEX_MARKETPLACE_PATH)
+
+    def test_codex_catalog_file_exists(self) -> None:
+        self.assertTrue(
+            _CODEX_MARKETPLACE_PATH.is_file(),
+            f"Codex marketplace catalog missing at {_CODEX_MARKETPLACE_PATH}",
+        )
+
+    def test_codex_plugin_source_is_url_to_repo_clone(self) -> None:
+        source = self._load_catalog()["plugins"][0]["source"]
+        # A relative path resolving to the repo root is rejected by
+        # Codex CLI (openai/codex#17066); the ``url`` source fetches the
+        # repo as an ``https://`` clone whose root is the plugin root.
+        self.assertEqual("url", source["source"])
+        self.assertEqual(
+            "https://github.com/tyunta/prefab-sentinel.git", source["url"]
+        )
+
+
+class TestMarketplaceCatalogDrift(unittest.TestCase):
+    """The two host catalogs must stay identical except for the
+    per-host plugin ``source`` form."""
+
+    def test_catalogs_differ_only_in_plugin_source(self) -> None:
+        claude = _load(_CLAUDE_MARKETPLACE_PATH)
+        codex = _load(_CODEX_MARKETPLACE_PATH)
+        # Drop the one intentionally per-host field, then require
+        # structural equality everywhere else.
+        claude_norm = copy.deepcopy(claude)
+        codex_norm = copy.deepcopy(codex)
+        claude_norm["plugins"][0].pop("source")
+        codex_norm["plugins"][0].pop("source")
+        self.assertEqual(
+            claude_norm,
+            codex_norm,
+            "Claude Code and Codex marketplace catalogs have drifted "
+            "in a field other than plugins[0].source.",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.201";
+        public const string BridgeVersion = "0.5.202";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118 / #225: ``run_script``, ``editor_recompile_and_wait``,

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.201"
+version = "0.5.202"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 背景

issue #1 の Codex 経路。`codex plugin marketplace add` は成功するが、Codex の install 候補にプラグインが出ない。

## 根本原因

Codex CLI は、リポジトリルートに解決される plugin source path を拒否する（[openai/codex#17066](https://github.com/openai/codex/issues/17066)、OPEN・複数ユーザーが再現）。本プラグインはリポジトリルートに置かれているため、`.claude-plugin/marketplace.json` の `"./"` source では Codex が marketplace 全体を skip し、プラグインが一覧に出ない。

Claude Code 側は `"./"` で install 成功済み（経路が異なる — `marketplace add <repo>` の生 GitHub 経路）。

## 修正

Codex の canonical な repo-scoped パス `.agents/plugins/marketplace.json` に2つ目のカタログを追加。source は `url`（`https://` でリポジトリを clone し、その clone ルート = プラグインルート）→ #17066 を回避。

- `.claude-plugin/marketplace.json` — Claude Code 用、`source: "./"`（変更なし、確認済み）
- `.agents/plugins/marketplace.json` — Codex 用（新設）、`source: url`
- 2カタログは `plugins[0].source` 以外は同一。`test_catalogs_differ_only_in_plugin_source` が drift を検出。

## 検証

- 全テストスイート: 2276 passed, 8 skipped, 0 failed。
- 両カタログの JSON 妥当性と「source 以外同一」を確認。
- Codex 実 install は merge 後、Codex で marketplace を remove → add し直して install 候補を確認（要ユーザー検証）。

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)