### PR TITLE
release: 0.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-21
+
+### Added
+
+- `editor_screenshot` に対象オブジェクト指定モードを追加。GameObject の hierarchy パスと角度プリセット（`front` / `three_quarter` / `back` / `right` / `left` / `top` の 6 種）を渡すと、Scene ビューで対象が画面いっぱい・中央に映る screenshot を 1 コールで取得できる。「カメラを動かして良い角度を探す」試し撮りループが不要になる。対象の transform 回転が傾いている場合（顔メッシュなど import で X 回転が掛かったオブジェクトを含む）でも、世界水平から対象の向いている方向に対して撮影される。
+
 ## [0.7.0] - 2026-05-19
 
 ### Changed

--- a/TESTING.md
+++ b/TESTING.md
@@ -268,3 +268,48 @@ Unity の `internal` メンバを参照する必要が生じた段階で初め�
 ### 安全網: 手動 deploy コンパイル確認
 
 Unity 依存 Bridge C#（`tools/unity/` の `UnityEditor` / VRChat SDK 参照ファイル）を変更したら、`deploy_bridge` で実 Unity 2022.3 + VRChat SDK プロジェクトに配置し、Unity のコンパイルがエラー 0 件であることを手動で確認する。これが現状唯一のコンパイル検証経路。pure-logic を新規抽出して Unity 非依存にできた分は xUnit ハーネス（`<Compile Include>`）へ取り込み、検証対象を段階的に CI 側へ移すことで、この未検証 surface を縮小していく。
+
+### 安全網: dev 経路での visual 検証
+
+コンパイルが 0 件でも、Unity 依存箇所の振る舞いは実機 SceneView で動かさないと確認できない（`SceneView.LookAt(instant:true)` の camera 同期挙動、`BakeMesh` の現ポーズ bounds、preset 角度の見え方など。issue #84 で実証）。リリース前に main / public mirror を待たず、dev 作業ブランチの資材だけで visual 検証する経路を残す。
+
+**前提と制約**:
+- visual 検証には **MCP plugin Python と Bridge C# が同じ commit の資材で揃っている必要**がある。bridge だけ手動配置しても plugin 側のリクエスト形が古いと検証が成立しない。
+- Claude Code / Codex CLI が起動済みの plugin プロセス（`~/.claude/plugins/cache/.../prefab-sentinel-mcp` 等）は session 開始時に固定されるため、session 内で同 plugin を最新ソースに張り替えても反映されない。`.mcp.json` を編集して再起動するか、本節の ad-hoc 経路を使う。
+
+**経路**: `uvx --from <local-path>[mcp] prefab-sentinel-mcp` で dev ソースから MCP server を一時起動し、stdio で `activate_project` → `deploy_bridge` → 検証ツールを呼ぶ Python script を走らせる。`mcp` Python SDK の `stdio_client` + `ClientSession` で実装する：
+
+```python
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+params = StdioServerParameters(
+    command="uvx",
+    args=[
+        "--from", "/mnt/d/git/prefab-sentinel-dev[mcp]",
+        "prefab-sentinel-mcp",
+    ],
+    env={**os.environ, "UNITYTOOL_BRIDGE_WATCH_DIR": "D:\\VRChatProject\\prefab-sentinel"},
+)
+async with stdio_client(params) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        await session.call_tool("activate_project", {...})
+        await session.call_tool("deploy_bridge", {})
+        await session.call_tool("<verify_tool>", {...})
+```
+
+実行は `uv run --with 'mcp>=1.12' python /tmp/verify_<topic>.py`。Claude Code 設定の永続変更も bg uvx 残置もなく完結する。
+
+**uv キャッシュの落とし穴**（astral-sh/uv#16196）:
+- `uvx --from <local-path>` のデフォルト cache key は `pyproject.toml` / `setup.py` / `setup.cfg` のみ。`tools/unity/*.cs` を編集しても **wheel が rebuild されない** ため、修正済みソースが配置されず古い bridge が deploy される事故が起こる。
+- 恒久対策として `pyproject.toml` に `[tool.uv] cache-keys` を追加し、`tools/unity/**/*.cs` / `*.asmdef` / `knowledge/**/*.md` を cache key に含めている（issue #84 修正のコミットで追加）。
+- 即時のリカバリは `uvx --reinstall --no-cache --from ...` で起動するか、`uv cache clean prefab-sentinel` でパッケージキャッシュを落としてから起動する。
+
+**Unity 側の手順**:
+1. `deploy_bridge` 直後は `Library/ScriptAssemblies/PrefabSentinel.Editor.dll` の mtime / サイズが変わっていることを確認（変化なしなら Unity がまだ import していない）。
+2. Unity Editor を**最前面に出して `Ctrl+R`** で AssetDatabase.Refresh を強制（background 化中は domain reload が保留される — グローバルメモリ `feedback-unity-background-defers-compile`）。
+3. `editor_console`（severity=error）で `CS****` が残っていないことを確認。
+4. 検証ツール（`editor_screenshot` 等）を呼んで結果を観察。screenshot は `D:\VRChatProject\<bridge-watch-dir>\screenshots\` に保存される。
+
+**bridge dispatch 経路の確認**: 新しい branch を追加した bridge handler は、応答の `message` / `code` フィールドで分岐先が確認できる。例えば issue #84 の `HandleObjectCaptureScreenshot` 成功時は `"Object-capture screenshot of '...' (angle=...)"` を返し、既存 SceneView capture 経路の `"Scene view captured to ..."` と区別できる。視覚以前に文字列で経路同定する習慣をつける。

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -101,6 +101,13 @@ wire `severity` の決定規則（issue #4）: `Diagnostic` dataclass は任意�
 | `EDITOR_CTRL_SAFE_SAVE_PREFAB_PROTECT_REQUIRED` | `editor_safe_save_prefab` の request payload に `protect_components` フィールド自体が含まれない場合（issue #193 / issue #228）。`severity="error"`。issue #228 でトリガが「リスト未指定」のみに narrow され、明示的な空リスト `[]` は raw-save mode へ向かう（rejection ではなく success path）。 |
 | `STALE_GUID_INDEX_HINT`（`Diagnostic.detail`） | `validate_refs` の missing-asset 失敗パスで、cached resolver が missing と報告した GUID のうち少なくとも 1 件が fresh meta-file scan で resolve できた場合（issue #229）。トップレベル code ではなく warning severity の `Diagnostic` として diagnostics 配列に追加される。`evidence` に stale-resolved 件数と `refresh_guid_index=True` を retry 推奨として含める。`refresh_guid_index=True` がすでにセット済みの場合・missing asset がそもそも報告されなかった場合・fresh scan も resolve できなかった場合は発火しない。 |
 | `CROP_ROI_INVALID` / `EDITOR_CTRL_CROP_ROI_INVALID` / `EDITOR_CTRL_CROP_ROI_OUT_OF_BOUNDS` / `EDITOR_CTRL_CROP_ROI_NO_TARGET` | `editor_screenshot` の `crop_roi` 検証（issue #249）。`severity="error"`。Wrapper 側は allowlist preset でも pixel quadruple でもない値を `CROP_ROI_INVALID` で pre-bridge reject。Bridge 側は同一形状違反を `_INVALID`、ピクセル範囲外を `_OUT_OF_BOUNDS`、対象 RenderTexture / Camera が存在しない場合を `_NO_TARGET` で返す。 |
+| `SCREENSHOT_VIEW_INVALID` | `editor_screenshot` の `view` セレクタが `SCREENSHOT_VIEW_ALLOWLIST`（`scene` / `game`）外の場合（issue #259）。`severity="error"`、Wrapper 側で pre-bridge reject。 |
+| `SCREENSHOT_ANGLE_INVALID` / `EDITOR_CTRL_SCREENSHOT_ANGLE_INVALID` | `editor_screenshot` の `angle` が `SCREENSHOT_ANGLE_PRESETS`（`front` / `three_quarter` / `back` / `right` / `left` / `top`）外の場合（issue #84）。`severity="error"`。Wrapper 側は `target` 非空のときのみ allowlist gate を発火（`target` 空のとき `angle` は意味を持たない）。Bridge 側は defense-in-depth ミラーで、Wrapper を経由しない経路（integration test 等）に対しても同じ拒否を行う。 |
+| `SCREENSHOT_TARGET_INVALID_VIEW` | `editor_screenshot` の object-capture モードが `view!='scene'` と組み合わされた場合（issue #84）。`severity="error"`、Wrapper 側で pre-bridge reject。object-capture は SceneView の framing 経路でしか実行できない。 |
+| `SCREENSHOT_TARGET_CROP_CONFLICT` | `editor_screenshot` の `target` 指定と face-feature `crop_roi`（`eye_left` / `eye_right` / `mouth` / `auto_face`）の同時指定（issue #84）。`severity="error"`、Wrapper 側で pre-bridge reject。両方が SceneView の再フレーミングを駆動するため拒否。`target` と pixel-rectangle `crop_roi` は許容（ピクセル切り出しは framing の後段で独立）。 |
+| `EDITOR_CTRL_SCREENSHOT_TARGET_NOT_FOUND` | `editor_screenshot` の object-capture モードで `target` の hierarchy path がアクティブな Scene / Prefab Stage に存在しなかった場合（issue #84）。`severity="error"`、Bridge 側で発火。 |
+| `EDITOR_CTRL_SCREENSHOT_TARGET_NO_RENDERERS` | `editor_screenshot` の object-capture モードで resolved subtree に active な `Renderer` / `SkinnedMeshRenderer` が 1 件もなかった場合（issue #84）。`severity="error"`、Bridge 側で発火。AABB を導けないため framing を実行しない。 |
+| `EDITOR_CTRL_SCREENSHOT_VIEW_INVALID` | `editor_screenshot` の Bridge 側 view-allowlist mirror（issue #259）。`severity="error"`。Wrapper 側 `SCREENSHOT_VIEW_INVALID` とペアで Bridge も同じ allowlist を強制し、出力 path 合成前に拒否する。 |
 | `EDITOR_CTRL_BATCH_BLEND_SHAPE_PARSE` | `editor_batch_set_blend_shape` の `shapes_json` を JSON として parse できなかった場合（issue #240）。`severity="error"`、Bridge 側で発火。 |
 | `EDITOR_CTRL_PREFAB_STAGE_NOT_FOUND` / `..._OPEN_FAILED` / `..._CLOSE_FAILED` | Prefab Stage open/close 系の Bridge 失敗（issue #236）。`severity="error"`。`_NOT_FOUND` は対象 Prefab パスが解決できない、`_OPEN_FAILED` / `_CLOSE_FAILED` は `PrefabStageUtility` 呼び出しで例外。 |
 | `REQUEST_ID_INVALID` | `editor_run_script_poll` 等の poll 系 MCP ツールが受け取った request identifier の形状違反（issue #233）。`severity="error"`、Python 入口で pre-bridge reject。期待形状は `prefab_sentinel.mcp_tools_editor_exec._build_request_id_invalid_envelope` を参照。 |
@@ -145,7 +152,7 @@ wire `severity` の決定規則（issue #4）: `Diagnostic` dataclass は任意�
 
 | モード | 入力 | 効果 |
 |--------|------|------|
-| Pivot orbit | `pivot` (+ `yaw` / `pitch` / `distance`) | pivot を中心に yaw/pitch/distance で周回。pivot 省略時は現在値を維持。 |
+| Pivot orbit | `pivot` (+ `yaw` / `pitch` / `size`) | pivot を中心に yaw/pitch/size で周回（`size` は SceneView 半幅、issue #81）。pivot 省略時は現在値を維持。 |
 | Position | `position` (+ `look_at` または `yaw`/`pitch`) | カメラ世界座標を直接指定。`look_at` で注視点モード、`yaw`/`pitch` でオイラーモード。`position` と `pivot` の同時指定は `EDITOR_CTRL_CAMERA_CONFLICT`。 |
 | Reset | `reset_to_defaults=True` | pivot=`(0,0,0)`, rotation=`Euler(30, -45, 0)`, size=10、perspective に戻す。他のパラメータは無視。 |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -105,7 +105,7 @@
 
 | ツール | 区分 | 簡潔説明 | 関連 issue | 種別 |
 |--------|------|----------|-----------|------|
-| `editor_screenshot` | editor_view | Scene / Game ビューのスクリーンショット取得。`view` allowlist / `crop_roi` preset 対応 | #249, #259 | read-only |
+| `editor_screenshot` | editor_view | Scene / Game ビューのスクリーンショット取得。`view` allowlist / `crop_roi` preset 対応。`target`（hierarchy_path）+ `angle`（`SCREENSHOT_ANGLE_PRESETS` の 6 プリセット `front` / `three_quarter` / `back` / `right` / `left` / `top`）で対象 GameObject を画面いっぱい・中央フィットに 1 コール capture できる object-capture モード（issue #84） | #249, #259, #84 | read-only |
 | `editor_force_scene_view_refresh` | editor_view | 全 SkinnedMeshRenderer の `forceMatrixRecalculationPerRender` を立てて player-loop を 1 tick 進める | #242, #268 | write |
 | `editor_select` | editor_view | Hierarchy 内の GameObject を選択（Prefab Stage 対応） | — | write |
 | `editor_frame` | editor_view | 選択オブジェクトを Scene ビューでフレーミング | — | write |

--- a/prefab_sentinel/editor_bridge_builders.py
+++ b/prefab_sentinel/editor_bridge_builders.py
@@ -16,13 +16,19 @@ def build_set_camera_kwargs(
     pivot: str = "",
     yaw: float = float("nan"),
     pitch: float = float("nan"),
-    distance: float = -1.0,
+    size: float = -1.0,
     orthographic: int = -1,
     position: str = "",
     look_at: str = "",
     reset_to_defaults: bool = False,
 ) -> dict[str, Any]:
-    """Build send_action kwargs from set_camera parameters."""
+    """Build send_action kwargs from set_camera parameters.
+
+    Issue #81: ``size`` carries ``SceneView.size`` semantics
+    (Scene-view half-width); ``-1.0`` is the "keep current" sentinel
+    and is omitted from the produced kwargs rather than forwarded
+    verbatim.
+    """
     kwargs: dict[str, Any] = {}
     if position:
         p = load_json(position)
@@ -37,8 +43,8 @@ def build_set_camera_kwargs(
         kwargs["yaw"] = yaw
     if not math.isnan(pitch):
         kwargs["pitch"] = pitch
-    if distance >= 0:
-        kwargs["distance"] = distance
+    if size >= 0:
+        kwargs["size"] = size
     if orthographic >= 0:
         kwargs["camera_orthographic"] = orthographic
     if reset_to_defaults:

--- a/prefab_sentinel/mcp_tools_editor_view.py
+++ b/prefab_sentinel/mcp_tools_editor_view.py
@@ -24,6 +24,8 @@ __all__ = [
     "RECOMPILE_AND_WAIT_TIMEOUT_MAX_SEC",
     "SCREENSHOT_CROP_ROI_PRESETS",
     "SCREENSHOT_VIEW_ALLOWLIST",
+    "SCREENSHOT_ANGLE_PRESETS",
+    "SCREENSHOT_ANGLE_DEFAULT",
 ]
 
 # Issue #249: canonical screenshot region preset allowlist.  Mirrors the
@@ -35,6 +37,25 @@ SCREENSHOT_CROP_ROI_PRESETS: tuple[str, ...] = (
     "mouth",
     "auto_face",
 )
+
+# Issue #84: canonical angle-preset allowlist for ``editor_screenshot``
+# target-oriented capture mode.  Mirrors ``ObjectCaptureFramingMath
+# .PresetNames`` on the bridge side; both layers enforce the same
+# six-name set so an unrecognised preset short-circuits at the
+# wrapper.  Order matches the issue body verbatim.
+SCREENSHOT_ANGLE_PRESETS: tuple[str, ...] = (
+    "front",
+    "three_quarter",
+    "back",
+    "right",
+    "left",
+    "top",
+)
+
+# Default preset used when the caller supplies ``target`` without
+# ``angle``.  Issue #84 body: ``three_quarter`` is the documented
+# default angle for the target-oriented capture mode.
+SCREENSHOT_ANGLE_DEFAULT: str = "three_quarter"
 
 # Issue #259: canonical view-selector allowlist for ``editor_screenshot``.
 # The selector is interpolated into the output filename on the bridge
@@ -228,6 +249,88 @@ def _crop_roi_invalid_envelope(value: str) -> dict[str, Any]:
     }
 
 
+def _screenshot_angle_invalid_envelope(value: str) -> dict[str, Any]:
+    """Return the canonical ``SCREENSHOT_ANGLE_INVALID`` envelope.
+
+    Issue #84: the message names the supplied value and the accepted
+    six-preset set so the caller can correct the request without
+    consulting external docs.
+    """
+    return {
+        "success": False,
+        "severity": "error",
+        "code": "SCREENSHOT_ANGLE_INVALID",
+        "message": (
+            f"angle={value!r} is not one of the accepted preset names "
+            f"({', '.join(SCREENSHOT_ANGLE_PRESETS)}); the target-oriented "
+            "screenshot mode rejects non-allowlisted angles at the wrapper "
+            "before any bridge transport activity."
+        ),
+        "data": {
+            "supplied": value,
+            "allowed_angles": list(SCREENSHOT_ANGLE_PRESETS),
+        },
+        "diagnostics": [],
+    }
+
+
+def _screenshot_target_invalid_view_envelope(view: str) -> dict[str, Any]:
+    """Return the canonical ``SCREENSHOT_TARGET_INVALID_VIEW`` envelope.
+
+    Issue #84: the target-oriented capture mode is Scene-view-only
+    because the framing math drives ``SceneView.LookAt``; the Game view
+    has no equivalent.
+    """
+    return {
+        "success": False,
+        "severity": "error",
+        "code": "SCREENSHOT_TARGET_INVALID_VIEW",
+        "message": (
+            f"view={view!r} is incompatible with the target-oriented "
+            "capture mode; target framing drives the SceneView only, so "
+            "``target`` requires view='scene'."
+        ),
+        "data": {
+            "supplied": view,
+            "allowed_views": ["scene"],
+        },
+        "diagnostics": [],
+    }
+
+
+def _screenshot_target_crop_conflict_envelope(
+    target: str, crop_roi: str,
+) -> dict[str, Any]:
+    """Return the canonical ``SCREENSHOT_TARGET_CROP_CONFLICT`` envelope.
+
+    Issue #84: the four face-feature ``crop_roi`` presets re-frame the
+    SceneView (``ResolvePresetTarget``), so combining one with the
+    target-oriented framing path would request two competing re-frame
+    operations on the same call.  Pixel-rectangle ``crop_roi`` is not
+    rejected — it post-crops the rendered frame and is orthogonal to
+    framing.
+    """
+    return {
+        "success": False,
+        "severity": "error",
+        "code": "SCREENSHOT_TARGET_CROP_CONFLICT",
+        "message": (
+            f"crop_roi={crop_roi!r} (face-feature preset) cannot be "
+            f"combined with target={target!r}: target framing and "
+            "face-feature preset cropping each drive a SceneView "
+            "re-frame, so requesting both in one call is rejected. "
+            "Pixel-rectangle crop_roi together with target is "
+            "supported."
+        ),
+        "data": {
+            "supplied_target": target,
+            "supplied_crop_roi": crop_roi,
+            "allowed_crop_roi_with_target": "pixel rectangle 'x,y,w,h' only",
+        },
+        "diagnostics": [],
+    }
+
+
 def _is_valid_pixel_rect(value: str) -> bool:
     """Return whether ``value`` is a comma-separated quadruple of
     non-negative integers (the pixel-rectangle escape hatch for
@@ -251,8 +354,10 @@ def editor_screenshot(
     height: int = 0,
     refresh: bool = True,
     crop_roi: str = "",
+    target: str = "",
+    angle: str = SCREENSHOT_ANGLE_DEFAULT,
 ) -> dict[str, Any]:
-    """Capture a screenshot of the Unity Editor (issues #249, #259).
+    """Capture a screenshot of the Unity Editor (issues #249, #259, #84).
 
     The view selector is interpolated into the output filename on the
     bridge side, so the wrapper enforces a positive allowlist
@@ -270,6 +375,23 @@ def editor_screenshot(
     ``"x,y,w,h"``; everything else is rejected at the wrapper with the
     ``CROP_ROI_INVALID`` envelope so the bridge is not contacted for a
     bogus region argument.
+
+    Issue #84 target-oriented capture mode: when ``target`` is non-empty
+    the bridge re-frames the SceneView onto the named GameObject's
+    world-space bounds at the requested angle preset.  The wrapper
+    rejects:
+
+    * ``angle`` values outside ``SCREENSHOT_ANGLE_PRESETS``
+      (``SCREENSHOT_ANGLE_INVALID``);
+    * ``view`` other than ``scene`` together with ``target``
+      (``SCREENSHOT_TARGET_INVALID_VIEW``);
+    * a face-feature ``crop_roi`` preset together with ``target``
+      (``SCREENSHOT_TARGET_CROP_CONFLICT``) — pixel-rectangle
+      ``crop_roi`` together with ``target`` is supported.
+
+    All wrapper rejections short-circuit before the pre-screenshot
+    refresh.  When ``target`` is empty, ``angle`` is ignored and the
+    wrapper behaves as it did before issue #84.
     """
     # Issue #259: view-selector allowlist must run BEFORE the refresh
     # round-trip so a rejected request never produces side-effecting
@@ -282,6 +404,17 @@ def editor_screenshot(
         and not _is_valid_pixel_rect(crop_roi)
     ):
         return _crop_roi_invalid_envelope(crop_roi)
+    if target:
+        # Issue #84: the angle allowlist gate fires whenever target is
+        # supplied, including when angle still carries the wrapper
+        # default — the default is meaningful only when target is set,
+        # so a tampered default surfaces here, not on the bridge.
+        if angle not in SCREENSHOT_ANGLE_PRESETS:
+            return _screenshot_angle_invalid_envelope(angle)
+        if view != "scene":
+            return _screenshot_target_invalid_view_envelope(view)
+        if crop_roi in SCREENSHOT_CROP_ROI_PRESETS:
+            return _screenshot_target_crop_conflict_envelope(target, crop_roi)
     if refresh:
         try:
             send_action(action="refresh_asset_database")
@@ -295,6 +428,9 @@ def editor_screenshot(
     }
     if crop_roi:
         kwargs["crop_roi"] = crop_roi
+    if target:
+        kwargs["target"] = target
+        kwargs["angle"] = angle
     return send_action(**kwargs)
 
 
@@ -359,8 +495,10 @@ def register_editor_view_tools(server: FastMCP) -> None:
         height: int = 0,
         refresh: bool = True,
         crop_roi: str = "",
+        target: str = "",
+        angle: str = SCREENSHOT_ANGLE_DEFAULT,
     ) -> dict[str, Any]:
-        """Capture a screenshot of the Unity Editor (issue #249).
+        """Capture a screenshot of the Unity Editor (issues #249, #84).
 
         Args:
             view: Which view to capture ("scene" or "game").
@@ -374,10 +512,23 @@ def register_editor_view_tools(server: FastMCP) -> None:
                 non-negative integers ``"x,y,w,h"``. Unrecognised values
                 are rejected pre-bridge with the ``CROP_ROI_INVALID``
                 envelope.
+            target: Hierarchy path of a GameObject. When supplied,
+                triggers the target-oriented capture mode (issue #84):
+                the SceneView is re-framed onto the target's world-
+                space AABB at the requested angle preset, the
+                screenshot is captured, then the previous SceneView
+                camera state is restored.  Empty (default) keeps the
+                pre-#84 behavior of capturing the current view.
+            angle: One of ``SCREENSHOT_ANGLE_PRESETS`` (``front`` /
+                ``three_quarter`` / ``back`` / ``right`` / ``left`` /
+                ``top``).  Meaningful only when ``target`` is supplied;
+                ignored when ``target`` is empty.  Default
+                ``three_quarter`` (issue #84 body).
         """
         return editor_screenshot(
             view=view, width=width, height=height,
             refresh=refresh, crop_roi=crop_roi,
+            target=target, angle=angle,
         )
 
     @server.tool(name="editor_force_scene_view_refresh")
@@ -437,7 +588,7 @@ def register_editor_view_tools(server: FastMCP) -> None:
         pivot: str = "",
         yaw: float = float("nan"),
         pitch: float = float("nan"),
-        distance: float = -1.0,
+        size: float = -1.0,
         orthographic: int = -1,
         position: str = "",
         look_at: str = "",
@@ -447,7 +598,7 @@ def register_editor_view_tools(server: FastMCP) -> None:
 
         Three modes (mutually exclusive):
 
-        * Pivot orbit — ``pivot`` + ``yaw`` / ``pitch`` / ``distance``.
+        * Pivot orbit — ``pivot`` + ``yaw`` / ``pitch`` / ``size``.
         * Position — ``position`` + (``look_at`` or ``yaw`` / ``pitch``).
         * Reset — ``reset_to_defaults=True`` returns the SceneView to its
           documented default pivot, rotation, size, and orthographic flag.
@@ -461,7 +612,7 @@ def register_editor_view_tools(server: FastMCP) -> None:
             pivot: JSON '{"x":0,"y":0,"z":0}' — orbit center.
             yaw: Horizontal rotation in degrees.
             pitch: Vertical rotation in degrees.
-            distance: SceneView.size (>=0 to set, -1 = keep).
+            size: SceneView.size, the Scene-view half-width (>=0 to set, -1 = keep).
             orthographic: -1=keep, 0=perspective, 1=orthographic.
             position: JSON '{"x":0,"y":1,"z":-5}' — camera world position.
             look_at: JSON '{"x":0,"y":1,"z":0}' — look-at target (requires position).
@@ -469,7 +620,7 @@ def register_editor_view_tools(server: FastMCP) -> None:
                 restore the SceneView to its documented defaults.
         """
         kwargs = build_set_camera_kwargs(
-            pivot=pivot, yaw=yaw, pitch=pitch, distance=distance,
+            pivot=pivot, yaw=yaw, pitch=pitch, size=size,
             orthographic=orthographic, position=position, look_at=look_at,
             reset_to_defaults=reset_to_defaults,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.7.0"
+version = "0.7.1"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
@@ -68,8 +68,22 @@ packages = ["prefab_sentinel"]
 "tools/unity" = "prefab_sentinel/_bridge_files"
 "knowledge" = "prefab_sentinel/_knowledge_files"
 
+# uv cache-keys: default cache invalidation only watches pyproject.toml,
+# setup.py, setup.cfg (astral-sh/uv#16196). The wheel force-includes
+# `tools/unity/` and `knowledge/`, so edits under those trees would
+# otherwise be invisible to `uvx --from <local-path>` and produce stale
+# wheels that ship outdated bridge C# or knowledge markdown. Listing
+# them here makes their mtime/contents part of the cache key.
+[tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "tools/unity/**/*.cs" },
+    { file = "tools/unity/**/*.asmdef" },
+    { file = "knowledge/**/*.md" },
+]
+
 [tool.bumpversion]
-current_version = "0.7.0"
+current_version = "0.7.1"
 commit = false
 tag = false
 allow_dirty = true

--- a/tests/csharp/ActionRegistryTests.cs
+++ b/tests/csharp/ActionRegistryTests.cs
@@ -85,9 +85,10 @@ public class EditorControlRequestTests
     {
         var request = new EditorControlRequest();
 
-        // yaw / pitch use NaN as the "keep current" sentinel; distance uses -1.
+        // yaw / pitch use NaN as the "keep current" sentinel; the
+        // orbit-radius ``size`` field (issue #81) uses -1.
         Assert.True(float.IsNaN(request.yaw));
         Assert.True(float.IsNaN(request.pitch));
-        Assert.Equal(-1f, request.distance);
+        Assert.Equal(-1f, request.size);
     }
 }

--- a/tests/csharp/ObjectCaptureFramingMathTests.cs
+++ b/tests/csharp/ObjectCaptureFramingMathTests.cs
@@ -1,0 +1,499 @@
+using System;
+using System.Collections.Generic;
+using PrefabSentinel;
+using Xunit;
+
+namespace PrefabSentinel.Tests;
+
+/// <summary>
+/// Issue #84 — exercise <see cref="ObjectCaptureFramingMath"/> end-to-end
+/// in the Unity-free C# xUnit harness.  These tests are the behavioral
+/// guarantee for the target-oriented screenshot mode's pure math
+/// (preset → camera-position direction, outlier-renderer selection,
+/// perspective-correct two-end binding solve + non-binding re-centering).
+///
+/// Convention recap (matches the issue body + spec.md):
+///   * <c>cameraDirection</c> is the camera-POSITION direction: a unit
+///     vector pointing FROM the framing pivot TOWARD the camera.
+///   * <c>cameraRight</c>/<c>cameraUp</c> complete the orthonormal basis
+///     in the orientation Unity's <c>SceneView.LookAt</c> would establish
+///     when the camera points at the pivot.
+///   * Front preset (yaw=0, pitch=-5) places the camera at a 5° elevation
+///     in front of the target (looking slightly down at the target).
+/// </summary>
+public class ObjectCaptureFramingMathTests
+{
+    private const float DirectionTolerance = 1e-4f;
+    private const float FramingTolerance = 1e-3f;
+
+    // Identity quaternion as (x, y, z, w).
+    private static float[] Identity() => new float[] { 0f, 0f, 0f, 1f };
+
+    // Expected target-local direction for each preset, computed from
+    // the issue-body authored (yaw, pitch) seeds under Unity's
+    // ``Q.Euler(pitch, yaw, 0) * Vector3.forward`` composition:
+    //   localDir = (cos(pitch)*sin(yaw), -sin(pitch), cos(pitch)*cos(yaw))
+    private static float[] ExpectedLocalDirection(float yawDeg, float pitchDeg)
+    {
+        double yawRad = yawDeg * Math.PI / 180.0;
+        double pitchRad = pitchDeg * Math.PI / 180.0;
+        double cp = Math.Cos(pitchRad);
+        double sp = Math.Sin(pitchRad);
+        double cy = Math.Cos(yawRad);
+        double sy = Math.Sin(yawRad);
+        double x = cp * sy;
+        double y = -sp;
+        double z = cp * cy;
+        double len = Math.Sqrt(x * x + y * y + z * z);
+        return new float[]
+        {
+            (float)(x / len),
+            (float)(y / len),
+            (float)(z / len),
+        };
+    }
+
+    private static void AssertDirectionsEqual(
+        float[] expected, float[] actual, string preset)
+    {
+        Assert.NotNull(actual);
+        Assert.Equal(3, actual.Length);
+        for (int i = 0; i < 3; i++)
+        {
+            float diff = Math.Abs(expected[i] - actual[i]);
+            Assert.True(
+                diff <= DirectionTolerance,
+                $"Preset '{preset}' axis[{i}] expected {expected[i]} ± "
+                + $"{DirectionTolerance}, got {actual[i]} (diff {diff}).");
+        }
+    }
+
+    // -------- Preset → camera direction (front) --------
+
+    [Fact]
+    public void Front_Preset_Composes_To_The_Issue_Body_Authored_Seed_Direction()
+    {
+        bool ok = ObjectCaptureFramingMath.TryResolvePresetDirection(
+            "front", Identity(), out float[] dir, out string reason);
+
+        Assert.True(ok, $"TryResolvePresetDirection failed: '{reason}'.");
+        Assert.Equal(string.Empty, reason);
+        AssertDirectionsEqual(ExpectedLocalDirection(0f, -5f), dir, "front");
+    }
+
+    // -------- Preset → camera direction (each non-default preset) --------
+
+    [Theory]
+    [InlineData("three_quarter", 35f, -10f)]
+    [InlineData("back", 180f, -5f)]
+    [InlineData("right", 90f, -5f)]
+    [InlineData("left", -90f, -5f)]
+    [InlineData("top", 0f, -89f)]
+    public void Each_Non_Default_Preset_Composes_To_Its_Authored_Seed(
+        string preset, float yawDeg, float pitchDeg)
+    {
+        bool ok = ObjectCaptureFramingMath.TryResolvePresetDirection(
+            preset, Identity(), out float[] dir, out string reason);
+
+        Assert.True(ok, $"TryResolvePresetDirection failed: '{reason}'.");
+        AssertDirectionsEqual(
+            ExpectedLocalDirection(yawDeg, pitchDeg), dir, preset);
+    }
+
+    // -------- Helper preset table values track the issue-body seed --------
+
+    [Fact]
+    public void Preset_Table_Yaw_And_Pitch_Match_The_Issue_Body_Seed_Values()
+    {
+        // Pin the table at the issue-body seeds verbatim. If the
+        // implementer retunes during manual in-Editor verification,
+        // BOTH this row and the helper table are updated together —
+        // a unilateral helper edit must surface here.
+        Assert.Equal(
+            new[] { "front", "three_quarter", "back", "right", "left", "top" },
+            ObjectCaptureFramingMath.PresetNames);
+        Assert.Equal(
+            new[] { 0f, 35f, 180f, 90f, -90f, 0f },
+            ObjectCaptureFramingMath.PresetYawDegrees);
+        Assert.Equal(
+            new[] { -5f, -10f, -5f, -5f, -5f, -89f },
+            ObjectCaptureFramingMath.PresetPitchDegrees);
+    }
+
+    // -------- Unknown preset rejected by helper --------
+
+    [Fact]
+    public void Unknown_Preset_Name_Yields_A_Typed_Failure()
+    {
+        bool ok = ObjectCaptureFramingMath.TryResolvePresetDirection(
+            "banana", Identity(), out float[] dir, out string reason);
+
+        Assert.False(ok, "Unknown preset must yield a typed failure.");
+        Assert.Equal(
+            ObjectCaptureFramingMath.FailureUnknownPreset, reason);
+        Assert.Null(dir);
+    }
+
+    // -------- Camera basis along -Z (used by the framing-solver tests) --------
+
+    private static float[] CameraRightAlongMinusZ() => new float[] { 1f, 0f, 0f };
+    private static float[] CameraUpAlongMinusZ() => new float[] { 0f, 1f, 0f };
+    private static float[] CameraDirectionAlongPlusZ() => new float[] { 0f, 0f, 1f };
+
+    // Build 8 corners of an axis-aligned cuboid centered at the origin
+    // with the supplied half-extents.
+    private static float[] CuboidCorners(float ex, float ey, float ez)
+    {
+        var arr = new float[24];
+        int k = 0;
+        for (int sx = -1; sx <= 1; sx += 2)
+        {
+            for (int sy = -1; sy <= 1; sy += 2)
+            {
+                for (int sz = -1; sz <= 1; sz += 2)
+                {
+                    arr[k++] = sx * ex;
+                    arr[k++] = sy * ey;
+                    arr[k++] = sz * ez;
+                }
+            }
+        }
+        return arr;
+    }
+
+    // -------- Framing solver — cubic AABB centered --------
+
+    [Fact]
+    public void Cubic_Aabb_Centered_Returns_Pivot_At_Origin_And_The_Closed_Form_Size()
+    {
+        const float fov = 60f;
+        const float aspect = 1f;
+        const float margin = 1f;
+        float[] corners = CuboidCorners(0.5f, 0.5f, 0.5f);
+
+        bool ok = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(),
+            CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            fov, aspect, margin,
+            ObjectCaptureFramingMath.RecenteringIterationCount,
+            out float[] pivot, out float size, out string reason);
+
+        Assert.True(ok, $"Solver failed: '{reason}'.");
+        Assert.NotNull(pivot);
+
+        // Closed-form: camera distance D = 0.5 (front face) + 0.5/tan(fov/2);
+        // size = D * sin(fov/2). For fov=60° this is 0.5*sin(30°) + 0.5*cos(30°)
+        // = 0.25 + 0.4330127 = 0.6830127.
+        double tanHalfFov = Math.Tan(fov * 0.5 * Math.PI / 180.0);
+        double sinHalfFov = Math.Sin(fov * 0.5 * Math.PI / 180.0);
+        double cosHalfFov = Math.Cos(fov * 0.5 * Math.PI / 180.0);
+        double expectedD = 0.5 + 0.5 / tanHalfFov;
+        float expectedSize = (float)(expectedD * sinHalfFov);
+
+        Assert.InRange(pivot[0], -FramingTolerance, FramingTolerance);
+        Assert.InRange(pivot[1], -FramingTolerance, FramingTolerance);
+        Assert.InRange(pivot[2], -FramingTolerance, FramingTolerance);
+        Assert.InRange(size, expectedSize - FramingTolerance, expectedSize + FramingTolerance);
+        // Sanity: the closed-form should equal 0.5*(sin+cos) for the cube.
+        Assert.InRange(
+            expectedSize,
+            (float)(0.5 * (sinHalfFov + cosHalfFov)) - 1e-5f,
+            (float)(0.5 * (sinHalfFov + cosHalfFov)) + 1e-5f);
+    }
+
+    // -------- Framing solver — wide AABB (X binding) --------
+
+    [Fact]
+    public void Wide_Aabb_Binds_On_The_Horizontal_Axis_And_Recenters_Vertical()
+    {
+        const float fov = 60f;
+        const float aspect = 1f;
+        const float margin = 1f;
+        float[] corners = CuboidCorners(1f, 0.5f, 0.5f);
+
+        bool ok = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(),
+            CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            fov, aspect, margin,
+            ObjectCaptureFramingMath.RecenteringIterationCount,
+            out float[] pivot, out float size, out string reason);
+
+        Assert.True(ok, $"Solver failed: '{reason}'.");
+
+        // Horizontal-binding closed-form: camera distance
+        // D = 1.0 / tan(fov/2) + 0.5; size = D * sin(fov/2).
+        double tanHalfFov = Math.Tan(fov * 0.5 * Math.PI / 180.0);
+        double sinHalfFov = Math.Sin(fov * 0.5 * Math.PI / 180.0);
+        double expectedD = 1.0 / tanHalfFov + 0.5;
+        float expectedSize = (float)(expectedD * sinHalfFov);
+        Assert.InRange(size, expectedSize - FramingTolerance, expectedSize + FramingTolerance);
+
+        // Pivot must remain on the AABB center for a symmetric AABB:
+        // both axes are symmetric around 0, so the binding corners
+        // touch ±K and the non-binding axis re-centers to 0.
+        Assert.InRange(pivot[0], -FramingTolerance, FramingTolerance);
+        Assert.InRange(pivot[1], -FramingTolerance, FramingTolerance);
+
+        // Binding constraint: a corner pair (+1, *, +0.5) and (-1, *, +0.5)
+        // satisfies (u - pivot.x) / (D - h) = ±K_h. With aspect=1.0,
+        // margin=1.0: K_h = tan(fov/2).
+        double k = tanHalfFov * aspect * margin;
+        double d = size / sinHalfFov;
+        double depthNearFace = d - 0.5;
+        double ratioRight = (1f - pivot[0]) / depthNearFace;
+        double ratioLeft = (-1f - pivot[0]) / depthNearFace;
+        Assert.InRange(ratioRight, k - 1e-3, k + 1e-3);
+        Assert.InRange(ratioLeft, -k - 1e-3, -k + 1e-3);
+    }
+
+    // -------- Framing solver — tall AABB (Y binding) --------
+
+    [Fact]
+    public void Tall_Aabb_Binds_On_The_Vertical_Axis_And_Recenters_Horizontal()
+    {
+        const float fov = 60f;
+        const float aspect = 1f;
+        const float margin = 1f;
+        float[] corners = CuboidCorners(0.5f, 1f, 0.5f);
+
+        bool ok = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(),
+            CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            fov, aspect, margin,
+            ObjectCaptureFramingMath.RecenteringIterationCount,
+            out float[] pivot, out float size, out string reason);
+
+        Assert.True(ok, $"Solver failed: '{reason}'.");
+
+        double tanHalfFov = Math.Tan(fov * 0.5 * Math.PI / 180.0);
+        double sinHalfFov = Math.Sin(fov * 0.5 * Math.PI / 180.0);
+        double expectedD = 1.0 / tanHalfFov + 0.5;
+        float expectedSize = (float)(expectedD * sinHalfFov);
+        Assert.InRange(size, expectedSize - FramingTolerance, expectedSize + FramingTolerance);
+        Assert.InRange(pivot[0], -FramingTolerance, FramingTolerance);
+        Assert.InRange(pivot[1], -FramingTolerance, FramingTolerance);
+
+        // Binding constraint on Y: a pair (*, +1, +0.5) and (*, -1, +0.5)
+        // satisfies (v - pivot.y) / (D - h) = ±K_v. With margin=1.0
+        // K_v = tan(fov/2).
+        double k = tanHalfFov * margin;
+        double d = size / sinHalfFov;
+        double depthNearFace = d - 0.5;
+        double ratioTop = (1f - pivot[1]) / depthNearFace;
+        double ratioBot = (-1f - pivot[1]) / depthNearFace;
+        Assert.InRange(ratioTop, k - 1e-3, k + 1e-3);
+        Assert.InRange(ratioBot, -k - 1e-3, -k + 1e-3);
+    }
+
+    // -------- Framing solver — re-centering iteration converges --------
+
+    [Fact]
+    public void Recentering_Converges_Within_The_Documented_Iteration_Bound()
+    {
+        // Asymmetric AABB: offset wedge that pushes the vertical axis
+        // off-center under horizontal binding. After horizontal-axis
+        // binding settles D_h, the vertical max/min projection corners
+        // sit at different depths so a single shift is insufficient;
+        // 3 iterations must converge to the same pivot as 6 iterations.
+        const float fov = 60f;
+        const float aspect = 1f;
+        const float margin = 1f;
+        var corners = new float[]
+        {
+            -1.0f, -0.2f, -0.3f,
+            -1.0f, -0.2f,  0.3f,
+            -1.0f,  0.6f, -0.3f,
+            -1.0f,  0.6f,  0.3f,
+             1.0f, -0.2f, -0.3f,
+             1.0f, -0.2f,  0.3f,
+             1.0f,  0.6f, -0.3f,
+             1.0f,  0.6f,  0.3f,
+        };
+
+        bool okA = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(),
+            CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            fov, aspect, margin,
+            ObjectCaptureFramingMath.RecenteringIterationCount,
+            out float[] pivotA, out float sizeA, out _);
+        bool okB = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(),
+            CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            fov, aspect, margin,
+            ObjectCaptureFramingMath.RecenteringIterationCount + 3,
+            out float[] pivotB, out float sizeB, out _);
+
+        Assert.True(okA && okB);
+        // The documented iteration bound (3) converges to the same
+        // pivot as one extra batch of iterations (6) — no oscillation.
+        for (int i = 0; i < 3; i++)
+        {
+            float diff = Math.Abs(pivotA[i] - pivotB[i]);
+            Assert.True(
+                diff <= 1e-4f,
+                $"Pivot drifted between 3-iter and 6-iter runs at axis {i}: "
+                + $"|{pivotA[i]} - {pivotB[i]}| = {diff}.");
+        }
+        Assert.InRange(sizeA - sizeB, -1e-4f, 1e-4f);
+
+        // Horizontal binding constraint must still hold (the wide
+        // ±1 X-extent dominates the vertical 0.4 spread).
+        double tanHalfFov = Math.Tan(fov * 0.5 * Math.PI / 180.0);
+        double sinHalfFov = Math.Sin(fov * 0.5 * Math.PI / 180.0);
+        double k = tanHalfFov * aspect * margin;
+        double d = sizeA / sinHalfFov;
+        // Find the near-face X-binding corner pair (h=+0.3, |u|=1).
+        double depthNearFace = d - 0.3;
+        double ratioRight = (1f - pivotA[0]) / depthNearFace;
+        double ratioLeft = (-1f - pivotA[0]) / depthNearFace;
+        Assert.InRange(ratioRight, k - 1e-3, k + 1e-3);
+        Assert.InRange(ratioLeft, -k - 1e-3, -k + 1e-3);
+    }
+
+    // -------- Framing solver — degenerate AABB --------
+
+    [Fact]
+    public void Degenerate_Aabb_Yields_A_Typed_Failure_Instead_Of_Dividing_By_Zero()
+    {
+        var corners = new float[24]; // every corner at (0, 0, 0)
+
+        bool ok = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(),
+            CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            60f, 1f, 1f,
+            ObjectCaptureFramingMath.RecenteringIterationCount,
+            out float[] pivot, out float size, out string reason);
+
+        Assert.False(ok, "Degenerate AABB must yield a typed failure.");
+        Assert.Equal(ObjectCaptureFramingMath.FailureDegenerateAabb, reason);
+        Assert.Null(pivot);
+        Assert.Equal(0f, size);
+    }
+
+    // -------- Outlier filter selects largest-extent renderer as core --------
+
+    [Fact]
+    public void Outlier_Filter_Picks_The_Largest_Extent_Renderer_As_The_Core()
+    {
+        // Per-axis AABB-containment outlier filter (matches the PoC
+        // reference): core extents (1.0, 0.5, 0.5) ⇒ per-axis allow
+        // box = extents + max(0.3 * extents, 0.1) = (1.3, 0.65, 0.65).
+        // Candidates whose absolute center offset fits inside the box
+        // along *every* axis are kept; ones that escape along even a
+        // single axis are dropped. The previous euclidean-sphere form
+        // dropped renderers far along one axis (e.g., a VRChat avatar's
+        // head 1 m above the body center) — this regression caused #84
+        // to clip the head out of frame in real-Unity visual verification.
+        var renderers = new List<ObjectCaptureFramingMath.RendererBoundsRecord>
+        {
+            new ObjectCaptureFramingMath.RendererBoundsRecord(
+                new float[] { 1.2f, 0f, 0f }, new float[] { 0.05f, 0.05f, 0.05f }),
+            new ObjectCaptureFramingMath.RendererBoundsRecord(
+                new float[] { 0f, 0f, 0f }, new float[] { 1.0f, 0.5f, 0.5f }),
+            new ObjectCaptureFramingMath.RendererBoundsRecord(
+                new float[] { 0f, 0f, 1.0f }, new float[] { 0.05f, 0.05f, 0.05f }),
+            new ObjectCaptureFramingMath.RendererBoundsRecord(
+                new float[] { 1.5f, 0f, 0f }, new float[] { 0.05f, 0.05f, 0.05f }),
+        };
+
+        IList<ObjectCaptureFramingMath.RendererBoundsRecord> kept =
+            ObjectCaptureFramingMath.SelectFramingRenderers(renderers);
+
+        // Stable order: core first, then in-input-order kept candidates.
+        // renderers[0] kept (|dx|=1.2 < 1.3 allowX);
+        // renderers[2] dropped (|dz|=1.0 > 0.65 allowZ);
+        // renderers[3] dropped (|dx|=1.5 > 1.3 allowX).
+        Assert.Equal(2, kept.Count);
+        Assert.Same(renderers[1], kept[0]); // core (largest extent)
+        Assert.Same(renderers[0], kept[1]); // inside per-axis box
+    }
+
+    // -------- Outlier filter per-axis box = extents + max(0.30 * extents, 0.1) --------
+
+    [Theory]
+    // Core (1.0, 0.5, 0.5) → allow (1.3, 0.65, 0.65); test each axis.
+    [InlineData(1.0f, 1.29f, 0f, 0f, true)]   // x 1.29 < 1.3
+    [InlineData(1.0f, 1.31f, 0f, 0f, false)]  // x 1.31 > 1.3
+    [InlineData(1.0f, 0f, 0.64f, 0f, true)]   // y 0.64 < 0.65
+    [InlineData(1.0f, 0f, 0.66f, 0f, false)]  // y 0.66 > 0.65
+    [InlineData(1.0f, 0f, 0f, 0.64f, true)]   // z 0.64 < 0.65
+    [InlineData(1.0f, 0f, 0f, 0.66f, false)]  // z 0.66 > 0.65
+    // Tiny core (0.01, 0.005, 0.005) → floor 0.1 m kicks in on every
+    // axis; allow ≈ (0.11, 0.105, 0.105).
+    [InlineData(0.01f, 0.10f, 0f, 0f, true)]
+    [InlineData(0.01f, 0.12f, 0f, 0f, false)]
+    public void Outlier_Filter_Per_Axis_Inclusion_Box_Matches_Max_Of_Relative_And_Floor(
+        float coreLargestExtent, float dx, float dy, float dz, bool expectedKept)
+    {
+        var core = new ObjectCaptureFramingMath.RendererBoundsRecord(
+            new float[] { 0f, 0f, 0f },
+            new float[] { coreLargestExtent, coreLargestExtent * 0.5f, coreLargestExtent * 0.5f });
+        var candidate = new ObjectCaptureFramingMath.RendererBoundsRecord(
+            new float[] { dx, dy, dz },
+            new float[] { 0.001f, 0.001f, 0.001f });
+        var input = new List<ObjectCaptureFramingMath.RendererBoundsRecord>
+        {
+            core, candidate,
+        };
+
+        IList<ObjectCaptureFramingMath.RendererBoundsRecord> kept =
+            ObjectCaptureFramingMath.SelectFramingRenderers(input);
+
+        bool candidateKept = false;
+        foreach (var r in kept)
+        {
+            if (ReferenceEquals(r, candidate)) { candidateKept = true; break; }
+        }
+        Assert.True(
+            candidateKept == expectedKept,
+            $"core_extent={coreLargestExtent}, offset=({dx},{dy},{dz}), "
+            + $"expected kept={expectedKept}, observed kept={candidateKept}.");
+    }
+
+    // -------- Framing solver consumes the supplied aspect --------
+
+    [Fact]
+    public void Wider_Aspect_Reduces_The_Required_SceneView_Size()
+    {
+        // Hold the AABB / direction / fov constant, vary aspect 1.0 → 2.0.
+        // Aspect 2.0 doubles the horizontal frame budget, so the X-binding
+        // axis can satisfy the constraint at a smaller D → smaller size.
+        const float fov = 60f;
+        const float margin = 1f;
+        float[] corners = CuboidCorners(1f, 0.5f, 0.5f);
+
+        bool okA = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(), CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            fov, 1.0f, margin,
+            ObjectCaptureFramingMath.RecenteringIterationCount,
+            out float[] _, out float sizeNarrow, out _);
+        bool okB = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+            corners,
+            CameraRightAlongMinusZ(), CameraUpAlongMinusZ(),
+            CameraDirectionAlongPlusZ(),
+            fov, 2.0f, margin,
+            ObjectCaptureFramingMath.RecenteringIterationCount,
+            out float[] _, out float sizeWide, out _);
+
+        Assert.True(okA && okB);
+        Assert.True(
+            sizeWide < sizeNarrow,
+            $"Expected size(aspect=2.0)={sizeWide} < size(aspect=1.0)="
+            + $"{sizeNarrow}; a wider rendered frame requires less "
+            + $"SceneView half-width to bound the same AABB.");
+    }
+}

--- a/tests/csharp/PrefabSentinel.Tests.csproj
+++ b/tests/csharp/PrefabSentinel.Tests.csproj
@@ -49,6 +49,9 @@
     <Compile Include="..\..\tools\unity\PrefabSentinel.Screenshot.ViewAllowlistClassifier.cs">
       <Link>Bridge\PrefabSentinel.Screenshot.ViewAllowlistClassifier.cs</Link>
     </Compile>
+    <Compile Include="..\..\tools\unity\PrefabSentinel.Screenshot.ObjectCaptureFramingMath.cs">
+      <Link>Bridge\PrefabSentinel.Screenshot.ObjectCaptureFramingMath.cs</Link>
+    </Compile>
     <!--
       H-track xUnit migration (issues #10-#16, #19): the Unity-free decision
       classes extracted from the C# bridge handlers. Each file references only

--- a/tests/test_editor_bridge.py
+++ b/tests/test_editor_bridge.py
@@ -344,18 +344,22 @@ class TestSetCameraParams(unittest.TestCase):
     """Validate editor_set_camera parameter conversion."""
 
     def test_pivot_orbit_kwargs(self) -> None:
+        # Issue #81: orbit-radius argument is named ``size`` (it
+        # carries ``SceneView.size`` semantics — Scene-view half-width).
         kwargs = build_set_camera_kwargs(
             pivot='{"x":0,"y":1.3,"z":0}',
             yaw=345.0,
             pitch=8.0,
-            distance=0.28,
+            size=0.28,
         )
         self.assertEqual(kwargs["camera_pivot"], [0, 1.3, 0])
         self.assertEqual(kwargs["yaw"], 345.0)
         self.assertEqual(kwargs["pitch"], 8.0)
-        self.assertEqual(kwargs["distance"], 0.28)
+        self.assertEqual(kwargs["size"], 0.28)
         self.assertNotIn("camera_position", kwargs)
         self.assertNotIn("camera_look_at", kwargs)
+        # The pre-rename key must not survive as a hidden alias.
+        self.assertNotIn("distance", kwargs)
 
     def test_position_look_at_kwargs(self) -> None:
         kwargs = build_set_camera_kwargs(
@@ -371,17 +375,36 @@ class TestSetCameraParams(unittest.TestCase):
             position='{"x":0,"y":1.5,"z":-1}',
             yaw=0.0,
             pitch=10.0,
-            distance=0.5,
+            size=0.5,
         )
         self.assertEqual(kwargs["camera_position"], [0, 1.5, -1])
         self.assertEqual(kwargs["yaw"], 0.0)
         self.assertEqual(kwargs["pitch"], 10.0)
-        self.assertEqual(kwargs["distance"], 0.5)
+        self.assertEqual(kwargs["size"], 0.5)
         self.assertNotIn("camera_look_at", kwargs)
+        self.assertNotIn("distance", kwargs)
 
     def test_omitted_params_excluded(self) -> None:
         kwargs = build_set_camera_kwargs(yaw=180.0)
         self.assertEqual(kwargs, {"yaw": 180.0})
+
+    def test_size_sentinel_minus_one_is_omitted(self) -> None:
+        # Issue #81: the orbit-radius sentinel ``-1.0`` means "keep
+        # current" and must not be forwarded verbatim; the produced
+        # kwargs dict must contain neither ``size`` nor the pre-rename
+        # alias ``distance``.
+        kwargs = build_set_camera_kwargs(size=-1.0)
+        self.assertEqual(kwargs, {})
+
+    def test_distance_is_not_a_registered_builder_parameter(self) -> None:
+        # Issue #81: the pre-rename keyword name must not survive as a
+        # hidden alias on the builder's keyword surface; callers that
+        # still pass ``distance=...`` should get the standard Python
+        # ``TypeError`` for an unknown keyword argument.
+        import inspect
+        params = inspect.signature(build_set_camera_kwargs).parameters
+        self.assertIn("size", params)
+        self.assertNotIn("distance", params)
 
     def test_orthographic_passed(self) -> None:
         kwargs = build_set_camera_kwargs(orthographic=1)

--- a/tests/test_editor_control_bridge_source.py
+++ b/tests/test_editor_control_bridge_source.py
@@ -3214,6 +3214,233 @@ class ScreenshotViewAllowlistSourceTests(unittest.TestCase):
         )
 
 
+class ScreenshotObjectCaptureSourceTests(unittest.TestCase):
+    """Issue #84 — bridge-side source-text invariants for the
+    target-oriented capture branch on ``HandleCaptureScreenshot``.
+
+    The new branch reads ``request.target`` and ``request.angle``,
+    delegates target resolution to the existing stage-aware resolver
+    ``TryResolveGameObjectInActiveStage`` (so the ambiguous-hierarchy
+    envelope ``EDITOR_CTRL_HIERARCHY_PATH_AMBIGUOUS`` surfaces
+    unchanged), invokes the Unity-free framing math via
+    ``ObjectCaptureFramingMath``, and surfaces the three new bridge
+    error codes for "no match", "no renderers", and "unknown preset".
+
+    The dispatcher routing for ``capture_screenshot`` is unchanged
+    (the action already exists); this class also pins the literal
+    presence of ``capture_screenshot`` in the dispatcher and the
+    ActionRegistry so a future routing rewrite is caught.
+
+    T3 source-text invariant: the bridge runs inside the Unity Editor;
+    the Python harness cannot drive the SceneView (justified in
+    spec.md Tier 3 Justification).
+    """
+
+    _BRIDGE_CODES = (
+        "EDITOR_CTRL_SCREENSHOT_TARGET_NOT_FOUND",
+        "EDITOR_CTRL_SCREENSHOT_TARGET_NO_RENDERERS",
+        "EDITOR_CTRL_SCREENSHOT_ANGLE_INVALID",
+    )
+
+    _DOCS_API_REFERENCE = (
+        Path(__file__).resolve().parent.parent / "docs" / "api-reference.md"
+    )
+
+    _DOCS_TOOLS = (
+        Path(__file__).resolve().parent.parent / "docs" / "tools.md"
+    )
+
+    def _screenshot_partial_body(self) -> str:
+        # The object-capture branch lives in the Screenshot partial
+        # (``PrefabSentinel.UnityEditorControlBridge.Screenshot.cs``);
+        # the partial may dispatch from ``HandleCaptureScreenshot`` to a
+        # private helper, so this T3 net inspects the full partial body
+        # (comments stripped) rather than a single method extraction.
+        partial = (
+            TOOLS_DIR / "PrefabSentinel.UnityEditorControlBridge.Screenshot.cs"
+        )
+        return _strip_cs_comments(partial.read_text(encoding="utf-8"))
+
+    def test_handler_branches_on_request_target(self) -> None:
+        body = _extract_method(_read(BRIDGE), "HandleCaptureScreenshot")
+        self.assertIn(
+            "request.target",
+            body,
+            msg=(
+                "HandleCaptureScreenshot must dispatch on "
+                "``request.target`` to engage the target-oriented "
+                "capture branch (#84)."
+            ),
+        )
+
+    def test_handler_routes_target_through_stage_aware_resolver(self) -> None:
+        body = self._screenshot_partial_body()
+        # The object-capture branch must route through the existing
+        # stage-aware resolver so the ambiguous-hierarchy envelope
+        # surfaces unchanged; an independent hierarchy walk would
+        # silently first-pick a same-named sibling.
+        self.assertIn(
+            "TryResolveGameObjectInActiveStage",
+            body,
+            msg=(
+                "The Screenshot partial's object-capture branch must "
+                "delegate target resolution to "
+                "TryResolveGameObjectInActiveStage so the existing "
+                "EDITOR_CTRL_HIERARCHY_PATH_AMBIGUOUS envelope surfaces "
+                "unchanged (#84)."
+            ),
+        )
+
+    def test_handler_invokes_pure_framing_math_helper(self) -> None:
+        body = self._screenshot_partial_body()
+        self.assertIn(
+            "ObjectCaptureFramingMath",
+            body,
+            msg=(
+                "The Screenshot partial's object-capture branch must "
+                "invoke the Unity-free ObjectCaptureFramingMath helper "
+                "(#84)."
+            ),
+        )
+
+    def test_handler_emits_new_bridge_error_codes(self) -> None:
+        body = self._screenshot_partial_body()
+        for code in self._BRIDGE_CODES:
+            with self.subTest(code=code):
+                self.assertIn(
+                    f'"{code}"', body,
+                    msg=(
+                        f"The Screenshot partial must reference the "
+                        f"bridge-side error code literal {code!r} (#84)."
+                    ),
+                )
+
+    def test_dispatcher_routes_capture_screenshot_unchanged(self) -> None:
+        # Issue #84: the dispatcher already routes ``capture_screenshot``;
+        # this row pins the routing so an accidental rewrite breaks the
+        # new mode.
+        source = _read(BRIDGE)
+        body = _extract_method(source, "DispatchAction")
+        self.assertIn('case "capture_screenshot":', body)
+        self.assertIn("HandleCaptureScreenshot", body)
+
+    def test_new_error_codes_documented_in_api_reference(self) -> None:
+        docs = self._DOCS_API_REFERENCE.read_text(encoding="utf-8")
+        wrapper_codes = (
+            "SCREENSHOT_ANGLE_INVALID",
+            "SCREENSHOT_TARGET_INVALID_VIEW",
+            "SCREENSHOT_TARGET_CROP_CONFLICT",
+        )
+        for code in wrapper_codes + self._BRIDGE_CODES:
+            with self.subTest(code=code):
+                self.assertIn(
+                    code, docs,
+                    msg=(
+                        f"docs/api-reference.md must document the new "
+                        f"error code {code!r} introduced by issue #84."
+                    ),
+                )
+
+    def test_tools_registry_mentions_target_and_angle(self) -> None:
+        docs = self._DOCS_TOOLS.read_text(encoding="utf-8")
+        for literal in ("target", "angle", "SCREENSHOT_ANGLE_PRESETS"):
+            with self.subTest(literal=literal):
+                self.assertIn(
+                    literal, docs,
+                    msg=(
+                        f"docs/tools.md must mention {literal!r} so the "
+                        f"editor_screenshot registry entry exposes the "
+                        f"new target-oriented capability (#84)."
+                    ),
+                )
+
+
+class HandleSetCameraSizeFieldSourceTests(unittest.TestCase):
+    """Issue #81 — the orbit-radius argument is named ``size`` end-to-end
+    (Python wrapper, kwargs builder, wire DTO, bridge handler).  This T3
+    net pins:
+
+    * ``HandleSetCamera`` reads from ``request.size`` (the consumer-side
+      half of the rename — a DTO-only rename that misses the consumer
+      would slip past the schema test);
+    * ``HandleSetCamera`` does not reference ``request.distance`` (no
+      hidden alias).
+
+    The handler runs only inside the Unity Editor process; this is the
+    bridge-side source-text regression net (justified in spec.md Tier 3
+    Justification).
+    """
+
+    def test_handle_set_camera_consumes_request_size(self) -> None:
+        body = _extract_method(_read(BRIDGE), "HandleSetCamera")
+        self.assertIn(
+            "request.size",
+            body,
+            msg=(
+                "HandleSetCamera must consume the orbit-radius field "
+                "under the name ``request.size`` (#81)."
+            ),
+        )
+
+    def test_handle_set_camera_does_not_reference_request_distance(self) -> None:
+        body = _extract_method(_read(BRIDGE), "HandleSetCamera")
+        self.assertNotIn(
+            "request.distance",
+            body,
+            msg=(
+                "HandleSetCamera must not reference ``request.distance``; "
+                "the orbit-radius field was renamed to ``size`` end-to-end "
+                "(#81) and the pre-rename alias must not survive."
+            ),
+        )
+
+
+class EditorSetCameraDocsRenameTests(unittest.TestCase):
+    """Issue #81 — the camera-modes table in ``docs/api-reference.md``
+    names the orbit-radius argument as ``size``; the pre-rename name
+    ``distance`` does not appear in the Pivot-orbit row.
+    """
+
+    _DOCS_PATH = (
+        Path(__file__).resolve().parent.parent / "docs" / "api-reference.md"
+    )
+
+    def _pivot_orbit_row(self) -> str:
+        text = self._DOCS_PATH.read_text(encoding="utf-8")
+        # Find the row starting with the "Pivot orbit" cell label so
+        # the assertion is anchored to the orbit-radius row and not to
+        # an unrelated mention of ``distance`` elsewhere in the doc.
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("| Pivot orbit "):
+                return line
+        raise AssertionError("Pivot orbit row not found in api-reference.md")
+
+    def test_pivot_orbit_row_names_size(self) -> None:
+        row = self._pivot_orbit_row()
+        self.assertIn(
+            "`size`",
+            row,
+            msg=(
+                "Pivot-orbit row of the camera-modes table must name the "
+                "orbit-radius argument as ``size`` (#81); observed row="
+                f"{row!r}"
+            ),
+        )
+
+    def test_pivot_orbit_row_does_not_name_distance(self) -> None:
+        row = self._pivot_orbit_row()
+        self.assertNotIn(
+            "distance",
+            row,
+            msg=(
+                "Pivot-orbit row of the camera-modes table must not "
+                "carry the pre-rename name ``distance`` (#81); observed "
+                f"row={row!r}"
+            ),
+        )
+
+
 def _extract_resolve_object_reference_body(source: str) -> str:
     """Custom extractor for ``ResolveObjectReference`` because the
     method's return type is the value tuple ``(UnityEngine.Object obj,
@@ -3355,6 +3582,9 @@ class EditorControlBridgeRequestSchemaTests(unittest.TestCase):
         "curves_json",
         # Prefab Stage save flag (issue #236).
         "save_on_close",
+        # Target-oriented screenshot (issue #84).
+        "target",
+        "angle",
     )
 
     _NEW_RESPONSE_FIELDS = (
@@ -4702,6 +4932,55 @@ class TestSetCameraGeometrySource(unittest.TestCase):
         self.assertIn("sv.orthographic", body)
         self.assertIn("sv.pivot", body)
         self.assertIn("sv.rotation", body)
+
+
+class TestGenericCollectionUsingDirective(unittest.TestCase):
+    """Issue #84 follow-up — every bridge ``.cs`` file that references a
+    generic collection type from ``System.Collections.Generic``
+    (``List<>`` / ``IList<>`` / ``Dictionary<>`` …) must also declare
+    ``using System.Collections.Generic;``.
+
+    The original target-oriented screenshot port shipped ``IList<>`` and
+    ``List<>`` references in ``PrefabSentinel.UnityEditorControlBridge
+    .Screenshot.cs`` without that using directive. CI compiles neither
+    the ``tools/unity/`` Unity-dependent ``.cs`` files (no Unity
+    reference assemblies in CI per CLAUDE.md §"Bridge C# コンパイル
+    検証") nor the xUnit-hosted ``tests/csharp`` mirror that excludes
+    them, so the resulting ``CS0246`` only surfaced when the bridge was
+    deployed into a real Unity project. This text-level invariant
+    closes that gap statically.
+    """
+
+    # Negative lookbehind ``(?<!\.)`` rejects fully-qualified usages
+    # like ``System.Collections.Generic.List<...>`` which resolve
+    # without the using directive (see PrefabSentinel.VRCSDKUploadHandler
+    # .cs for an in-tree example) — only the *short* unqualified form
+    # requires the directive to compile.
+    GENERIC_TYPE_REGEX = re.compile(
+        r"(?<!\.)\b(?:List|IList|IReadOnlyList|Dictionary|IDictionary|HashSet|"
+        r"Queue|Stack|IEnumerable|IReadOnlyCollection|ICollection)<"
+    )
+    USING_DIRECTIVE = "using System.Collections.Generic;"
+
+    def test_bridge_files_referencing_generic_collections_declare_the_using(
+        self,
+    ) -> None:
+        offenders: list[str] = []
+        for path in sorted(TOOLS_DIR.glob("PrefabSentinel*.cs")):
+            text = path.read_text(encoding="utf-8")
+            if self.GENERIC_TYPE_REGEX.search(text) and (
+                self.USING_DIRECTIVE not in text
+            ):
+                offenders.append(path.name)
+        self.assertEqual(
+            [],
+            offenders,
+            msg=(
+                "Bridge C# files reference generic collection types but miss "
+                f"`{self.USING_DIRECTIVE}`: {offenders}. Without the "
+                "directive, Unity rejects the file at deploy time (CS0246)."
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2373,10 +2373,14 @@ class TestEditorReadOnlyTools(unittest.TestCase):
         mock_send.assert_called_once_with(action="get_camera")
 
     def test_editor_set_camera_mode_b(self) -> None:
+        # Issue #81: orbit-radius MCP argument is named ``size``;
+        # the pre-rename ``distance`` alias is not registered on the
+        # MCP surface and must not appear on the bridge call kwargs.
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_set_camera", {"yaw": 45.0, "pitch": 15.0, "distance": 3.0}))
-        mock_send.assert_called_once_with(action="set_camera", yaw=45.0, pitch=15.0, distance=3.0)
+            _run(server.call_tool("editor_set_camera", {"yaw": 45.0, "pitch": 15.0, "size": 3.0}))
+        mock_send.assert_called_once_with(action="set_camera", yaw=45.0, pitch=15.0, size=3.0)
+        self.assertNotIn("distance", mock_send.call_args.kwargs)
 
     def test_editor_set_camera_defaults(self) -> None:
         server = create_server()

--- a/tests/test_mcp_tools_editor_view.py
+++ b/tests/test_mcp_tools_editor_view.py
@@ -353,6 +353,210 @@ class EditorScreenshotViewAllowlistTests(unittest.TestCase):
         )
 
 
+class EditorScreenshotAngleAllowlistTests(unittest.TestCase):
+    """Issue #84 — ``editor_screenshot`` rejects an ``angle`` value
+    outside the six-preset allowlist before any bridge transport
+    activity, and the exported allowlist tuple pins the canonical
+    six-name set in issue-body order.
+    """
+
+    _BRIDGE_OK = _SCREENSHOT_BRIDGE_OK
+
+    def test_allowlist_constant_pins_exact_value(self) -> None:
+        # Pin the exported tuple verbatim in the issue-body order;
+        # drift (adding a seventh, reordering, swapping a name) is
+        # the failure mode this row catches.
+        self.assertEqual(
+            ("front", "three_quarter", "back", "right", "left", "top"),
+            mcp_tools_editor_view.SCREENSHOT_ANGLE_PRESETS,
+            msg=(
+                "Wrapper-side angle allowlist must equal the six "
+                "preset names from issue #84 in canonical order."
+            ),
+        )
+
+    def test_unknown_angle_preset_rejected_pre_bridge(self) -> None:
+        with patch.object(
+            mcp_tools_editor_view, "send_action", return_value=self._BRIDGE_OK,
+        ) as send:
+            response = mcp_tools_editor_view.editor_screenshot(
+                target="/Avatar", angle="three_eighths", refresh=False,
+            )
+        send.assert_not_called()
+        observed = (
+            response["success"],
+            response["severity"],
+            response["code"],
+            "three_eighths" in response["message"],
+            "three_quarter" in response["message"],
+        )
+        self.assertEqual(
+            (False, "error", "SCREENSHOT_ANGLE_INVALID", True, True),
+            observed,
+            msg=(
+                "Unknown angle preset must yield SCREENSHOT_ANGLE_INVALID "
+                "with a message naming the supplied value and at least "
+                "one of the six allowed preset names."
+            ),
+        )
+
+    def test_wrapper_rejection_on_target_path_suppresses_refresh(self) -> None:
+        # Pre-bridge wrapper rejection on an angle-allowlist violation
+        # must suppress the pre-screenshot refresh round-trip; the
+        # wrapper performs no transport activity at all on rejection.
+        with patch.object(
+            mcp_tools_editor_view, "send_action", return_value=self._BRIDGE_OK,
+        ) as send:
+            response = mcp_tools_editor_view.editor_screenshot(
+                target="/Avatar", angle="bogus", refresh=True,
+            )
+        send.assert_not_called()
+        self.assertEqual(
+            "SCREENSHOT_ANGLE_INVALID", response["code"],
+            msg=(
+                "Rejected target/angle combination must suppress the "
+                "pre-screenshot refresh round-trip (#84)."
+            ),
+        )
+
+
+class EditorScreenshotTargetForwardingTests(unittest.TestCase):
+    """Issue #84 — ``editor_screenshot`` target-oriented capture mode
+    forwarding contract.
+
+    Pins:
+
+    * Default screenshot call carries neither ``target`` nor ``angle``
+      on the bridge kwargs (no silent forwarding of the default
+      ``angle="three_quarter"`` when ``target`` is empty).
+    * Object-capture forwarding: both ``target`` and ``angle`` reach
+      the bridge action verbatim.
+    * ``view="game"`` + ``target`` is rejected pre-bridge with
+      ``SCREENSHOT_TARGET_INVALID_VIEW``.
+    * ``target`` + face-feature ``crop_roi`` preset is rejected with
+      ``SCREENSHOT_TARGET_CROP_CONFLICT``.
+    * ``target`` + pixel-rectangle ``crop_roi`` is accepted; both
+      fields reach the bridge.
+    """
+
+    _BRIDGE_OK = _SCREENSHOT_BRIDGE_OK
+
+    def test_default_args_produce_no_target_or_angle_on_kwargs(self) -> None:
+        with patch.object(
+            mcp_tools_editor_view, "send_action", return_value=self._BRIDGE_OK,
+        ) as send:
+            mcp_tools_editor_view.editor_screenshot(refresh=False)
+        send.assert_called_once()
+        kwargs = send.call_args.kwargs
+        self.assertEqual(
+            ("capture_screenshot", False, False),
+            (
+                kwargs["action"],
+                "target" in kwargs,
+                "angle" in kwargs,
+            ),
+            msg=(
+                "Default editor_screenshot() must carry neither "
+                "``target`` nor ``angle`` on the bridge kwargs (no "
+                "silent forwarding of the wrapper default angle when "
+                "target is empty)."
+            ),
+        )
+
+    def test_target_and_angle_both_reach_the_bridge_verbatim(self) -> None:
+        with patch.object(
+            mcp_tools_editor_view, "send_action", return_value=self._BRIDGE_OK,
+        ) as send:
+            mcp_tools_editor_view.editor_screenshot(
+                target="/Avatar/Body", angle="three_quarter", refresh=False,
+            )
+        send.assert_called_once()
+        kwargs = send.call_args.kwargs
+        self.assertEqual(
+            ("capture_screenshot", "/Avatar/Body", "three_quarter"),
+            (kwargs["action"], kwargs["target"], kwargs["angle"]),
+            msg=(
+                "target='/Avatar/Body' and angle='three_quarter' must "
+                "reach the bridge unchanged on the capture_screenshot "
+                "action."
+            ),
+        )
+
+    def test_view_game_with_target_is_rejected_pre_bridge(self) -> None:
+        with patch.object(
+            mcp_tools_editor_view, "send_action", return_value=self._BRIDGE_OK,
+        ) as send:
+            response = mcp_tools_editor_view.editor_screenshot(
+                view="game", target="/Avatar", refresh=False,
+            )
+        send.assert_not_called()
+        observed = (
+            response["success"],
+            response["severity"],
+            response["code"],
+            "game" in response["message"],
+            "scene" in response["message"],
+        )
+        self.assertEqual(
+            (False, "error", "SCREENSHOT_TARGET_INVALID_VIEW", True, True),
+            observed,
+            msg=(
+                "view='game' with target must yield "
+                "SCREENSHOT_TARGET_INVALID_VIEW naming the supplied "
+                "view and the Scene-view-only constraint."
+            ),
+        )
+
+    def test_target_with_face_feature_crop_roi_is_rejected(self) -> None:
+        with patch.object(
+            mcp_tools_editor_view, "send_action", return_value=self._BRIDGE_OK,
+        ) as send:
+            response = mcp_tools_editor_view.editor_screenshot(
+                target="/Avatar", crop_roi="auto_face", refresh=False,
+            )
+        send.assert_not_called()
+        observed = (
+            response["success"],
+            response["severity"],
+            response["code"],
+            "auto_face" in response["message"],
+            "/Avatar" in response["message"],
+        )
+        self.assertEqual(
+            (False, "error", "SCREENSHOT_TARGET_CROP_CONFLICT", True, True),
+            observed,
+            msg=(
+                "target + face-feature crop_roi must yield "
+                "SCREENSHOT_TARGET_CROP_CONFLICT naming both supplied "
+                "values."
+            ),
+        )
+
+    def test_target_with_pixel_rectangle_crop_roi_passes_through(self) -> None:
+        # Pixel-rectangle crop_roi is independent of the framing
+        # re-frame, so the combination is explicitly accepted by
+        # the spec; both fields must reach the bridge.
+        with patch.object(
+            mcp_tools_editor_view, "send_action", return_value=self._BRIDGE_OK,
+        ) as send:
+            mcp_tools_editor_view.editor_screenshot(
+                target="/Avatar",
+                crop_roi="10,20,300,200",
+                refresh=False,
+            )
+        send.assert_called_once()
+        kwargs = send.call_args.kwargs
+        self.assertEqual(
+            ("capture_screenshot", "/Avatar", "10,20,300,200"),
+            (kwargs["action"], kwargs["target"], kwargs["crop_roi"]),
+            msg=(
+                "target + pixel-rectangle crop_roi must both reach the "
+                "bridge on the capture_screenshot action (the rectangle "
+                "is applied to the rendered frame after framing)."
+            ),
+        )
+
+
 class EditorForceSceneViewRefreshTests(unittest.TestCase):
     """Issue #242 — ``editor_force_scene_view_refresh`` routing."""
 

--- a/tools/unity/PrefabSentinel.Dispatch.EditorControlRequest.cs
+++ b/tools/unity/PrefabSentinel.Dispatch.EditorControlRequest.cs
@@ -53,11 +53,13 @@ namespace PrefabSentinel
         public int depth = 1;
 
         // camera (get_camera / set_camera)
-        // Pivot orbit: pivot + yaw/pitch/distance
+        // Pivot orbit: pivot + yaw/pitch/size (issue #81 — orbit-radius
+        // argument carries SceneView.size semantics, Scene-view
+        // half-width; named ``size`` end-to-end).
         public float[] camera_pivot = null;      // [x, y, z] pivot point
         public float yaw = float.NaN;           // NaN = keep current
         public float pitch = float.NaN;
-        public float distance = -1f;             // SceneView.size; -1 = keep current
+        public float size = -1f;                 // SceneView.size; -1 = keep current
         // Position mode: camera_position + camera_look_at or yaw/pitch
         public float[] camera_position = null;   // [x, y, z] camera world coords
         public float[] camera_look_at = null;    // [x, y, z] look-at target
@@ -230,6 +232,16 @@ namespace PrefabSentinel
         // a comma-separated pixel quadruple ``"x,y,w,h"``.  Empty =
         // no region, capture full frame.
         public string crop_roi = string.Empty;
+
+        // Issue #84: target-oriented capture mode payload for
+        // ``capture_screenshot``.  ``target`` is the hierarchy path
+        // of the GameObject to frame (empty = no object-capture
+        // mode, current-view capture).  ``angle`` is one of the
+        // six preset names from ``ObjectCaptureFramingMath.PresetNames``
+        // (``front`` / ``three_quarter`` / ``back`` / ``right`` /
+        // ``left`` / ``top``); ignored when ``target`` is empty.
+        public string target = string.Empty;
+        public string angle = string.Empty;
 
         // Issue #241: caller-supplied pagination knobs for
         // ``get_blend_shapes``.  Defaults reproduce the pre-pagination

--- a/tools/unity/PrefabSentinel.Screenshot.ObjectCaptureFramingMath.cs
+++ b/tools/unity/PrefabSentinel.Screenshot.ObjectCaptureFramingMath.cs
@@ -1,0 +1,544 @@
+// The helper exposes ``out float[]`` parameters that are set to ``null``
+// on the failure branch; ``#nullable disable`` keeps the file warning-
+// clean under both the Unity assembly (nullable off) and the xUnit test
+// project (nullable on), matching the precedent of the request-DTO
+// partial ``PrefabSentinel.Dispatch.EditorControlRequest.cs``.
+#nullable disable
+using System;
+using System.Collections.Generic;
+
+// Pure framing math for the target-oriented screenshot capture mode
+// (issue #84). The helper is Unity-free so the C# xUnit harness can
+// exercise the math end-to-end without a Unity assembly reference;
+// the bridge-side ``HandleCaptureScreenshot`` partial consumes its
+// outputs (preset direction, outlier-filtered renderer subset,
+// framing pivot + Scene-view half-width) and then applies them via
+// ``SceneView.LookAt``.
+//
+// Naming/placement precedent: PrefabSentinel.Screenshot.ViewAllowlistClassifier.cs.
+//
+// Conventions match the issue body verbatim:
+//   * Preset (yaw, pitch) seeds are target-LOCAL; the camera-position
+//     direction is composed as
+//     ``targetRotation * Q.Euler(pitch, yaw, 0) * Vector3.forward``
+//     under Unity's left-handed Y-up convention (``yaw=0`` faces +Z).
+//   * ``cameraDirectionWorld`` is the camera-POSITION direction:
+//     a unit vector pointing FROM the framing pivot TOWARD the
+//     camera (= ``-cameraForward``).  ``cameraRight``/``cameraUp``
+//     complete the orthonormal basis as the Unity SceneView would
+//     derive them via ``Quaternion.LookRotation(-cameraDir, worldUp)``.
+//   * Outlier-renderer inclusion margin is
+//     ``max(0.30 * core_largest_extent_dimension, 0.1)`` world-space
+//     units, applied to the AABB-center-to-AABB-center distance from
+//     the largest-extent renderer.
+//   * Perspective-correct two-end binding: per-axis enumerate every
+//     ordered corner pair (i, j), accept pairs whose D > 0 and where
+//     every other corner stays inside the ±K frame, take the smallest
+//     such D, then re-center the non-binding axis at the final
+//     ``max(D_horizontal, D_vertical)``.  The re-centering iteration
+//     bound is 3 (the issue body's "1〜3 iterations" upper limit).
+namespace PrefabSentinel
+{
+    /// <summary>
+    /// Pure-math helpers for the target-oriented screenshot capture
+    /// branch (issue #84).  Exposed as a static class so the bridge
+    /// handler and the C# xUnit harness consume the same source.
+    /// </summary>
+    public static class ObjectCaptureFramingMath
+    {
+        /// <summary>
+        /// Canonical six-member preset name list in the issue-body order:
+        /// ``front`` / ``three_quarter`` / ``back`` / ``right`` / ``left`` / ``top``.
+        /// </summary>
+        public static readonly string[] PresetNames =
+        {
+            "front",
+            "three_quarter",
+            "back",
+            "right",
+            "left",
+            "top",
+        };
+
+        /// <summary>
+        /// Issue #84 body authored (yaw_degrees, pitch_degrees) seed
+        /// pairs.  Index aligns with <see cref="PresetNames"/>.
+        ///
+        /// The seeds are target-LOCAL.  A change to one entry here must
+        /// be reflected in the per-preset T1 row and the issue-body-seed
+        /// row in the test class so drift between the helper and the
+        /// authored seed surfaces rather than going silent.
+        /// </summary>
+        public static readonly float[] PresetYawDegrees =
+            { 0f, 35f, 180f, 90f, -90f, 0f };
+
+        public static readonly float[] PresetPitchDegrees =
+            { -5f, -10f, -5f, -5f, -5f, -89f };
+
+        /// <summary>
+        /// Outlier-filter inclusion margin: include other renderers
+        /// whose AABB center lies within
+        /// ``max(OutlierMarginRelative * core_largest_extent_dim,
+        /// OutlierMarginFloor)`` world-space units of the core
+        /// renderer's center.  Both constants are exposed so the C#
+        /// xUnit harness pins them.
+        /// </summary>
+        public const float OutlierMarginRelative = 0.30f;
+        public const float OutlierMarginFloor = 0.1f;
+
+        /// <summary>
+        /// Internal framing margin factor (issue body: PoC verified
+        /// 1.0).  Multiplies the K = tan(fov/2) bound so the rendered
+        /// subject can be padded by a fixed fraction without exposing
+        /// a continuous ``fill`` parameter on the MCP surface.
+        /// </summary>
+        public const float DefaultFramingMargin = 1.0f;
+
+        /// <summary>
+        /// Re-centering iteration count for the non-binding axis
+        /// (issue body: "1〜3 反復で収束").
+        /// </summary>
+        public const int RecenteringIterationCount = 3;
+
+        // Failure reason literals returned through the Try* helpers
+        // so callers (bridge handler, xUnit tests) can branch on a
+        // structured value instead of message parsing.
+        public const string FailureUnknownPreset = "unknown_preset";
+        public const string FailureDegenerateAabb = "degenerate_aabb";
+        public const string FailureNoValidBinding = "no_valid_binding";
+
+        /// <summary>
+        /// Resolve <paramref name="preset"/> to the issue-body authored
+        /// target-local (yaw, pitch) pair.  Returns true and writes the
+        /// pair into the out parameters when the name is in
+        /// <see cref="PresetNames"/>; returns false otherwise.
+        /// </summary>
+        public static bool TryGetPresetAngles(
+            string preset,
+            out float yawDegrees,
+            out float pitchDegrees)
+        {
+            for (int i = 0; i < PresetNames.Length; i++)
+            {
+                if (string.Equals(preset, PresetNames[i], StringComparison.Ordinal))
+                {
+                    yawDegrees = PresetYawDegrees[i];
+                    pitchDegrees = PresetPitchDegrees[i];
+                    return true;
+                }
+            }
+            yawDegrees = 0f;
+            pitchDegrees = 0f;
+            return false;
+        }
+
+        /// <summary>
+        /// Resolve <paramref name="preset"/> to a world-space camera-
+        /// position direction unit vector.  Composition order matches
+        /// Unity's ``targetRotation * Quaternion.Euler(pitch, yaw, 0)
+        /// * Vector3.forward`` (the +Z convention documented in
+        /// ``docs/api-reference.md``).  The output is a length-3 unit
+        /// vector pointing FROM the framing pivot TOWARD the camera.
+        ///
+        /// <paramref name="targetRotationQuaternionXYZW"/> is the
+        /// target's world rotation as ``[x, y, z, w]``; the identity
+        /// rotation is ``[0, 0, 0, 1]``.
+        /// </summary>
+        public static bool TryResolvePresetDirection(
+            string preset,
+            float[] targetRotationQuaternionXYZW,
+            out float[] cameraDirectionWorld,
+            out string failureReason)
+        {
+            cameraDirectionWorld = null;
+            failureReason = string.Empty;
+            if (!TryGetPresetAngles(preset, out float yawDeg, out float pitchDeg))
+            {
+                failureReason = FailureUnknownPreset;
+                return false;
+            }
+            if (targetRotationQuaternionXYZW == null
+                || targetRotationQuaternionXYZW.Length != 4)
+            {
+                throw new ArgumentException(
+                    "targetRotationQuaternionXYZW must be length 4 (x, y, z, w).",
+                    nameof(targetRotationQuaternionXYZW));
+            }
+
+            // Target-local direction = Q.Euler(pitch, yaw, 0) * (0, 0, 1).
+            // Unity ZXY intrinsic order reduces to RotY(yaw) * RotX(pitch)
+            // when the Z angle is zero. The closed form (with Unity's
+            // sign convention for RotX) yields:
+            //   localDir.x = cos(pitch) * sin(yaw)
+            //   localDir.y = -sin(pitch)
+            //   localDir.z = cos(pitch) * cos(yaw)
+            double yawRad = yawDeg * Math.PI / 180.0;
+            double pitchRad = pitchDeg * Math.PI / 180.0;
+            double cp = Math.Cos(pitchRad);
+            double sp = Math.Sin(pitchRad);
+            double cy = Math.Cos(yawRad);
+            double sy = Math.Sin(yawRad);
+            double lx = cp * sy;
+            double ly = -sp;
+            double lz = cp * cy;
+
+            // Rotate local direction by the target's world rotation:
+            //   v' = v + 2 * cross(q.xyz, cross(q.xyz, v) + q.w * v)
+            double qx = targetRotationQuaternionXYZW[0];
+            double qy = targetRotationQuaternionXYZW[1];
+            double qz = targetRotationQuaternionXYZW[2];
+            double qw = targetRotationQuaternionXYZW[3];
+
+            double tx = qy * lz - qz * ly + qw * lx;
+            double ty = qz * lx - qx * lz + qw * ly;
+            double tz = qx * ly - qy * lx + qw * lz;
+            double wx = lx + 2.0 * (qy * tz - qz * ty);
+            double wy = ly + 2.0 * (qz * tx - qx * tz);
+            double wz = lz + 2.0 * (qx * ty - qy * tx);
+
+            cameraDirectionWorld = NormalizeOrFallback(wx, wy, wz);
+            return true;
+        }
+
+        /// <summary>
+        /// Renderer-bounds record: one axis-aligned bounding box in
+        /// world space, described by its center and per-axis half-
+        /// extents.  Plain POCO so the C# xUnit harness consumes the
+        /// helper without dragging in Unity's ``Bounds`` type.
+        /// </summary>
+        public sealed class RendererBoundsRecord
+        {
+            public float[] CenterWorld;
+            public float[] ExtentsWorld;
+
+            public RendererBoundsRecord(
+                float[] centerWorld, float[] extentsWorld)
+            {
+                if (centerWorld == null || centerWorld.Length != 3)
+                {
+                    throw new ArgumentException(
+                        "centerWorld must be length 3.",
+                        nameof(centerWorld));
+                }
+                if (extentsWorld == null || extentsWorld.Length != 3)
+                {
+                    throw new ArgumentException(
+                        "extentsWorld must be length 3.",
+                        nameof(extentsWorld));
+                }
+                CenterWorld = centerWorld;
+                ExtentsWorld = extentsWorld;
+            }
+
+            public float LargestExtentDimension()
+            {
+                float ex = Math.Abs(ExtentsWorld[0]);
+                float ey = Math.Abs(ExtentsWorld[1]);
+                float ez = Math.Abs(ExtentsWorld[2]);
+                float max = ex;
+                if (ey > max) max = ey;
+                if (ez > max) max = ez;
+                return max;
+            }
+        }
+
+        /// <summary>
+        /// Outlier filter (issue #84): select the renderer with the
+        /// largest per-axis extent dimension as the core envelope,
+        /// then keep every other renderer whose AABB center lies
+        /// within ``max(OutlierMarginRelative * core_largest_extent,
+        /// OutlierMarginFloor)`` of the core renderer's center.
+        ///
+        /// Returns the input unchanged on empty or single-member
+        /// input (nothing to filter against).  Stable order: the
+        /// core renderer appears first, then every kept candidate
+        /// in input order.
+        /// </summary>
+        public static IList<RendererBoundsRecord> SelectFramingRenderers(
+            IList<RendererBoundsRecord> renderers)
+        {
+            if (renderers == null) return Array.Empty<RendererBoundsRecord>();
+            if (renderers.Count <= 1) return renderers;
+
+            int coreIndex = 0;
+            float coreExtent = renderers[0].LargestExtentDimension();
+            for (int i = 1; i < renderers.Count; i++)
+            {
+                float ex = renderers[i].LargestExtentDimension();
+                if (ex > coreExtent)
+                {
+                    coreExtent = ex;
+                    coreIndex = i;
+                }
+            }
+
+            // Per-axis AABB containment matches the PoC reference
+            // (PFPoCFraming.Frame ``Bounds.Contains`` with a per-axis
+            // expansion vector). A euclidean-sphere distance test —
+            // the bridge's initial port — over-aggressively drops
+            // renderers far from the core along a single axis: a
+            // VRChat avatar's head sits ~1m above the body's center,
+            // so a sphere threshold of ``OutlierMarginRelative *
+            // largest-extent`` (~0.24 m for an 0.8 m core) excludes
+            // it, the aggregate AABB then covers only the body, and
+            // framing clips the head out of frame.
+            var core = renderers[coreIndex];
+            float allowX = core.ExtentsWorld[0]
+                + Math.Max(OutlierMarginRelative * core.ExtentsWorld[0], OutlierMarginFloor);
+            float allowY = core.ExtentsWorld[1]
+                + Math.Max(OutlierMarginRelative * core.ExtentsWorld[1], OutlierMarginFloor);
+            float allowZ = core.ExtentsWorld[2]
+                + Math.Max(OutlierMarginRelative * core.ExtentsWorld[2], OutlierMarginFloor);
+
+            var kept = new List<RendererBoundsRecord> { core };
+            for (int i = 0; i < renderers.Count; i++)
+            {
+                if (i == coreIndex) continue;
+                var r = renderers[i];
+                float dx = Math.Abs(r.CenterWorld[0] - core.CenterWorld[0]);
+                float dy = Math.Abs(r.CenterWorld[1] - core.CenterWorld[1]);
+                float dz = Math.Abs(r.CenterWorld[2] - core.CenterWorld[2]);
+                if (dx <= allowX && dy <= allowY && dz <= allowZ)
+                {
+                    kept.Add(r);
+                }
+            }
+            return kept;
+        }
+
+        /// <summary>
+        /// Solve the perspective-correct framing for the AABB whose
+        /// eight world-space corners are supplied flat as 24 floats
+        /// (``[x0,y0,z0, x1,y1,z1, ..., x7,y7,z7]``).
+        ///
+        /// On success writes the world-space framing pivot and the
+        /// corresponding Scene-view half-width (``SceneView.size``)
+        /// to the out parameters.  Returns false when the AABB is
+        /// degenerate (every projected extent is below the numerical
+        /// epsilon) or when no valid binding pair exists at any
+        /// orientation (e.g., every candidate D > 0 places at least
+        /// one corner behind the camera plane).
+        ///
+        /// <paramref name="recenteringIterations"/> is the number of
+        /// re-centering passes for the non-binding axis at the final
+        /// max(D_horizontal, D_vertical).  3 is the issue body's
+        /// upper bound; tests pass 4+ to verify convergence stability.
+        /// </summary>
+        public static bool TrySolveFramingForAabb(
+            float[] cornersWorld,
+            float[] cameraRightWorld,
+            float[] cameraUpWorld,
+            float[] cameraDirectionWorld,
+            float fovDegrees,
+            float aspect,
+            float margin,
+            int recenteringIterations,
+            out float[] pivotWorld,
+            out float size,
+            out string failureReason)
+        {
+            pivotWorld = null;
+            size = 0f;
+            failureReason = string.Empty;
+            if (cornersWorld == null || cornersWorld.Length != 24)
+            {
+                throw new ArgumentException(
+                    "cornersWorld must carry 8 corners flattened to 24 floats.",
+                    nameof(cornersWorld));
+            }
+            RequireLength3(cameraRightWorld, nameof(cameraRightWorld));
+            RequireLength3(cameraUpWorld, nameof(cameraUpWorld));
+            RequireLength3(cameraDirectionWorld, nameof(cameraDirectionWorld));
+
+            // Translate corners so the AABB-center sits at the origin
+            // in the chosen camera basis. The pivot we solve for is
+            // expressed as (delta_h, delta_v) offsets from AABB center
+            // along (cameraRight, cameraUp); we add the AABB center
+            // back at the end.
+            double aabbCenterX = 0.0, aabbCenterY = 0.0, aabbCenterZ = 0.0;
+            for (int i = 0; i < 8; i++)
+            {
+                aabbCenterX += cornersWorld[i * 3 + 0];
+                aabbCenterY += cornersWorld[i * 3 + 1];
+                aabbCenterZ += cornersWorld[i * 3 + 2];
+            }
+            aabbCenterX /= 8.0;
+            aabbCenterY /= 8.0;
+            aabbCenterZ /= 8.0;
+
+            // Project the corners onto the three camera basis axes.
+            double[] uProj = new double[8];
+            double[] vProj = new double[8];
+            double[] hProj = new double[8];
+            double maxExtentSq = 0.0;
+            for (int i = 0; i < 8; i++)
+            {
+                double cx = cornersWorld[i * 3 + 0] - aabbCenterX;
+                double cy = cornersWorld[i * 3 + 1] - aabbCenterY;
+                double cz = cornersWorld[i * 3 + 2] - aabbCenterZ;
+                uProj[i] = cx * cameraRightWorld[0]
+                         + cy * cameraRightWorld[1]
+                         + cz * cameraRightWorld[2];
+                vProj[i] = cx * cameraUpWorld[0]
+                         + cy * cameraUpWorld[1]
+                         + cz * cameraUpWorld[2];
+                hProj[i] = cx * cameraDirectionWorld[0]
+                         + cy * cameraDirectionWorld[1]
+                         + cz * cameraDirectionWorld[2];
+                double extentSq = cx * cx + cy * cy + cz * cz;
+                if (extentSq > maxExtentSq) maxExtentSq = extentSq;
+            }
+
+            const double DegenerateEpsilon = 1e-10;
+            if (maxExtentSq < DegenerateEpsilon)
+            {
+                failureReason = FailureDegenerateAabb;
+                return false;
+            }
+
+            double tanHalfFov = Math.Tan(fovDegrees * 0.5 * Math.PI / 180.0);
+            double kH = tanHalfFov * aspect * margin;
+            double kV = tanHalfFov * margin;
+
+            if (!TrySolveAxis(uProj, hProj, kH, out double dH, out double deltaH))
+            {
+                failureReason = FailureNoValidBinding;
+                return false;
+            }
+            if (!TrySolveAxis(vProj, hProj, kV, out double dV, out double deltaV))
+            {
+                failureReason = FailureNoValidBinding;
+                return false;
+            }
+
+            double dFinal = Math.Max(dH, dV);
+
+            // Re-center the non-binding axis at dFinal. The binding
+            // axis already touches both edges at dFinal (it's the
+            // axis that drove dFinal), so it does not move.
+            if (dV > dH)
+            {
+                deltaH = Recenter(uProj, hProj, dFinal, deltaH, recenteringIterations);
+            }
+            else if (dH > dV)
+            {
+                deltaV = Recenter(vProj, hProj, dFinal, deltaV, recenteringIterations);
+            }
+
+            pivotWorld = new float[3]
+            {
+                (float)(aabbCenterX
+                    + deltaH * cameraRightWorld[0]
+                    + deltaV * cameraUpWorld[0]),
+                (float)(aabbCenterY
+                    + deltaH * cameraRightWorld[1]
+                    + deltaV * cameraUpWorld[1]),
+                (float)(aabbCenterZ
+                    + deltaH * cameraRightWorld[2]
+                    + deltaV * cameraUpWorld[2]),
+            };
+            size = (float)(dFinal * Math.Sin(fovDegrees * 0.5 * Math.PI / 180.0));
+            return true;
+        }
+
+        // Per-axis two-end binding solve. Returns the smallest valid
+        // (D, delta) over all ordered corner pairs (i, j) for which
+        // every other corner stays inside the ±K frame at depth D.
+        private static bool TrySolveAxis(
+            double[] proj, double[] hProj, double k,
+            out double bestD, out double bestDelta)
+        {
+            bestD = double.PositiveInfinity;
+            bestDelta = 0.0;
+            bool found = false;
+            const double DepthEpsilon = 1e-6;
+            // The validity bound includes a small slack so the binding
+            // pair's own corners (which sit exactly on |val|/depth = K)
+            // do not fall out of the tolerance bound.
+            double kBound = k * (1.0 + 1e-4) + 1e-6;
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    if (i == j) continue;
+                    double d = (proj[i] - proj[j]) / (2.0 * k)
+                             + (hProj[i] + hProj[j]) / 2.0;
+                    if (d <= DepthEpsilon) continue;
+                    double delta = (proj[i] + proj[j]) / 2.0
+                                 + k * (hProj[i] - hProj[j]) / 2.0;
+                    bool valid = true;
+                    for (int kc = 0; kc < 8; kc++)
+                    {
+                        double depth = d - hProj[kc];
+                        if (depth <= DepthEpsilon) { valid = false; break; }
+                        double lateral = proj[kc] - delta;
+                        double ratio = lateral / depth;
+                        if (ratio > kBound || ratio < -kBound)
+                        {
+                            valid = false;
+                            break;
+                        }
+                    }
+                    if (valid && d < bestD)
+                    {
+                        bestD = d;
+                        bestDelta = delta;
+                        found = true;
+                    }
+                }
+            }
+            return found;
+        }
+
+        // Re-center the non-binding axis at the final D: pick the
+        // current max- and min-projection corners (each at its own
+        // depth) and shift delta so the lateral / depth projections
+        // balance.  Iterate to handle corner swaps after the shift.
+        private static double Recenter(
+            double[] proj, double[] hProj, double dFinal,
+            double delta, int iterations)
+        {
+            for (int iter = 0; iter < iterations; iter++)
+            {
+                double maxProj = double.NegativeInfinity;
+                double minProj = double.PositiveInfinity;
+                double depthAtMax = 1.0;
+                double depthAtMin = 1.0;
+                for (int k = 0; k < 8; k++)
+                {
+                    double depth = dFinal - hProj[k];
+                    if (depth <= 0.0) continue;
+                    double p = (proj[k] - delta) / depth;
+                    if (p > maxProj) { maxProj = p; depthAtMax = depth; }
+                    if (p < minProj) { minProj = p; depthAtMin = depth; }
+                }
+                double denom = 1.0 / depthAtMax + 1.0 / depthAtMin;
+                if (denom <= 0.0) break;
+                double shift = (maxProj + minProj) / denom;
+                if (Math.Abs(shift) < 1e-9) break;
+                delta += shift;
+            }
+            return delta;
+        }
+
+        private static void RequireLength3(float[] vec, string name)
+        {
+            if (vec == null || vec.Length != 3)
+            {
+                throw new ArgumentException(
+                    $"{name} must be length 3.", name);
+            }
+        }
+
+        private static float[] NormalizeOrFallback(double x, double y, double z)
+        {
+            double len = Math.Sqrt(x * x + y * y + z * z);
+            if (len < 1e-9)
+            {
+                return new float[] { 0f, 0f, 1f };
+            }
+            double inv = 1.0 / len;
+            return new float[] { (float)(x * inv), (float)(y * inv), (float)(z * inv) };
+        }
+    }
+}

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.CameraView.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.CameraView.cs
@@ -360,7 +360,8 @@ namespace PrefabSentinel
             bool hasPivot = request.camera_pivot != null && request.camera_pivot.Length == 3;
             bool hasYaw = !float.IsNaN(request.yaw);
             bool hasPitch = !float.IsNaN(request.pitch);
-            bool hasDistance = request.distance >= 0f;
+            // Issue #81: orbit-radius field is named ``size`` end-to-end.
+            bool hasSize = request.size >= 0f;
 
             // Reset mode (issue #112): restore the SceneView to documented
             // defaults via the public synchronous LookAt entry point and
@@ -438,7 +439,7 @@ namespace PrefabSentinel
                 }
                 else
                 {
-                    float newSize = hasDistance ? request.distance : sceneView.size;
+                    float newSize = hasSize ? request.size : sceneView.size;
                     Vector3 currentEuler = sceneView.rotation.eulerAngles;
                     float curYaw = (currentEuler.y + 180f) % 360f;
                     float curPitch = currentEuler.x > 180f ? currentEuler.x - 360f : currentEuler.x;
@@ -478,7 +479,7 @@ namespace PrefabSentinel
                     newRot = Quaternion.Euler(newPitch, internalYaw, 0f);
                 }
 
-                float newSize = hasDistance ? request.distance : sceneView.size;
+                float newSize = hasSize ? request.size : sceneView.size;
                 sceneView.LookAt(
                     newPivot, newRot, newSize, sceneView.orthographic,
                     instant: true);

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.Screenshot.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.Screenshot.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -119,7 +120,7 @@ namespace PrefabSentinel
         }
 
         /// <summary>
-        /// Capture a screenshot of the Unity Editor (issue #249).
+        /// Capture a screenshot of the Unity Editor (issues #249, #84).
         ///
         /// When ``crop_roi`` is non-empty the handler resolves it to a
         /// preset label or a pixel rectangle and surfaces the resolution
@@ -129,6 +130,16 @@ namespace PrefabSentinel
         /// so the editor's scene view pivot returns to its pre-call
         /// value before the response is built. The pixel-rect branch
         /// crops the encoded PNG to the supplied rectangle.
+        ///
+        /// Issue #84: when ``request.target`` is non-empty the handler
+        /// re-frames the SceneView onto the named GameObject's
+        /// world-space AABB at the requested angle preset via
+        /// ``ObjectCaptureFramingMath`` and ``SceneView.LookAt``, then
+        /// restores the previous SceneView camera state before the
+        /// response is built. The response carries the framing
+        /// AABB on the existing ``bounds_center`` / ``bounds_extents``
+        /// fields (additive: these fields are unset on the existing
+        /// capture paths).
         /// </summary>
         private static EditorControlResponse HandleCaptureScreenshot(EditorControlRequest request, string requestPath)
         {
@@ -155,6 +166,20 @@ namespace PrefabSentinel
 
             string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
             string outputPath = Path.Combine(outputDir, $"{request.view}_{timestamp}.png");
+
+            // Issue #84: target-oriented capture mode is dispatched
+            // here, BEFORE the crop_roi resolution. The wrapper rejects
+            // ``target`` + face-feature crop_roi, so on the bridge side
+            // a non-empty ``target`` only ever arrives with empty
+            // crop_roi or a pixel rectangle (the latter is orthogonal
+            // to framing and applied post-render by
+            // ``HandleObjectCaptureScreenshot``). The branch owns its
+            // own render and camera-state restore; it never falls
+            // through to the existing scene/game switch below.
+            if (!string.IsNullOrEmpty(request.target))
+            {
+                return HandleObjectCaptureScreenshot(request, outputPath);
+            }
 
             // Issue #249: resolve the optional region argument before
             // engaging the renderer.  An unrecognised value short-circuits
@@ -259,19 +284,7 @@ namespace PrefabSentinel
                     Texture2D tex = null;
                     try
                     {
-                        var smrs = UnityEngine.Object.FindObjectsOfType<SkinnedMeshRenderer>();
-                        foreach (var smr in smrs)
-                            smr.forceMatrixRecalculationPerRender = true;
-
-                        rt = new RenderTexture(w, h, 24);
-                        RenderTexture prev = cam.targetTexture;
-                        cam.targetTexture = rt;
-                        cam.Render();
-                        cam.targetTexture = prev;
-
-                        foreach (var smr in smrs)
-                            smr.forceMatrixRecalculationPerRender = false;
-
+                        rt = RenderSceneViewToTexture(cam, w, h);
                         RenderTexture.active = rt;
                         if (cropLabel == "pixel_rect" && cropBounds != null)
                         {
@@ -381,6 +394,388 @@ namespace PrefabSentinel
             {
                 return BuildError("EDITOR_CTRL_SCREENSHOT_FAILED", $"Screenshot failed: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Issue #84 — target-oriented capture branch of
+        /// ``HandleCaptureScreenshot``.  Resolves ``request.target``
+        /// through the existing stage-aware resolver, aggregates
+        /// renderer bounds (SkinnedMeshRenderer baked at the current
+        /// pose; MeshRenderer corners world-transformed), runs the
+        /// Unity-free outlier filter + framing solver, applies the
+        /// computed pivot/rotation/size via ``SceneView.LookAt``,
+        /// renders + encodes, and restores the previous SceneView
+        /// state before returning.  Returns the response envelope
+        /// (success or error); the caller dispatches on a non-null
+        /// return.
+        /// </summary>
+        private static EditorControlResponse HandleObjectCaptureScreenshot(
+            EditorControlRequest request, string outputPath)
+        {
+            // Defense-in-depth: the wrapper rejects unknown presets,
+            // but the bridge mirrors the gate so a direct bridge call
+            // (e.g., from the integration test runner) sees the same
+            // typed error.
+            string angle = string.IsNullOrEmpty(request.angle)
+                ? "three_quarter"
+                : request.angle;
+            bool knownPreset = false;
+            foreach (var preset in ObjectCaptureFramingMath.PresetNames)
+            {
+                if (string.Equals(preset, angle, StringComparison.Ordinal))
+                {
+                    knownPreset = true;
+                    break;
+                }
+            }
+            if (!knownPreset)
+            {
+                return BuildError(
+                    "EDITOR_CTRL_SCREENSHOT_ANGLE_INVALID",
+                    $"angle='{request.angle}' is not one of the accepted preset names "
+                    + $"({string.Join(", ", ObjectCaptureFramingMath.PresetNames)}).");
+            }
+
+            SceneView sceneView = SceneView.lastActiveSceneView;
+            if (sceneView == null)
+                return BuildError("EDITOR_CTRL_NO_SCENE_VIEW", "No active SceneView found.");
+            Camera cam = sceneView.camera;
+            if (cam == null)
+                return BuildError("EDITOR_CTRL_NO_SCENE_CAMERA", "SceneView camera is null.");
+
+            // Resolve the target through the stage-aware resolver so
+            // the existing EDITOR_CTRL_HIERARCHY_PATH_AMBIGUOUS envelope
+            // surfaces unchanged on ambiguous hierarchy paths.
+            EditorControlResponse ambiguity;
+            bool resolved = TryResolveGameObjectInActiveStage(
+                request.target, out GameObject target, out ambiguity);
+            if (ambiguity != null) return ambiguity;
+            if (!resolved || target == null)
+            {
+                return BuildError(
+                    "EDITOR_CTRL_SCREENSHOT_TARGET_NOT_FOUND",
+                    $"target='{request.target}' matched no GameObject in "
+                    + "the active Scene or Prefab Stage.");
+            }
+
+            // Aggregate active renderer bounds on the resolved subtree.
+            // SkinnedMeshRenderer.BakeMesh gives a tight pose-current
+            // AABB; Renderer.bounds is conservative (culling-oriented)
+            // but adequate for non-skinned meshes.
+            var records = new List<ObjectCaptureFramingMath.RendererBoundsRecord>();
+            foreach (var smr in target.GetComponentsInChildren<SkinnedMeshRenderer>(includeInactive: false))
+            {
+                var baked = new Mesh();
+                try
+                {
+                    smr.BakeMesh(baked);
+                    Bounds local = baked.bounds;
+                    Bounds world = TransformBoundsToWorld(local, smr.transform);
+                    records.Add(new ObjectCaptureFramingMath.RendererBoundsRecord(
+                        new float[] { world.center.x, world.center.y, world.center.z },
+                        new float[] { world.extents.x, world.extents.y, world.extents.z }));
+                }
+                finally
+                {
+                    UnityEngine.Object.DestroyImmediate(baked);
+                }
+            }
+            foreach (var r in target.GetComponentsInChildren<Renderer>(includeInactive: false))
+            {
+                if (r is SkinnedMeshRenderer) continue; // already baked
+                if (!r.enabled) continue;
+                Bounds world = r.bounds;
+                records.Add(new ObjectCaptureFramingMath.RendererBoundsRecord(
+                    new float[] { world.center.x, world.center.y, world.center.z },
+                    new float[] { world.extents.x, world.extents.y, world.extents.z }));
+            }
+            if (records.Count == 0)
+            {
+                return BuildError(
+                    "EDITOR_CTRL_SCREENSHOT_TARGET_NO_RENDERERS",
+                    $"target='{request.target}' resolved to a subtree with "
+                    + "no active SkinnedMeshRenderer or MeshRenderer.");
+            }
+
+            var kept = ObjectCaptureFramingMath.SelectFramingRenderers(records);
+            Bounds aggregated = AggregateRendererBounds(kept);
+            Vector3 c = aggregated.center;
+            Vector3 e = aggregated.extents;
+            float[] corners = new float[24];
+            int idx = 0;
+            for (int sx = -1; sx <= 1; sx += 2)
+            for (int sy = -1; sy <= 1; sy += 2)
+            for (int sz = -1; sz <= 1; sz += 2)
+            {
+                corners[idx++] = c.x + sx * e.x;
+                corners[idx++] = c.y + sy * e.y;
+                corners[idx++] = c.z + sz * e.z;
+            }
+
+            // Resolve the preset to a world-space camera-position
+            // direction relative to the target's yaw (Y-axis) rotation
+            // only. Pitch / roll from ``target.transform.rotation`` are
+            // discarded because sub-tree targets (face meshes, parts,
+            // accessories) frequently inherit non-identity X / Z
+            // rotations from FBX / PMX axis-import conventions — e.g.,
+            // MMD face meshes are imported with X=-90 so the local
+            // ``forward`` points along world +Y. Applying the preset
+            // relative to that local frame produces nonsensical views
+            // (front becomes top-down). Caller intent is virtually
+            // always "frame this object from world-horizontal at its
+            // facing direction", so we collapse the rotation to its
+            // yaw component before composing the preset direction.
+            // Avatar roots typically have identity or pure-yaw
+            // rotations, so this is a no-op there.
+            Quaternion targetRot = target.transform.rotation;
+            float targetYawDeg = targetRot.eulerAngles.y;
+            Quaternion targetYawOnly = Quaternion.Euler(0f, targetYawDeg, 0f);
+            bool dirOk = ObjectCaptureFramingMath.TryResolvePresetDirection(
+                angle,
+                new float[] { targetYawOnly.x, targetYawOnly.y, targetYawOnly.z, targetYawOnly.w },
+                out float[] cameraDir,
+                out string dirReason);
+            if (!dirOk)
+            {
+                return BuildError(
+                    "EDITOR_CTRL_SCREENSHOT_ANGLE_INVALID",
+                    $"angle='{request.angle}' rejected by framing math: {dirReason}.");
+            }
+
+            // Compose the orthonormal camera basis. The SceneView
+            // looks at the pivot; the camera position is on the
+            // ``+cameraDir`` side of the pivot, so the camera forward
+            // is ``-cameraDir``. Right and up are derived as Unity's
+            // ``Quaternion.LookRotation`` would (Y-up, with the world
+            // ``Vector3.up`` as the reference up).
+            Vector3 cameraDirV = new Vector3(cameraDir[0], cameraDir[1], cameraDir[2]).normalized;
+            Vector3 cameraForward = -cameraDirV;
+            Quaternion lookRot = Quaternion.LookRotation(cameraForward, Vector3.up);
+            Vector3 cameraRight = lookRot * Vector3.right;
+            Vector3 cameraUp = lookRot * Vector3.up;
+
+            float fov = cam.fieldOfView;
+            float aspect = (request.width > 0 && request.height > 0)
+                ? ((float)request.width / (float)request.height)
+                : cam.aspect;
+            bool framingOk = ObjectCaptureFramingMath.TrySolveFramingForAabb(
+                corners,
+                new float[] { cameraRight.x, cameraRight.y, cameraRight.z },
+                new float[] { cameraUp.x, cameraUp.y, cameraUp.z },
+                new float[] { cameraDirV.x, cameraDirV.y, cameraDirV.z },
+                fov, aspect, ObjectCaptureFramingMath.DefaultFramingMargin,
+                ObjectCaptureFramingMath.RecenteringIterationCount,
+                out float[] pivot, out float size, out string framingReason);
+            if (!framingOk)
+            {
+                return BuildError(
+                    "EDITOR_CTRL_SCREENSHOT_FAILED",
+                    $"Framing solver failed: {framingReason}.");
+            }
+
+            CameraSnapshot previous = CaptureCameraState(sceneView);
+            try
+            {
+                Vector3 newPivotWorld = new Vector3(pivot[0], pivot[1], pivot[2]);
+                sceneView.LookAt(
+                    newPivotWorld,
+                    lookRot, size, ortho: false, instant: true);
+
+                // SceneView.LookAt(instant:true) sets m_Position /
+                // m_Rotation / m_Size immediately, but the underlying
+                // ``sceneView.camera.transform`` is only re-synced when
+                // the next ``SceneView.OnGUI`` runs ``SetupCamera()``.
+                // Because this handler then calls ``cam.Render()`` in
+                // the same dispatch tick, without an explicit sync the
+                // render would use the pre-LookAt transform and every
+                // angle preset would produce an identical image. Mirror
+                // the SceneView perspective-distance derivation
+                // (issue #66: distance = size / sin(fov/2)) and apply
+                // pivot / rotation directly so the in-call render
+                // reflects the requested framing.
+                float halfFovRad = cam.fieldOfView * 0.5f * Mathf.Deg2Rad;
+                float cameraDistance = size / Mathf.Sin(halfFovRad);
+                cam.transform.position = newPivotWorld + cameraDirV * cameraDistance;
+                cam.transform.rotation = lookRot;
+                cam.orthographic = false;
+
+                ForceRenderAndRepaint(sceneView);
+
+                int w = request.width > 0 ? request.width : (int)sceneView.position.width;
+                int h = request.height > 0 ? request.height : (int)sceneView.position.height;
+
+                RenderTexture rt = null;
+                Texture2D tex = null;
+                try
+                {
+                    rt = RenderSceneViewToTexture(cam, w, h);
+
+                    // Pixel-rectangle crop_roi (issue #84 + #249): the
+                    // wrapper accepts ``target`` + pixel-rectangle
+                    // crop_roi (face-feature presets are rejected at
+                    // the wrapper), and the spec requires the rectangle
+                    // to be applied to the rendered frame after
+                    // framing. Out-of-frame rectangles return the same
+                    // EDITOR_CTRL_CROP_ROI_OUT_OF_BOUNDS envelope as
+                    // the existing pixel-rect branch.
+                    int readX = 0, readY = 0, readW = w, readH = h;
+                    CropBoundsEntry pixelRectApplied = null;
+                    if (!string.IsNullOrEmpty(request.crop_roi))
+                    {
+                        if (!TryResolveCropRoi(request.crop_roi,
+                                out string roiLabel, out CropBoundsEntry roiBounds)
+                            || roiLabel != "pixel_rect"
+                            || roiBounds == null)
+                        {
+                            return BuildError(
+                                "EDITOR_CTRL_CROP_ROI_INVALID",
+                                $"crop_roi='{request.crop_roi}' is not a pixel "
+                                + "quadruple (face-feature presets are rejected "
+                                + "at the wrapper when target is supplied).");
+                        }
+                        if (roiBounds.w <= 0 || roiBounds.h <= 0
+                            || roiBounds.x + roiBounds.w > w
+                            || roiBounds.y + roiBounds.h > h)
+                        {
+                            return BuildError(
+                                "EDITOR_CTRL_CROP_ROI_OUT_OF_BOUNDS",
+                                $"crop_roi pixel rectangle {request.crop_roi} does "
+                                + $"not fit inside the rendered frame {w}x{h}.");
+                        }
+                        readX = roiBounds.x;
+                        readY = roiBounds.y;
+                        readW = roiBounds.w;
+                        readH = roiBounds.h;
+                        pixelRectApplied = roiBounds;
+                    }
+
+                    RenderTexture.active = rt;
+                    tex = new Texture2D(readW, readH, TextureFormat.RGB24, false);
+                    tex.ReadPixels(new Rect(readX, readY, readW, readH), 0, 0);
+                    tex.Apply();
+                    RenderTexture.active = null;
+
+                    byte[] png = tex.EncodeToPNG();
+                    File.WriteAllBytes(outputPath, png);
+
+                    return BuildSuccess(
+                        "EDITOR_CTRL_SCREENSHOT_OK",
+                        $"Object-capture screenshot of '{request.target}' "
+                        + $"(angle={angle}) captured to {outputPath}",
+                        data: new EditorControlData
+                        {
+                            output_path = outputPath,
+                            view = "scene",
+                            width = readW,
+                            height = readH,
+                            executed = true,
+                            bounds_center = new float[] { c.x, c.y, c.z },
+                            bounds_extents = new float[] { e.x, e.y, e.z },
+                            crop_roi_applied = pixelRectApplied != null ? "pixel_rect" : string.Empty,
+                            crop_bounds = pixelRectApplied,
+                        });
+                }
+                finally
+                {
+                    if (tex != null) UnityEngine.Object.DestroyImmediate(tex);
+                    if (rt != null) UnityEngine.Object.DestroyImmediate(rt);
+                    RenderTexture.active = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                return BuildError(
+                    "EDITOR_CTRL_SCREENSHOT_FAILED",
+                    $"Object-capture screenshot failed: {ex.Message}");
+            }
+            finally
+            {
+                // Restore the previous SceneView camera state so the
+                // caller observes no persistent framing change. This
+                // mirrors the existing crop_roi preset branch.
+                if (SceneView.lastActiveSceneView != null)
+                {
+                    var sv = SceneView.lastActiveSceneView;
+                    var prevPivot = new Vector3(
+                        previous.pivot[0], previous.pivot[1], previous.pivot[2]);
+                    var prevRot = new Quaternion(
+                        previous.rotation_quat[0], previous.rotation_quat[1],
+                        previous.rotation_quat[2], previous.rotation_quat[3]);
+                    sv.LookAt(prevPivot, prevRot, previous.size, previous.orthographic, instant: true);
+                }
+            }
+        }
+
+        private static Bounds TransformBoundsToWorld(Bounds local, Transform t)
+        {
+            Vector3 c = local.center;
+            Vector3 e = local.extents;
+            Vector3[] corners = new Vector3[8];
+            int idx = 0;
+            for (int sx = -1; sx <= 1; sx += 2)
+            for (int sy = -1; sy <= 1; sy += 2)
+            for (int sz = -1; sz <= 1; sz += 2)
+            {
+                corners[idx++] = t.TransformPoint(new Vector3(
+                    c.x + sx * e.x, c.y + sy * e.y, c.z + sz * e.z));
+            }
+            Vector3 min = corners[0];
+            Vector3 max = corners[0];
+            for (int i = 1; i < 8; i++)
+            {
+                min = Vector3.Min(min, corners[i]);
+                max = Vector3.Max(max, corners[i]);
+            }
+            var world = new Bounds((min + max) * 0.5f, max - min);
+            return world;
+        }
+
+        private static Bounds AggregateRendererBounds(
+            IList<ObjectCaptureFramingMath.RendererBoundsRecord> records)
+        {
+            var first = records[0];
+            Vector3 fc = new Vector3(
+                first.CenterWorld[0], first.CenterWorld[1], first.CenterWorld[2]);
+            Vector3 fe = new Vector3(
+                first.ExtentsWorld[0], first.ExtentsWorld[1], first.ExtentsWorld[2]);
+            Bounds aggregated = new Bounds(fc, fe * 2f);
+            for (int i = 1; i < records.Count; i++)
+            {
+                var r = records[i];
+                Vector3 rc = new Vector3(
+                    r.CenterWorld[0], r.CenterWorld[1], r.CenterWorld[2]);
+                Vector3 re = new Vector3(
+                    r.ExtentsWorld[0], r.ExtentsWorld[1], r.ExtentsWorld[2]);
+                aggregated.Encapsulate(new Bounds(rc, re * 2f));
+            }
+            return aggregated;
+        }
+
+        /// <summary>
+        /// Render the current scene through ``cam`` into a freshly
+        /// allocated ``RenderTexture`` sized ``width × height``. Sets
+        /// ``forceMatrixRecalculationPerRender`` on every active
+        /// ``SkinnedMeshRenderer`` for the duration of the render so
+        /// blendshape-driven meshes evaluate at the current pose
+        /// (knowledge/blendshape-capture-pipeline.md; issue #242). The
+        /// caller owns the returned ``RenderTexture`` and is responsible
+        /// for ``DestroyImmediate``-ing it.
+        /// </summary>
+        private static RenderTexture RenderSceneViewToTexture(Camera cam, int width, int height)
+        {
+            var smrs = UnityEngine.Object.FindObjectsOfType<SkinnedMeshRenderer>();
+            foreach (var smr in smrs)
+                smr.forceMatrixRecalculationPerRender = true;
+
+            var rt = new RenderTexture(width, height, 24);
+            RenderTexture prev = cam.targetTexture;
+            cam.targetTexture = rt;
+            cam.Render();
+            cam.targetTexture = prev;
+
+            foreach (var smr in smrs)
+                smr.forceMatrixRecalculationPerRender = false;
+            return rt;
         }
 
         /// <summary>

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.7.0";
+        public const string BridgeVersion = "0.7.1";
 
         /// <summary>Actions that write their response file asynchronously (not on return).</summary>
         // Issue H-8: the membership sets are owned by ``ActionRegistry`` as the

--- a/tools/unity/PrefabSentinel.UnityIntegrationTests.cs
+++ b/tools/unity/PrefabSentinel.UnityIntegrationTests.cs
@@ -2639,7 +2639,7 @@ namespace PrefabSentinel
             // Seed an arbitrary state first so the reset is observable.
             var seed = RunEditorControlBridge(BuildEditorControlRequest(
                 "set_camera",
-                "\"camera_pivot\":[5.0,3.0,-7.0],\"yaw\":120.0,\"pitch\":15.0,\"distance\":12.0"));
+                "\"camera_pivot\":[5.0,3.0,-7.0],\"yaw\":120.0,\"pitch\":15.0,\"size\":12.0"));
             // Failures here are not fatal — the reset must work regardless.
 
             var resp = RunEditorControlBridge(BuildEditorControlRequest(

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Feature patch release.

- Adds a target-oriented capture mode to `editor_screenshot`: supply the GameObject's hierarchy path and one of six angle presets (`front` / `three_quarter` / `back` / `right` / `left` / `top`) and the Scene view re-frames the object full-frame, centred, in a single call. The "tweak camera, retake, retry" loop is gone for object-level shots.
- The angle is interpreted in a world-horizontal frame at the object's facing direction, so face meshes and other parts imported with non-identity X / Z rotations still come out upright.

See [CHANGELOG.md](./CHANGELOG.md) for the full 0.7.1 entry.

## Test plan

- [x] Source mirror from upstream dev `0.7.1` (single clean commit, `.serena/` excluded)
- [x] Version pinned to `0.7.1` (commit打ったときに pre-commit patch bump が走らないよう `SKIP_BUMP=1` で打鍵)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)