### PR TITLE
fix: resolve Editor Bridge C# compile drift

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.6.0"
+version = "0.6.1"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -69,7 +69,7 @@ packages = ["prefab_sentinel"]
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
 [tool.bumpversion]
-current_version = "0.6.0"
+current_version = "0.6.1"
 commit = false
 tag = false
 allow_dirty = true

--- a/tools/unity/PrefabSentinel.EditorReflectHandler.cs
+++ b/tools/unity/PrefabSentinel.EditorReflectHandler.cs
@@ -103,7 +103,7 @@ namespace PrefabSentinel
         // ── Entry Point ──
 
         public static UnityEditorControlBridge.EditorControlResponse Handle(
-            UnityEditorControlBridge.EditorControlRequest request)
+            EditorControlRequest request)
         {
             if (EditorApplication.isCompiling)
                 return UnityEditorControlBridge.BuildError(
@@ -125,7 +125,7 @@ namespace PrefabSentinel
         // ── Action Handlers ──
 
         private static UnityEditorControlBridge.EditorControlResponse HandleSearch(
-            UnityEditorControlBridge.EditorControlRequest request)
+            EditorControlRequest request)
         {
             if (string.IsNullOrEmpty(request.query))
                 return UnityEditorControlBridge.BuildError(
@@ -179,7 +179,7 @@ namespace PrefabSentinel
         }
 
         private static UnityEditorControlBridge.EditorControlResponse HandleGetType(
-            UnityEditorControlBridge.EditorControlRequest request)
+            EditorControlRequest request)
         {
             if (string.IsNullOrEmpty(request.class_name))
                 return UnityEditorControlBridge.BuildError(
@@ -216,7 +216,7 @@ namespace PrefabSentinel
         }
 
         private static UnityEditorControlBridge.EditorControlResponse HandleGetMember(
-            UnityEditorControlBridge.EditorControlRequest request)
+            EditorControlRequest request)
         {
             if (string.IsNullOrEmpty(request.class_name))
                 return UnityEditorControlBridge.BuildError(

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.MaterialQuery.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.MaterialQuery.cs
@@ -143,7 +143,7 @@ namespace PrefabSentinel
                     $"Property '{request.property_name}' not found on shader '{shader.name}'.",
                     new EditorControlData
                     {
-                        suggestions = SuggestSimilar(request.property_name, CollectShaderPropertyNames(shader)),
+                        suggestions = SuggestionRanker.SuggestSimilar(request.property_name, CollectShaderPropertyNames(shader)),
                     });
 
             return BuildSuccess("EDITOR_CTRL_GET_MATERIAL_PROPERTY_OK",

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.MaterialWrite.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.MaterialWrite.cs
@@ -173,7 +173,7 @@ namespace PrefabSentinel
                     $"Property '{propertyName}' not found on shader '{shader.name}'.",
                     new EditorControlData
                     {
-                        suggestions = SuggestSimilar(propertyName, CollectShaderPropertyNames(shader)),
+                        suggestions = SuggestionRanker.SuggestSimilar(propertyName, CollectShaderPropertyNames(shader)),
                     });
 
             var propType = shader.GetPropertyType(propIdx);

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.UdonSharpFieldWrite.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.UdonSharpFieldWrite.cs
@@ -90,7 +90,7 @@ namespace PrefabSentinel
                     new EditorControlData
                     {
                         selected_object = request.hierarchy_path,
-                        suggestions = SuggestSimilar(
+                        suggestions = SuggestionRanker.SuggestSimilar(
                             request.field_name, available, 5),
                     });
             }

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.6.0";
+        public const string BridgeVersion = "0.6.1";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issue H-8: the membership sets are owned by ``ActionRegistry`` as the

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
The Editor Bridge C# failed to compile in a fresh Unity project. Earlier
helper-extraction refactors updated most call sites but left a few
referencing the old nested type path and an unqualified helper name.

## Fixes

### CS0426 — stale nested type path (×4)
`PrefabSentinel.EditorReflectHandler.cs`:
`UnityEditorControlBridge.EditorControlRequest` → `EditorControlRequest`.
`EditorControlRequest` is now a top-level type and resolves unqualified
within `namespace PrefabSentinel`.

### CS0103 — unqualified helper call (×3)
`MaterialQuery.cs` / `MaterialWrite.cs` / `UdonSharpFieldWrite.cs`:
unqualified `SuggestSimilar(` → `SuggestionRanker.SuggestSimilar(`, the
class the helper was extracted into. The
`SuggestSimilar(string, IReadOnlyList<string>, int maxResults = 3)`
signature matches both the 2-argument and 3-argument call sites.

## Verification
- `tools/unity/*.cs` was grep-scanned for remaining stale references:
  none remain.
- Cascading errors can only be confirmed by a real Unity compile and are
  out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
