### PR TITLE
fix: codex MCP uses git source; correct Codex install steps (#1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.203",
+  "version": "0.5.204",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -2,7 +2,7 @@
   "prefab-sentinel": {
     "command": "uvx",
     "args": [
-      "--from", "${CLAUDE_PLUGIN_ROOT}",
+      "--from", "git+https://github.com/tyunta/prefab-sentinel.git",
       "--with", "mcp>=1.12",
       "prefab-sentinel-mcp"
     ]

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.5.203",
+  "version": "0.5.204",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ read-only 経路（`validate_refs` / `inspect_*` / `find_*` 等）は Unity を�
 
 ## Quickstart
 
-プラグインとして導入する。ホスト（Claude Code / Codex CLI）に応じて 2 つの経路がある。インストールは marketplace から取得し、導入後の MCP サーバーは実行時にネットワーク通信せずローカルで完結する。
+プラグインとして導入する。ホスト（Claude Code / Codex CLI）に応じて 2 つの経路があり、いずれも marketplace から取得する。
 
 **Claude Code**（Claude Code 内に入力するスラッシュコマンド）:
 
@@ -40,12 +40,13 @@ read-only 経路（`validate_refs` / `inspect_*` / `find_*` 等）は Unity を�
 /plugin install prefab-sentinel@tyunta-prefab-sentinel
 ```
 
-**Codex CLI**（Codex CLI 内に入力するスラッシュコマンド）:
+**Codex CLI**（シェルで marketplace を登録 → Codex CLI 内の `/plugins` TUI で有効化）:
 
-```text
-/plugin marketplace add tyunta/prefab-sentinel
-/plugin install prefab-sentinel@tyunta-prefab-sentinel
+```bash
+codex plugin marketplace add tyunta/prefab-sentinel
 ```
+
+登録後、Codex CLI 内で `/plugins` を開き、一覧から `prefab-sentinel` を選んで Install する（`codex plugin install` というシェルコマンドは存在しない）。
 
 導入後、MCP クライアントから `activate_project(scope=..., project_root=...)` で scope と Unity プロジェクトルートを宣言し、`validate_refs(scope="Assets/...")` を呼ぶと broken GUID / fileID が JSON で返る。
 
@@ -67,7 +68,7 @@ MCP サーバーは Plugin 内部で `uv` / `uvx` 経由でローカル起動さ
 
 ### Codex CLI Plugin
 
-[Quickstart](#quickstart) の 2 コマンドで導入する。MCP サーバーは Plugin 定義（`.codex-plugin/plugin.json`）の `mcpServers` エントリから自動登録され、skill bundle も同時に展開される。Plugin を更新したら Codex CLI セッションを再起動する。登録解除は Codex CLI 内のスラッシュコマンド `/plugin uninstall prefab-sentinel@tyunta-prefab-sentinel`。
+[Quickstart](#quickstart) の手順で導入する（シェルで `codex plugin marketplace add` → Codex CLI 内の `/plugins` TUI で `prefab-sentinel` を Install）。MCP サーバーは Plugin 定義（`.codex-plugin/plugin.json` の `mcpServers` が指す `.codex-plugin/mcp.json`）から登録され、skill bundle も同時に展開される。Codex の MCP サーバーは `uvx` が GitHub から本体を取得して起動するため、起動時にネットワーク接続が必要（Claude Code 経路はローカル導入物から起動する）。Plugin を更新したら Codex CLI セッションを再起動する。無効化・登録解除は `/plugins` TUI から行う。
 
 ### スキル
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.5.203"
+version = "0.5.204"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.5.203"
+current_version = "0.5.204"
 commit = false
 tag = false
 allow_dirty = true

--- a/tests/test_codex_plugin_manifest.py
+++ b/tests/test_codex_plugin_manifest.py
@@ -71,6 +71,18 @@ class TestCodexPluginManifest(unittest.TestCase):
         invocation = servers["prefab-sentinel"]
         command = invocation.get("command", "")
         self.assertNotEqual("", command, f"command empty: {invocation!r}")
+        # Codex launches a plugin MCP server with the workspace as cwd,
+        # sets no plugin-root env var, does not expand ${...} templates
+        # in .mcp.json, and does not resolve a relative command against
+        # the plugin root (all confirmed by probe, issue #1). Every arg
+        # must therefore be self-contained — no template, no path that
+        # depends on the install location.
+        for arg in invocation.get("args", []):
+            self.assertNotIn(
+                "${",
+                arg,
+                f"Codex does not expand templates in .mcp.json args: {arg!r}",
+            )
 
     def test_manifest_does_not_declare_interface_block(self) -> None:
         # Issue #338 excludes per-plugin icon/screenshot asset authoring;

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.5.203";
+        public const string BridgeVersion = "0.5.204";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issues #108 / #118 / #225: ``run_script``, ``editor_recompile_and_wait``,

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.5.203"
+version = "0.5.204"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 背景

issue #1 の Codex 経路を end-to-end で検証した結果の2点修正。

## 1. `.codex-plugin/mcp.json` の MCP 起動

診断 probe で Codex の MCP 起動環境を実測:

- CWD = ワークスペース（プラグインルートではない）
- `PLUGIN_ROOT` / `CLAUDE_PLUGIN_ROOT` / `CODEX_PLUGIN_ROOT` すべて unset
- `.mcp.json` 内で `${...}` テンプレートは展開されない
- 相対 `command` はプラグインルート基準で解決されない

→ `--from "${CLAUDE_PLUGIN_ROOT}"` は原理的に解決不可（`error: Failed to parse: ${CLAUDE_PLUGIN_ROOT}`）。プラグインのインストール場所を `.mcp.json` から知る手段が存在しない。

**修正**: source を `git+https://github.com/tyunta/prefab-sentinel.git` に変更。パス・変数・CWD・env に一切依存しない自己完結指定。`uvx` が GitHub から取得して起動する。Codex で MCP サーバー起動を確認済み。`test_codex_plugin_manifest` に「MCP args に未展開 `${...}` を含まない」検証を追加。

## 2. README の Codex install 手順

`codex plugin install` は実在しないコマンド（`codex plugin` 配下は `marketplace` と `help` のみ）。install/有効化は `/plugins` TUI で行う。Quickstart と Codex CLI Plugin 節を実手順（シェルで `codex plugin marketplace add` → Codex CLI 内 `/plugins` TUI で Install）に修正。`git+https` 化で実行時にネットワーク取得が発生するため、「実行時ネットワーク通信なし」の記述も実態に合わせて修正。

## 検証

- 全テストスイート: 2277 passed, 8 skipped, 0 failed。
- `uvx --from git+https://...` で MCP handshake をローカル確認（`initialize` 応答正常）。
- Codex 実機で MCP サーバー起動を確認（ユーザー検証済み）。

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)