### PR TITLE
fix: codex plugin.json mcpServers must be a string path (#1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.202",
+  "version": "0.5.203",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -1,0 +1,10 @@
+{
+  "prefab-sentinel": {
+    "command": "uvx",
+    "args": [
+      "--from", "${CLAUDE_PLUGIN_ROOT}",
+      "--with", "mcp>=1.12",
+      "prefab-sentinel-mcp"
+    ]
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.202",
+  "version": "0.5.203",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",
@@ -10,14 +10,5 @@
   "license": "MIT",
   "keywords": ["unity", "prefab", "validation", "inspection", "reference", "patch"],
   "skills": "./skills",
-  "mcpServers": {
-    "prefab-sentinel": {
-      "command": "uvx",
-      "args": [
-        "--from", "${CLAUDE_PLUGIN_ROOT}",
-        "--with", "mcp>=1.12",
-        "prefab-sentinel-mcp"
-      ]
-    }
-  }
+  "mcpServers": "./.codex-plugin/mcp.json"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.202"
+version = "0.5.203"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.5.202"
+current_version = "0.5.203"
 commit = false
 tag = false
 allow_dirty = true

--- a/tests/test_codex_plugin_manifest.py
+++ b/tests/test_codex_plugin_manifest.py
@@ -2,9 +2,11 @@
 
 The Codex CLI install path reads ``.codex-plugin/plugin.json`` to
 provision the plugin. The manifest carries identity, canonical version,
-and the MCP server invocation block; it deliberately omits the
-``interface`` block (icon/screenshot/displayName) because issue #338
-excludes per-plugin asset authoring and issue #339 places
+and ``mcpServers`` as a *string path* to a bundled MCP config file —
+Codex's parser rejects Claude Code's inline object map there ("invalid
+type: map, expected a string", issue #1). The manifest deliberately
+omits the ``interface`` block (icon/screenshot/displayName) because
+issue #338 excludes per-plugin asset authoring and issue #339 places
 ``interface.displayName`` at the marketplace root rather than inside
 plugin manifests.
 """
@@ -47,10 +49,25 @@ class TestCodexPluginManifest(unittest.TestCase):
         manifest = self._load_manifest()
         self.assertEqual(_canonical_project_version(), manifest["version"])
 
-    def test_mcp_invocation_command_is_non_empty(self) -> None:
-        manifest = self._load_manifest()
-        servers = manifest["mcpServers"]
-        self.assertIn("prefab-sentinel", servers)
+    def test_mcp_servers_field_is_a_relative_path_string(self) -> None:
+        # Codex's manifest parser requires ``mcpServers`` to be a string
+        # path to a bundled config file. An inline object map (Claude
+        # Code's form) fails the Codex install with "invalid type: map,
+        # expected a string" (issue #1).
+        mcp_servers = self._load_manifest()["mcpServers"]
+        self.assertIsInstance(mcp_servers, str)
+        self.assertTrue(
+            mcp_servers.startswith("./"),
+            f"mcpServers path must start with './': {mcp_servers!r}",
+        )
+
+    def test_mcp_servers_file_carries_non_empty_command(self) -> None:
+        rel = self._load_manifest()["mcpServers"]
+        mcp_path = _PROJECT_ROOT / rel
+        self.assertTrue(mcp_path.is_file(), f"missing MCP config: {mcp_path}")
+        config = json.loads(mcp_path.read_text(encoding="utf-8"))
+        # Codex accepts a direct server map or a ``mcp_servers`` wrapper.
+        servers = config.get("mcp_servers", config)
         invocation = servers["prefab-sentinel"]
         command = invocation.get("command", "")
         self.assertNotEqual("", command, f"command empty: {invocation!r}")

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.202";
+        public const string BridgeVersion = "0.5.203";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118 / #225: ``run_script``, ``editor_recompile_and_wait``,

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.202"
+version = "0.5.203"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 背景

issue #1 の Codex 経路。marketplace 表示・プラグイン一覧までは通るが install が失敗。`~/.codex/log/codex-tui.log`:

```
WARN codex_core_plugins::manifest: failed to parse plugin manifest:
  invalid type: map, expected a string at line 13 column 16
  path=.../.codex-plugin/plugin.json
```

## 根本原因

`.codex-plugin/plugin.json` の13行目は `mcpServers` キー。Codex のマニフェストパーサは `mcpServers` を**文字列パス**（`skills` と同様、バンドルした構成ファイルへのプラグインルート相対パス）として期待するが、当該マニフェストは Claude Code 形式の**インラインオブジェクト map** を入れていた。`.codex-plugin/plugin.json`（issue #338 作成）は Claude Code のスキーマをコピーしたまま Codex で未検証だった。

## 修正

- `.codex-plugin/plugin.json`: `mcpServers` → 文字列 `"./.codex-plugin/mcp.json"`
- `.codex-plugin/mcp.json`（新設）: サーバー定義（uvx 起動）を Codex の direct server-map 形式で配置
- `.claude-plugin/plugin.json` のインライン `mcpServers` オブジェクトは変更なし（Claude Code 形式のまま）
- `test_codex_plugin_manifest`: 同じインラインmap前提を pin していたので、文字列パス検証＋参照ファイル検証に更新

## 検証

- 全テストスイート: 2277 passed, 8 skipped, 0 failed。
- `.codex-plugin/plugin.json` / `mcp.json` の JSON 妥当性、`mcpServers` パスが実ファイルに解決することを確認。
- Codex 実 install は merge 後に要ユーザー検証（marketplace を remove → add し直し）。

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)