### PR TITLE
release: publish 0.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",
@@ -14,7 +14,7 @@
       "command": "uvx",
       "args": [
         "--from", "${CLAUDE_PLUGIN_ROOT}",
-        "--with", "mcp>=1.12",
+        "--with", "mcp>=2,<3",
         "prefab-sentinel-mcp"
       ]
     }

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -3,7 +3,7 @@
     "command": "uvx",
     "args": [
       "--from", "git+https://github.com/tyunta/prefab-sentinel.git",
-      "--with", "mcp>=1.12",
+      "--with", "mcp>=2,<3",
       "prefab-sentinel-mcp"
     ]
   }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prefab-sentinel",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "An MCP server specialized for VRChat avatar and world projects: it parses the asset YAML directly — including UdonSharp's split program/behaviour structure — to detect and repair broken references, prefab Variant override drift, and null wiring across prefabs, scenes, and materials. Built for AI agents, every fix runs through a dry-run → confirm gate with an audit log, so asset YAML is never hand-edited.",
   "author": {
     "name": "tyunta",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,412 @@ jobs:
       - name: Run Unit Tests
         run: uv run python scripts/run_unit_tests.py
 
+  mcp-conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Install MCP server
+        run: uv sync --extra mcp
+
+      - name: Start loopback MCP server
+        run: |
+          stop_server_launcher() {
+            launcher_pid=${1:-}
+            case "$launcher_pid" in
+              ''|*[!0-9]*)
+                echo "Missing or invalid MCP server launcher PID: ${launcher_pid:-<unset>}" >&2
+                return 1
+                ;;
+            esac
+            if [ "$launcher_pid" -le 1 ] || [ "$launcher_pid" -eq "$$" ]; then
+              echo "Unsafe MCP server launcher PID: $launcher_pid" >&2
+              return 1
+            fi
+            if ! kill -0 "$launcher_pid" 2>/dev/null; then
+              echo "MCP server launcher $launcher_pid already exited"
+              return 0
+            fi
+            kill -TERM "$launcher_pid" 2>/dev/null || true
+            for attempt in $(seq 1 20); do
+              if ! kill -0 "$launcher_pid" 2>/dev/null; then
+                echo "MCP server launcher $launcher_pid stopped"
+                return 0
+              fi
+              sleep 0.25
+            done
+            echo "MCP server launcher $launcher_pid did not stop after SIGTERM; sending SIGKILL" >&2
+            kill -KILL "$launcher_pid" 2>/dev/null || true
+            for attempt in $(seq 1 20); do
+              if ! kill -0 "$launcher_pid" 2>/dev/null; then
+                echo "MCP server launcher $launcher_pid stopped after SIGKILL"
+                return 0
+              fi
+              sleep 0.25
+            done
+            echo "MCP server launcher $launcher_pid is still alive after SIGKILL" >&2
+            return 1
+          }
+
+          workflow_pgid=$(ps -o pgid= -p "$$" | tr -d '[:space:]')
+          case "$workflow_pgid" in
+            ''|*[!0-9]*)
+              echo "Invalid workflow process group: $workflow_pgid" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$workflow_pgid" -le 1 ]; then
+            echo "Unsafe workflow process group: $workflow_pgid" >&2
+            exit 1
+          fi
+
+          server_pgid_file="$RUNNER_TEMP/prefab-sentinel-mcp.pgid"
+          setsid --fork --wait sh -c '
+            candidate_pgid=$$
+            case "$candidate_pgid" in
+              ""|*[!0-9]*) exit 1 ;;
+            esac
+            [ "$candidate_pgid" -gt 1 ] || exit 1
+            case "$1" in
+              ""|*[!0-9]*) exit 1 ;;
+            esac
+            [ "$1" -gt 1 ] || exit 1
+            actual_candidate_pgid=$(ps -o pgid= -p "$candidate_pgid") || exit 1
+            actual_candidate_pgid=$(printf "%s" "$actual_candidate_pgid" | tr -d "[:space:]")
+            [ "$actual_candidate_pgid" = "$candidate_pgid" ] || exit 1
+            [ "$candidate_pgid" != "$1" ] || exit 1
+            printf "%s\n" "$candidate_pgid" > "$2" || exit 1
+            exec uv run prefab-sentinel-mcp --transport streamable-http --port 8000
+          ' sh "$workflow_pgid" "$server_pgid_file" \
+            > "$RUNNER_TEMP/prefab-sentinel-mcp.log" 2>&1 &
+          server_launcher_pid=$!
+          echo "server_launcher_pid=$server_launcher_pid" >> "$GITHUB_ENV"
+
+          for attempt in $(seq 1 40); do
+            if [ -s "$server_pgid_file" ]; then
+              break
+            fi
+            if ! kill -0 "$server_launcher_pid" 2>/dev/null; then
+              echo "MCP server launcher $server_launcher_pid exited before recording its process group" >&2
+              cat "$RUNNER_TEMP/prefab-sentinel-mcp.log" >&2
+              stop_server_launcher "$server_launcher_pid" || true
+              exit 1
+            fi
+            sleep 0.05
+          done
+          if [ ! -s "$server_pgid_file" ]; then
+            echo "MCP server did not record its process group" >&2
+            cat "$RUNNER_TEMP/prefab-sentinel-mcp.log" >&2
+            if ! stop_server_launcher "$server_launcher_pid"; then
+              echo "Failed to stop MCP server launcher after publication timeout" >&2
+            fi
+            exit 1
+          fi
+
+          IFS= read -r server_pgid < "$server_pgid_file"
+          case "$server_pgid" in
+            ''|*[!0-9]*)
+              echo "Invalid MCP server process group: $server_pgid" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$server_pgid" -le 1 ]; then
+            echo "Unsafe MCP server process group: $server_pgid" >&2
+            exit 1
+          fi
+          echo "server_pgid=$server_pgid" >> "$GITHUB_ENV"
+
+          if ! actual_server_pgid=$(ps -o pgid= -p "$server_pgid"); then
+            echo "MCP server group leader $server_pgid exited during launch" >&2
+            cat "$RUNNER_TEMP/prefab-sentinel-mcp.log" >&2
+            exit 1
+          fi
+          actual_server_pgid=$(printf '%s' "$actual_server_pgid" | tr -d '[:space:]')
+          workflow_pgid=$(ps -o pgid= -p "$$" | tr -d '[:space:]')
+          if [ "$actual_server_pgid" != "$server_pgid" ]; then
+            echo "MCP server PGID mismatch: recorded=$server_pgid actual=$actual_server_pgid" >&2
+            exit 1
+          fi
+          if [ "$server_pgid" = "$workflow_pgid" ]; then
+            echo "Refusing to use workflow process group $workflow_pgid for the MCP server" >&2
+            exit 1
+          fi
+          if ! kill -0 -- "-$server_pgid" 2>/dev/null; then
+            echo "MCP server process group $server_pgid exited during launch" >&2
+            cat "$RUNNER_TEMP/prefab-sentinel-mcp.log" >&2
+            exit 1
+          fi
+
+      - name: Wait for MCP endpoint
+        run: |
+          case "${server_pgid:-}" in
+            ''|*[!0-9]*)
+              echo "Missing or invalid MCP server process group: ${server_pgid:-<unset>}" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$server_pgid" -le 1 ]; then
+            echo "Unsafe MCP server process group: $server_pgid" >&2
+            exit 1
+          fi
+          workflow_pgid=$(ps -o pgid= -p "$$" | tr -d '[:space:]')
+          if [ "$server_pgid" = "$workflow_pgid" ]; then
+            echo "Refusing to probe workflow process group $workflow_pgid" >&2
+            exit 1
+          fi
+
+          for attempt in $(seq 1 60); do
+            if ! kill -0 -- "-$server_pgid" 2>/dev/null; then
+              echo "MCP server process group $server_pgid exited before readiness" >&2
+              if [ -f "$RUNNER_TEMP/prefab-sentinel-mcp.log" ]; then
+                cat "$RUNNER_TEMP/prefab-sentinel-mcp.log" >&2
+              else
+                echo "No MCP server log was generated" >&2
+              fi
+              exit 1
+            fi
+            if curl --silent --output /dev/null \
+              --connect-timeout 0.2 \
+              --max-time 0.2 \
+              http://127.0.0.1:8000/mcp
+            then
+              if ! kill -0 -- "-$server_pgid" 2>/dev/null; then
+                echo "MCP server process group $server_pgid exited during readiness" >&2
+                if [ -f "$RUNNER_TEMP/prefab-sentinel-mcp.log" ]; then
+                  cat "$RUNNER_TEMP/prefab-sentinel-mcp.log" >&2
+                else
+                  echo "No MCP server log was generated" >&2
+                fi
+                exit 1
+              fi
+              exit 0
+            fi
+            sleep 0.25
+          done
+          echo "MCP endpoint was not ready after 60 attempts" >&2
+          if [ -f "$RUNNER_TEMP/prefab-sentinel-mcp.log" ]; then
+            cat "$RUNNER_TEMP/prefab-sentinel-mcp.log" >&2
+          else
+            echo "No MCP server log was generated" >&2
+          fi
+          exit 1
+
+      - name: Run MCP 2026-07-28 conformance scenarios
+        run: |
+          mkdir -p results
+          scenario_failures=0
+          for scenario in \
+            tools-list \
+            dns-rebinding-protection \
+            http-header-validation
+          do
+            scenario_failed=0
+            if npx --yes @modelcontextprotocol/conformance@0.2.0-alpha.11 \
+                server \
+                --url http://127.0.0.1:8000/mcp \
+                --scenario "$scenario" \
+                --spec-version 2026-07-28 \
+                --output-dir "results/$scenario"
+            then
+              scenario_status=0
+            else
+              scenario_status=$?
+              scenario_failed=1
+            fi
+            echo "scenario=$scenario exit=$scenario_status"
+            printf '%s\n' "$scenario_status" > "results/$scenario.exit-code"
+
+            scenario_report_manifest="results/$scenario.checks.manifest"
+            if find "results/$scenario" -name checks.json -print0 > "$scenario_report_manifest"; then
+              scenario_report_count=0
+              scenario_report=
+              while IFS= read -r -d '' report; do
+                scenario_report_count=$((scenario_report_count + 1))
+                scenario_report=$report
+              done < "$scenario_report_manifest"
+              if [ "$scenario_report_count" -ne 1 ]; then
+                echo "scenario=$scenario expected exactly one checks.json; found $scenario_report_count" >&2
+                scenario_failed=1
+              elif ! jq -e \
+                  'type == "array" and length > 0 and all(.[]; .status == "SUCCESS")' \
+                  "$scenario_report" > /dev/null
+              then
+                echo "scenario=$scenario checks.json must be a nonempty all-SUCCESS array" >&2
+                scenario_failed=1
+              fi
+            else
+              echo "scenario=$scenario failed to enumerate checks.json" >&2
+              scenario_failed=1
+            fi
+            if [ "$scenario_failed" -ne 0 ]; then
+              scenario_failures=$((scenario_failures + 1))
+            fi
+          done
+          if [ "$scenario_failures" -ne 0 ]; then
+            echo "$scenario_failures conformance scenario(s) failed" >&2
+            exit 1
+          fi
+
+      - name: Print conformance reports
+        if: always()
+        run: |
+          diagnostics_failed=0
+          reports_found=0
+          if [ -d results ]; then
+            report_manifest="$RUNNER_TEMP/conformance-checks.manifest"
+            if ! find results -name checks.json -print0 > "$report_manifest"; then
+              echo "Failed to enumerate conformance reports" >&2
+              diagnostics_failed=1
+            fi
+            while IFS= read -r -d '' report; do
+              reports_found=1
+              echo "$report"
+              if ! jq '.' "$report"; then
+                echo "Failed to print conformance report: $report" >&2
+                diagnostics_failed=1
+              fi
+            done < "$report_manifest"
+            if [ "$reports_found" -eq 0 ]; then
+              echo "No conformance checks.json reports were generated"
+            fi
+          else
+            echo "No conformance results directory was generated"
+          fi
+          if [ -f "$RUNNER_TEMP/prefab-sentinel-mcp.log" ]; then
+            echo "MCP server log:"
+            cat "$RUNNER_TEMP/prefab-sentinel-mcp.log"
+          else
+            echo "No MCP server log was generated"
+          fi
+          if [ "$diagnostics_failed" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Stop MCP server
+        if: always()
+        run: |
+          stop_server_launcher() {
+            launcher_pid=${1:-}
+            case "$launcher_pid" in
+              '')
+                echo "No MCP server launcher PID was recorded; nothing to stop"
+                return 0
+                ;;
+              *[!0-9]*)
+                echo "Invalid MCP server launcher PID: $launcher_pid" >&2
+                return 1
+                ;;
+            esac
+            if [ "$launcher_pid" -le 1 ] || [ "$launcher_pid" -eq "$$" ]; then
+              echo "Unsafe MCP server launcher PID: $launcher_pid" >&2
+              return 1
+            fi
+            if ! kill -0 "$launcher_pid" 2>/dev/null; then
+              echo "MCP server launcher $launcher_pid already exited"
+              return 0
+            fi
+            kill -TERM "$launcher_pid" 2>/dev/null || true
+            for attempt in $(seq 1 20); do
+              if ! kill -0 "$launcher_pid" 2>/dev/null; then
+                echo "MCP server launcher $launcher_pid stopped"
+                return 0
+              fi
+              sleep 0.25
+            done
+            echo "MCP server launcher $launcher_pid did not stop after SIGTERM; sending SIGKILL" >&2
+            kill -KILL "$launcher_pid" 2>/dev/null || true
+            for attempt in $(seq 1 20); do
+              if ! kill -0 "$launcher_pid" 2>/dev/null; then
+                echo "MCP server launcher $launcher_pid stopped after SIGKILL"
+                return 0
+              fi
+              sleep 0.25
+            done
+            echo "MCP server launcher $launcher_pid is still alive after SIGKILL" >&2
+            return 1
+          }
+
+          case "${server_pgid:-}" in
+            '')
+              echo "No MCP server process group was recorded; stopping launcher only"
+              stop_server_launcher "${server_launcher_pid:-}"
+              exit $?
+              ;;
+            *[!0-9]*)
+              echo "Invalid MCP server process group: $server_pgid" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$server_pgid" -le 1 ]; then
+            echo "Unsafe MCP server process group: $server_pgid" >&2
+            exit 1
+          fi
+          workflow_pgid=$(ps -o pgid= -p "$$" | tr -d '[:space:]')
+          if [ "$server_pgid" = "$workflow_pgid" ]; then
+            echo "Refusing to signal workflow process group $workflow_pgid" >&2
+            exit 1
+          fi
+          cleanup_failed=0
+          if ! kill -0 -- "-$server_pgid" 2>/dev/null; then
+            echo "MCP server process group $server_pgid already exited"
+          else
+            kill -TERM -- "-$server_pgid" 2>/dev/null || true
+            group_stopped=0
+            for attempt in $(seq 1 20); do
+              if ! kill -0 -- "-$server_pgid" 2>/dev/null; then
+                echo "MCP server process group $server_pgid stopped"
+                group_stopped=1
+                break
+              fi
+              sleep 0.25
+            done
+            if [ "$group_stopped" -eq 0 ]; then
+              echo "MCP server process group $server_pgid did not stop after SIGTERM; sending SIGKILL" >&2
+              kill -KILL -- "-$server_pgid" 2>/dev/null || true
+              for attempt in $(seq 1 20); do
+                if ! kill -0 -- "-$server_pgid" 2>/dev/null; then
+                  echo "MCP server process group $server_pgid stopped after SIGKILL"
+                  group_stopped=1
+                  break
+                fi
+                sleep 0.25
+              done
+            fi
+            if [ "$group_stopped" -eq 0 ]; then
+              echo "MCP server process group $server_pgid is still alive after SIGKILL" >&2
+              cleanup_failed=1
+            fi
+          fi
+          if ! stop_server_launcher "${server_launcher_pid:-}"; then
+            cleanup_failed=1
+          fi
+          exit "$cleanup_failed"
+
+      - name: Upload conformance evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mcp-2026-07-28-conformance
+          path: |
+            results/
+            ${{ runner.temp }}/prefab-sentinel-mcp.log
+          if-no-files-found: error
+
   performance-benchmarks:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,11 +4,13 @@ Prefab Sentinel の構成概観・レイヤ責務・サービス仕様・デー�
 
 ## 概要
 
-MCP クライアントから入った 1 リクエストは、`mcp_tools` で受信され、`orchestrator` がユースケース単位に各 `services` を順序付き編成し、書き込み・実行検証は `tools/unity` の常駐 Editor Bridge へ file-IPC で中継される。Bridge は Unity Editor 内で操作を実行し、`success / severity / code / message / data / diagnostics` エンベロープを応答として返す。
+MCP クライアントから入った 1 リクエストは、stdio またはローカル loopback HTTP の protocol boundary を通って `mcp_tools` へ渡される。`orchestrator` がユースケース単位に各 `services` を順序付き編成し、書き込み・実行検証は `tools/unity` の常駐 Editor Bridge へ file-IPC で中継される。Bridge は Unity Editor 内で操作を実行し、`success / severity / code / message / data / diagnostics` エンベロープを応答として返す。
 
 ```mermaid
 flowchart LR
-    Client["MCP client<br/>(AI agent)"] -->|tool call| Tools["mcp_tools<br/>(MCP surface)"]
+    Client["MCP client<br/>(AI agent)"] --> Transport["stdio or loopback HTTP<br/>POST /mcp"]
+    Transport --> Boundary["MCPServer + protocol middleware<br/>2026-07-28 / Tools only"]
+    Boundary -->|tools/call| Tools["mcp_tools<br/>(MCP surface)"]
     Tools --> Orch["orchestrator<br/>(per-use-case)"]
     Orch --> Svc["services<br/>(serialized-object /<br/>prefab-variant /<br/>reference-resolver /<br/>runtime-validation)"]
     Svc -->|"file-IPC<br/>(request.json)"| Bridge["tools/unity<br/>Editor Bridge"]
@@ -16,7 +18,8 @@ flowchart LR
     Bridge -.->|EditorApplication.update| Unity["Unity Editor<br/>(Assets / Scene / Prefab)"]
     Svc --> Orch
     Orch --> Tools
-    Tools -->|envelope| Client
+    Tools -->|tool result| Boundary
+    Boundary -->|MCP response| Client
 ```
 
 データフロー原則:
@@ -28,6 +31,14 @@ flowchart LR
 ## レイヤ責務
 
 各レイヤは単一責務を持ち、入出力は隣接レイヤとの境界でだけ正規化される。書き込みは必ず `confirm=True` + `change_reason` を要求し、未配線・必須参照欠落は `error` で fail-fast する。冗長化のためのフォールバック実装（自動探索・代替経路）は持たない。
+
+### MCPServer / protocol boundary
+
+Python SDK 2.x の `MCPServer` と protocol middleware が公開 wire contract を所有する。受理する protocol version は `2026-07-28` のみ、公開 capability は Tools のみ、request method allowlist は `server/discover` / `tools/list` / `tools/call` の 3 つである。stdio の `notifications/cancelled` は request method ではなく notification として middleware が SDK へ転送し、HTTP notification は gate が拒否する。legacy client の `initialize` / `initialized` handshake や `Mcp-Session-Id` による session lifecycle は持たず、互換レイヤも置かない。HTTP は `MCP20260728HTTPGate` が loopback host、method、header、request metadata を SDK dispatch 前に検査し、fixed host `127.0.0.1` の configurable port、単一 endpoint `/mcp` への POST に限定する。transport と起動方法は [docs/execution-reference.md](./docs/execution-reference.md)、request metadata と result semantics は [docs/tool-conventions.md](./docs/tool-conventions.md)、protocol-boundary error の優先順位と stdio transport 例外は [docs/api-reference.md](./docs/api-reference.md#エラーコード規約) を正本とする。
+
+サーバー生成時に作る `ProjectSession` は MCP protocol session ではなく、activation、cache、watcher を保持する process-wide application state である。1 プロセスを 1 logical client / 1 project scope として運用し、`activate_project` が後続 request で暗黙利用される state を更新する。`tools/call` は process-wide lock で直列化し、`server/discover` / `tools/list` は tool-call lock の対象外とする。複数 client / project の共有 server や request ごとの ProjectSession は提供しない。
+
+この request 間の `ProjectSession` / `activate_project` continuity は **意図した product constraint であると同時に、MCP 2026-07-28 の per-request metadata / stateless model に対する既知の逸脱**である。protocol-level session header を使わないことと、application state が stateless であることは同義ではない。選択した HTTP conformance scenarios が通過してもこの逸脱は解消されないため、現行設計について full 2026-07-28 conformance は主張しない。
 
 ### services
 
@@ -145,7 +156,8 @@ orchestrator / services 間で受け渡すコアエンティティと、それ�
 | `prefab-variant` | どこが上書きされているか | Variant パス | `overrides[]` / stale 候補 / chain values | `serialized-object`（before 解決元）/ `reference-resolver`（参照確認） |
 | `reference-resolver` | 参照が有効か | GUID / fileID / asset path / scope | `resolved` / `missing_asset` / `missing_local_id` / `type_mismatch` | `prefab-variant`（参照存在チェック）/ orchestrator（snapshot diff） |
 | `runtime-validation` | 実行時に壊れていないか | scene 経路 + log_file | UdonSharp compile 結果 / 分類済み console / `critical` 件数 | `tools/unity`（compile / ClientSim 実行）/ Skills（運用判断） |
-| `mcp_tools` | どの API を公開するか | MCP リクエスト | 標準エンベロープ または 参照系ペイロード | クライアント / orchestrator |
+| MCPServer / protocol boundary | どの wire contract を受理するか | stdio / HTTP の MCP リクエスト | 2026-07-28 MCP response または protocol error | クライアント / `mcp_tools` |
+| `mcp_tools` | どの tool API を公開するか | 検証済み `tools/call` | 標準エンベロープ または 参照系ペイロード | protocol boundary / orchestrator |
 | `orchestrator` | どの順で繋ぐか | ユースケース引数 | 編成済み `ToolResponse` | 各 services / `mcp_tools` |
 | `skills` | どの順で使うか | 運用フェーズ宣言 | `safe_fix` / `decision_required` 分類 | ユーザー / orchestrator |
 
@@ -159,6 +171,7 @@ orchestrator / services 間で受け渡すコアエンティティと、それ�
 * **orchestrator** — ユースケース単位で複数 service を順序付き編成する層。`prefab_sentinel.orchestrator*` モジュール群が実体で、応答は標準エンベロープに正規化する。
 * **Skill** — `skills/<name>/SKILL.md` に記述された運用手順書。ツール呼び出し順・停止条件・成功条件を含み、Claude Code Plugin として `/prefab-sentinel:<name>` で呼び出される。
 * **Service** — 単一責務サブパッケージ（`prefab_sentinel/services/<name>/`）。公開 API はファサードクラス 1 つに絞り、後方互換シムは持たない。
+* **ProjectSession** — activation / cache / watcher を process-wide に保持する application state。MCP protocol session や client handshake を表さないが、後続 request が暗黙に再利用するため 2026-07-28 stateless model からは意図的に逸脱する。1 server process を 1 logical client / project scope とする。
 * **partial concern** — 1 つの C# クラスを `disk 上の partial ファイル` ごとに概念単位で分割した責務分割の単位。`UnityEditorControlBridge` / `UnityPatchBridge` は両方ともこの形で構成され、AGENTS.md の per-concern token inventory がドリフト検出の正本。
 * **scope** — `validate_refs` / `find_referencing_assets` 等で受け取る走査範囲指定。`--scope` で実行時指定し、固定パスは持たない。`<scope>/config/ignore_guids.txt` 等の auto-load はこのパスを起点に解決する。
 * **handle** — Bridge への 1 回の create / open 操作で確立した resource identifier。`prefab create mode` の root asset `$asset`、scene mode の component `$handle` / asset `$handle` などで `target` フィールドに与え、後続 mutation op の対象を一意に指す（[docs/execution-reference.md「Unity bridge / runtime」](./docs/execution-reference.md#unity-bridge--runtime)）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-14
+
+### Added
+
+- stdio を既定のまま、必要に応じて `127.0.0.1:<port>/mcp` の loopback 限定 Streamable HTTP endpoint を利用できるようにした。外部公開用の host 設定は提供しない。
+
+### Changed
+
+- MCP server を Python SDK 2.x と MCP `2026-07-28` の Tools-only contract へ移行した。legacy `initialize` / `initialized` と `Mcp-Session-Id` lifecycle は非対応となるため、旧 client は更新が必要になる破壊的変更。
+- `editor_set_udonsharp_field.values_json` は explicit `null` を受け付けず、省略または空文字列を「配列値なし」として扱う。
+
 ## [0.8.9] - 2026-07-23
 
 ### Added

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -2,6 +2,14 @@
 
 `UNITYTOOL_*` 環境変数・`ignore_guids.txt` ファイル・`<scope>/config/` 規約・書き込み系ツールの監査ペアの正本。実行・bridge 連携の仕様は [docs/execution-reference.md](./docs/execution-reference.md)、運用ルールの正本は [AGENTS.md](./AGENTS.md)。本ファイルは設定項目を 1 箇所に集約して、新規・既存いずれのコントリビュータが「何を設定すれば動くか / 何を設定しないと止まるか」を一覧で確認できるようにする。
 
+## MCP dependency / transport configuration
+
+- optional dependency `mcp` は Python SDK `mcp>=2,<3` を使用する。server、MCP-focused test、ad-hoc client を実行するときは `uv sync --extra mcp` または `uv run --extra mcp ...` で導入する。
+- transport は stdio が既定。HTTP を使う場合は `--transport streamable-http --port <port>` を指定する。port の既定値は `8000`、受理範囲は `1..65535`。
+- HTTP host は `127.0.0.1`、path は `/mcp` に固定する。host / path の CLI option や環境変数はなく、public bind、TLS、OAuth / authentication をこの server に設定することはできない。
+- 公開 contract は MCP `2026-07-28` の Tools-only surface。legacy handshake / session lifecycle を有効化する compatibility flag はない。
+- `ProjectSession` は process-wide application state で、request / network client ごとに生成する設定はない。`activate_project` の結果を後続 request が暗黙利用する continuity は deliberate product constraint かつ MCP 2026-07-28 stateless model からの既知逸脱であり、これを conformance option で無効化する設定もない。1 logical client / project scope ごとに server process を分離する。起動例と transport semantics は [docs/execution-reference.md](./docs/execution-reference.md#実行方法)、責務境界は [ARCHITECTURE.md](./ARCHITECTURE.md#mcpserver--protocol-boundary) を参照。
+
 ## 環境変数一覧
 
 `UNITYTOOL_*` プレフィックスの環境変数は Unity Editor Bridge 連携・CI 連携・テストゲーティングに使用する。`種別` 列の値は **active**（実運用で active に読まれる）/ **test-only**（テストの opt-in ゲートにのみ使用）/ **planned**（AGENTS.md / README.md で仕様化済みだが現コードベースでは未参照）/ **legacy**（旧経路用で現コードでは未参照、docstring または ideas doc にのみ残る）。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,12 @@ For plugin development or debugging you can launch the MCP server straight from 
 uv sync --extra mcp --extra watch
 uv run prefab-sentinel-mcp                                       # stdio transport (default)
 uv run prefab-sentinel-mcp --project-root /path/to/unity/project # pin the Unity project root
-uv run prefab-sentinel-mcp --transport streamable-http           # HTTP transport
+uv run prefab-sentinel-mcp --transport streamable-http --port 8000 # loopback HTTP
 ```
 
-The server keeps caches across requests: `activate_project` warms the GUID index, script-name map, and symbol tree, and the `watch` extra invalidates them on `.meta` / `.cs` / asset changes. `--project-root` is optional — the target project can also be declared per session via `activate_project`.
+The HTTP endpoint is fixed to `http://127.0.0.1:<port>/mcp`; there is no public-host option. Both transports expose only the MCP `2026-07-28` Tools surface, with three request methods: `server/discover`, `tools/list`, and `tools/call`. stdio additionally forwards the `notifications/cancelled` notification; it is not a fourth request method. Legacy `initialize` / `initialized` and `Mcp-Session-Id` lifecycle are intentionally unsupported, so older clients must migrate to per-request namespaced metadata.
+
+The server keeps one process-wide `ProjectSession`: `activate_project` warms the GUID index, script-name map, and symbol tree, and the `watch` extra invalidates them on `.meta` / `.cs` / asset changes. `--project-root` is optional — the target project can also be declared after process start via `activate_project`. Later requests implicitly reuse that state. This is a deliberate product constraint and a known deviation from MCP 2026-07-28 statelessness, not evidence of full conformance. Treat one process as one logical client / project scope; tool calls execute serially. Run separate processes rather than sharing one HTTP server between projects or clients. See [the execution reference](./docs/execution-reference.md#実行方法), [protocol/result conventions](./docs/tool-conventions.md#mcp-protocol--result-境界), and [configuration](./CONFIGURATION.md#mcp-dependency--transport-configuration) for the owned details.
 
 ## Running tests and lint
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Unity / VRChat プロジェクトの Prefab / Scene / Asset を安全に検査�
 
 YAML-backed read-only 経路（`validate_refs` / `validate_materials` / `inspect_wiring` / `inspect_variant` / `inspect_hierarchy` / `find_referencing_assets` 等）は Unity を起動せずに完結する。`inspect_serialized_surface` / `inspect_with_profile` / `validate_inspector_profile` は、last-saved `SerializedObject` surface を常駐 Editor Bridge 経由で取得する。書き込み経路（`patch_apply` / `set_property` / `editor_*` 等）は常駐 Editor Bridge との file-IPC で動き、`confirm=True` + 非空 `change_reason` の監査ペアを欠く呼び出しは `CHANGE_REASON_REQUIRED` で拒否される。
 
+公開 MCP 境界は **2026-07-28 のみ・Tools capability のみ**をサポートする。stdio が既定で、任意の HTTP 経路はローカル loopback の `/mcp` に限定する。これは full conformance の合格宣言ではなく、protocol error の優先順位と stdio transport 例外は [docs/api-reference.md](./docs/api-reference.md#エラーコード規約)、厳格 CI gate の対象範囲は [TESTING.md](./TESTING.md#mcp-2026-07-28-protocol--wire-conformance)、process-state の既知逸脱は [ARCHITECTURE.md](./ARCHITECTURE.md#mcpserver--protocol-boundary) を正本とする。対応する request method と transport は [docs/tool-conventions.md](./docs/tool-conventions.md)、[docs/execution-reference.md](./docs/execution-reference.md) を参照。
+
 本 README は各専門ドキュメントへの入口（[ドキュメントマップ](#ドキュメントマップ) 参照）。仕様の正本は専門ドキュメント群、運用ルールの正本は [AGENTS.md](./AGENTS.md)。
 
 ## やること / やらないこと
@@ -31,6 +33,7 @@ YAML-backed read-only 経路（`validate_refs` / `validate_materials` / `inspect
 - 変更根拠のない自動最適化をしない
 - 実プロジェクトを timing gate に使わず、weekly benchmark から baseline を自動更新しない
 - ユーザー判断が要る仕様変更を勝手に適用しない
+- legacy MCP の handshake / session lifecycle を互換維持せず、remote / shared HTTP server として公開しない
 
 ## Quickstart
 
@@ -96,7 +99,7 @@ Python wheel は `tools/unity/` と `knowledge/` の配布対象だけを packag
 
 | ツール | 説明 |
 |--------|------|
-| `activate_project` | プロジェクトスコープ設定 + キャッシュ warm（セッション開始時に呼ぶ） |
+| `activate_project` | プロジェクトスコープ設定 + キャッシュ warm（サーバープロセス起動後に呼ぶ） |
 | `validate_refs` | 壊れた GUID / fileID 参照のスキャン |
 | `validate_materials` | `.mat` / renderer slot / TMP material preset / folder policy の静的検証。任意ルールは [CONFIGURATION.md](./CONFIGURATION.md#material_validation_rulesjson-形式仕様) を正本とする |
 | `validate_structure` | YAML 内部構造の検証（fileID 重複・Transform 整合性） |
@@ -135,9 +138,9 @@ YAML-backed read-only 検査（`validate_refs` / `validate_materials` / `inspect
 |--------------|------|
 | [ARCHITECTURE.md](./ARCHITECTURE.md) | 構成概観・レイヤ責務・サービス仕様・データモデル・用語集 |
 | [docs/tools.md](./docs/tools.md) | 全 MCP ツールの正本カタログ |
-| [docs/tool-conventions.md](./docs/tool-conventions.md) | MCP ツールの住所表現・引数命名・監査ペア要否の規約 |
-| [docs/api-reference.md](./docs/api-reference.md) | MCP 応答エンベロープの形状とエラーコードの正本 |
-| [docs/execution-reference.md](./docs/execution-reference.md) | MCP サーバーの実行リファレンス / smoke-batch / ベンチマーク / patch スキーマ / レポート出力フォーマット |
+| [docs/tool-conventions.md](./docs/tool-conventions.md) | MCP protocol / result 境界と、ツールの住所表現・引数命名・監査ペア要否の規約 |
+| [docs/api-reference.md](./docs/api-reference.md) | MCP protocol error、ツール応答エンベロープ、domain error code の正本 |
+| [docs/execution-reference.md](./docs/execution-reference.md) | MCP transport / 起動方法 / smoke-batch / ベンチマーク / patch スキーマ / レポート出力フォーマット |
 | [TESTING.md](./TESTING.md) | ユニット / 統合 / 回帰 / mutation テストの実行手順とテスト戦略 |
 | [CONFIGURATION.md](./CONFIGURATION.md) | `UNITYTOOL_*` 環境変数・`ignore_guids.txt`・scope config 規約 |
 | [skills/inspector-profile-authoring/SKILL.md](./skills/inspector-profile-authoring/SKILL.md) | `inspector-profile.v1` の安全な project-local author / repair 手順 |

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,6 +10,52 @@ PR を上げる前にローカルで走らせるテストの実行手順とテ�
 uv run --extra test --extra mcp python scripts/run_unit_tests.py
 ```
 
+## MCP 2026-07-28 protocol / wire conformance
+
+MCP-focused regression gate は、protocol contract / distribution surface、middleware、stdio wire、HTTP gate を同時に固定する。migration 変更時は次を実行する。
+
+```bash
+uv run --extra mcp pytest \
+  tests/test_mcp_distribution_contract.py \
+  tests/test_mcp_protocol.py \
+  tests/test_mcp_http.py \
+  tests/test_mcp_stdio_transport.py \
+  tests/test_mcp_http_transport.py -q
+```
+
+この gate は `2026-07-28` のみ、Tools-only request-method allowlist、request ごとの namespaced `_meta`、legacy lifecycle rejection、stdio `notifications/cancelled` forwarding、loopback HTTP wire、process-wide tool-call serialization を対象とする。domain envelope の `success=false`、tool execution error、top-level protocol error の区別は [docs/tool-conventions.md](./docs/tool-conventions.md#mcp-protocol--result-境界) を正本とする。
+
+公式 conformance runner は server を別 process で起動し、各 scenario を個別の output directory へ保存する。
+
+```bash
+uv run prefab-sentinel-mcp --transport streamable-http --port 8000
+```
+
+別 shell で:
+
+```bash
+for scenario in \
+  tools-list \
+  dns-rebinding-protection \
+  http-header-validation
+do
+  npx --yes @modelcontextprotocol/conformance@0.2.0-alpha.11 \
+    server \
+    --url http://127.0.0.1:8000/mcp \
+    --scenario "$scenario" \
+    --spec-version 2026-07-28 \
+    --output-dir "results/$scenario"
+done
+```
+
+各 `results/<scenario>/checks.json` を検査し、failure が 0 件であることを acceptance criterion とする。normative docs や unit test の成功を、この runner の代替証跡にしない。
+
+CI の strict gate は `tools-list`、`dns-rebinding-protection`、`http-header-validation` の 3 scenario だけを実行する。baseline、expected-failures、`continue-on-error`、`--suite`、`--requirements`、diagnostic tool は使わず、3 exit のいずれかが非 0、またはいずれかの `checks.json` に failure / warning があれば失敗とする。
+
+`server-stateless` は alpha.11 が `test_missing_capability` structural diagnostic tool と `-32021` response を要求するため対象外とする。現行の固定 101-tool product には client capability を必要とする tool がなく、この probe のために public tool や hidden conformance hook は追加しない。初回の 4-scenario run と公式 source audit は historical evidence として保持し、upstream が non-applicable structural probe の skip をサポートした時点で scenario 採用を再検討する。
+
+valid modern HTTP `initialize` は removed method として `404` / `-32601` になり、以前の RED gap は解消済みである。real stdio だけは pinned MCP Python SDK v2.0.0 が product middleware より先に `-32022` を返す transport 例外として test で固定する。process-wide `ProjectSession` と `activate_project` の暗黙 continuity は deliberate product constraint かつ per-request stateless model からの既知逸脱のままなので、選択した 3 scenario の通過を full 2026-07-28 conformance と表現しない。error precedence と SDK 例外は [docs/api-reference.md](./docs/api-reference.md#エラーコード規約) を参照。
+
 ## ユニットテスト
 
 `scripts/run_unit_tests.py` が `unittest_parallel` のラッパーで、3 段の preflight（stale `mutants/` 検出 → `mcp` extra 検出 → `unittest_parallel` 検出）を順に通してからテストを発火する。
@@ -331,10 +377,12 @@ Issue #156 は real-Unity layer と deterministic fault-injection layer の双�
 - visual 検証には **MCP plugin Python と Bridge C# が同じ commit の資材で揃っている必要**がある。bridge だけ手動配置しても plugin 側のリクエスト形が古いと検証が成立しない。
 - Claude Code / Codex CLI が起動済みの plugin プロセス（`~/.claude/plugins/cache/.../prefab-sentinel-mcp` 等）は session 開始時に固定されるため、session 内で同 plugin を最新ソースに張り替えても反映されない。`.mcp.json` を編集して再起動するか、本節の ad-hoc 経路を使う。
 
-**経路**: `uvx --from <local-path>[mcp] prefab-sentinel-mcp` で dev ソースから MCP server を一時起動し、stdio で `activate_project` → `deploy_bridge` → 検証ツールを呼ぶ Python script を走らせる。`mcp` Python SDK の `stdio_client` + `ClientSession` で実装する：
+**経路**: `uvx --from <local-path>[mcp] prefab-sentinel-mcp` で dev ソースから MCP server を一時起動し、stdio で `activate_project` → `deploy_bridge` → 検証ツールを呼ぶ Python script を走らせる。Python SDK 2.x の `Client` を `mode="2026-07-28"` で使い、legacy handshake を挟まず request ごとの namespaced `_meta` を送る：
 
 ```python
-from mcp import ClientSession, StdioServerParameters
+import os
+
+from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 params = StdioServerParameters(
@@ -345,15 +393,14 @@ params = StdioServerParameters(
     ],
     env={**os.environ, "UNITYTOOL_BRIDGE_WATCH_DIR": "D:\\UnitySampleProject\\prefab-sentinel"},
 )
-async with stdio_client(params) as (read, write):
-    async with ClientSession(read, write) as session:
-        await session.initialize()
-        await session.call_tool("activate_project", {...})
-        await session.call_tool("deploy_bridge", {})
-        await session.call_tool("<verify_tool>", {...})
+async with Client(stdio_client(params), mode="2026-07-28") as client:
+    assert client.protocol_version == "2026-07-28"
+    await client.call_tool("activate_project", {...})
+    await client.call_tool("deploy_bridge", {})
+    await client.call_tool("<verify_tool>", {...})
 ```
 
-実行は `uv run --with 'mcp>=1.12' python /tmp/verify_<topic>.py`。Claude Code 設定の永続変更も bg uvx 残置もなく完結する。
+実行は `uv run --with 'mcp>=2,<3' python /tmp/verify_<topic>.py`。Claude Code 設定の永続変更も bg uvx 残置もなく完結する。
 
 **uv キャッシュの落とし穴**（astral-sh/uv#16196）:
 - `uvx --from <local-path>` のデフォルト cache key は `pyproject.toml` / `setup.py` / `setup.cfg` のみ。`tools/unity/*.cs` を編集しても **wheel が rebuild されない** ため、修正済みソースが配置されず古い bridge が deploy される事故が起こる。

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -227,6 +227,29 @@ Exactly one `kind="prefab"`, `mode="open"` resource with `confirm=true` returns 
 
 ## エラーコード規約
 
+### MCP protocol-boundary JSON-RPC errors
+
+次の表は、現行の Prefab Sentinel protocol / HTTP gate が自ら返す JSON-RPC error を網羅する。これらは MCP wire contract 自体の rejection であり、`tools/call` の `CallToolResult` や Prefab Sentinel の `success / severity / code / ...` domain envelope には包まない。HTTP status は Streamable HTTP の場合だけ適用し、stdio には HTTP status がない。JSON-RPC / MCP 全体の error inventory ではなく、現在の gate-owned emission surface である。
+
+| JSON-RPC code | 名前 | 条件 | HTTP status |
+|---:|---|---|---:|
+| `-32700` | `Parse error` | request body が JSON として parse できない | `400` |
+| `-32600` | `Invalid Request` | JSON-RPC request object が不正。HTTP では request ID を持たない notification（`notifications/cancelled` を含む）も現行 gate がこの code で拒否する | `400` |
+| `-32602` | `Invalid params` | 必須の namespaced request `_meta` または method parameter が欠落・不正 | `400` |
+| `-32022` | `UnsupportedProtocolVersion` | namespaced request metadata の protocol version が `2026-07-28` 以外。`data` に requested / supported version evidence を返す | `400` |
+| `-32020` | `HeaderMismatch` | HTTP の必須 header が欠落・malformed、または header value が対応する request body value と一致しない | `400` |
+| `-32601` | `Method not found` | 上記 validation を通過した後、3 つの request method (`server/discover` / `tools/list` / `tools/call`) 以外。valid modern `initialize` も removed method としてこの code を返す | `404` |
+
+HTTP の request classification は、malformed metadata `-32602` → unsupported version `-32022` → header/body mismatch `-32020` → valid modern removed method（`initialize` を含む）`-32601` の優先順位である。legacy `params.protocolVersion` は removed method を復活させない。
+
+stdio では pinned MCP Python SDK v2.0.0 の stream loop が modern `initialize` を product middleware より先に処理し、`-32022` と `data.supported=["2026-07-28"]` を返す。これは SDK-owned transport 例外であり、HTTP または direct middleware の method-resolution contract を変更する互換経路ではない。
+
+現行 101 tool は client capability を必要としないため、product が `-32021` (`MissingRequiredClientCapability`) を返す経路はない。pinned conformance alpha.11 の `server-stateless` は `test_missing_capability` という structural diagnostic tool を要求するが、その tool を公開 surface または hidden dispatch に追加しない。この非適用 probe を含む scenario は厳格 CI gate から除外し、upstream が non-applicable structural probe の skip をサポートした時点で再検討する。これは full conformance の主張ではなく、process-wide state の既知逸脱は [ARCHITECTURE.md](../ARCHITECTURE.md#mcpserver--protocol-boundary) に残る。
+
+この表の numeric code を下記の domain-code inventory に文字列として追加しない。tool が正常に実行されて domain envelope の `success=false` を返す場合は MCP execution error ではなく、`CallToolResult.isError=false` の structured result として保持する。SDK の tool 引数検証・handler 実行失敗だけが `CallToolResult.isError=true` になる。result 境界の正本は [tool-conventions.md](./tool-conventions.md#mcp-protocol--result-境界)。
+
+### Prefab Sentinel domain-code inventory
+
 | コード | 説明 |
 |--------|------|
 | `SER001` | Serialized path not found — `propertyPath` の構文不正（空文字列、空セグメント `a..b`、閉じ括弧欠落 `a.Array.data[0` 等）または対象のプロパティが存在しない。 |

--- a/docs/execution-reference.md
+++ b/docs/execution-reference.md
@@ -7,9 +7,28 @@ v0.4.0 で CLI (`prefab-sentinel` コマンド) は廃止され、MCP サーバ�
 
 ## 実行方法
 
-- MCP サーバー: `prefab-sentinel-mcp`（エントリポイント）。検査・編集はすべて MCP ツール経由で行う（ツール一覧は [docs/tools.md](./tools.md)）。
-- 環境変数プレフィックス（`UNITYTOOL_*`）は互換性のため現状維持とする（一覧は [CONFIGURATION.md](../CONFIGURATION.md)）。
-- unit test は `scripts/run_unit_tests.py` で並列実行する（「CI / テスト実行」節参照）。
+`prefab-sentinel-mcp` が MCP server entry point。検査・編集はすべて MCP ツール経由で行う（ツール一覧は [docs/tools.md](./tools.md)）。公開 contract は **MCP 2026-07-28 only / Tools only** で、request method は `server/discover` / `tools/list` / `tools/call` の 3 つだけを受理する。stdio の `notifications/cancelled` はこの request method allowlist とは別の notification 経路として SDK へ転送する。legacy client の `initialize` / `initialized` handshake、version negotiation、`Mcp-Session-Id` lifecycle はサポートしない。
+
+### stdio（既定）
+
+```bash
+uv run prefab-sentinel-mcp
+uv run prefab-sentinel-mcp --project-root /path/to/unity/project
+```
+
+stdio は既定 transport で、ホスト側が server process の stdin / stdout を所有する。1 server process は 1 logical client / project scope として扱う。
+
+### local Streamable HTTP
+
+```bash
+uv run prefab-sentinel-mcp --transport streamable-http --port 8000
+```
+
+endpoint は `http://127.0.0.1:<port>/mcp`。host は `127.0.0.1` 固定で設定項目を持たず、port の既定値は `8000`、受理範囲は `1..65535`。MCP request は `/mcp` への POST のみで、GET / DELETE による stream や session termination は提供しない。2026-07-28 の HTTP core protocol には client-to-server notification がないため、request ID のない `notifications/cancelled` 等は現行 gate が HTTP `400` / `-32600` で拒否する。legacy session header が送られても session は作られず、response に session ID を発行しない。remote / shared server、public bind、TLS termination、認証はこの process の責務外である。
+
+transport にかかわらず `ProjectSession` は process-wide application state で、MCP protocol session ではない。`activate_project` は後続 request が暗黙利用する state と cache / watcher を更新し、`tools/call` は process-wide に直列実行する。複数 client / project を分離する場合は server process も分ける。この continuity は deliberate product constraint であり、MCP 2026-07-28 の per-request stateless model に対する既知の逸脱なので、現行 server について full conformance は主張しない。責務境界は [ARCHITECTURE.md](../ARCHITECTURE.md#mcpserver--protocol-boundary)、request metadata と result semantics は [tool-conventions.md](./tool-conventions.md#mcp-protocol--result-境界)、protocol error の優先順位と stdio transport 例外は [api-reference.md](./api-reference.md#エラーコード規約) を参照。
+
+環境変数プレフィックス（`UNITYTOOL_*`）は互換性のため現状維持とする（一覧は [CONFIGURATION.md](../CONFIGURATION.md)）。unit test は `scripts/run_unit_tests.py` で並列実行する（「CI / テスト実行」節参照）。
 
 ## レポート / ignore-guid
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -1,10 +1,24 @@
 # MCP ツール表面規約
 
-`prefab-sentinel-mcp` が公開する MCP ツールの **住所表現・引数命名・監査ペア要否** の規約の正本。[docs/tools.md](./tools.md) が「どのツールがあるか」のカタログであるのに対し、本書は「ツールをどう名付け・どう住所し・いつ監査するか」の規約を定める。
+`prefab-sentinel-mcp` が公開する **MCP protocol / result 境界、住所表現、引数命名、監査ペア要否** の規約の正本。[docs/tools.md](./tools.md) が「どのツールがあるか」のカタログであるのに対し、本書は「どの request / result contract でツールを公開し、どう名付け・住所し・監査するか」を定める。
 
 本書は規約（あるべき形）の正本であり、新規ツールの追加・既存ツールの変更は本書に従う。本書ではスキーム名をハイフン（`asset-path`）、実際の引数名をアンダースコア（`asset_path`）で表記する。
 
 _規約確定: 2026-05-18_
+
+## MCP protocol / result 境界
+
+公開 MCP contract は `2026-07-28` のみを受理し、server capability は Tools (`listChanged=false`) のみを宣言する。request method allowlist は `server/discover` / `tools/list` / `tools/call` の 3 つで、legacy `initialize` / `initialized` と resource / prompt request method は公開しない。stdio の `notifications/cancelled` はこの 3 request method に数えず、notification として SDK handler へ転送する。HTTP core protocol には client-to-server notification がないため、HTTP gate は request ID のない notification を `-32600` で拒否する。この移行は legacy client に対する意図的な breaking change であり、version negotiation や session lifecycle の互換レイヤは持たない。
+
+この節は受理 surface の規約であり、full conformance の合格宣言ではない。現行 protocol error の優先順位と stdio transport 例外は [api-reference.md](./api-reference.md#エラーコード規約)、process-wide application state の statelessness 逸脱は [ARCHITECTURE.md](../ARCHITECTURE.md#mcpserver--protocol-boundary) を正本とする。
+
+2026-07-28 の各 request は `_meta["io.modelcontextprotocol/protocolVersion"]="2026-07-28"` と `_meta["io.modelcontextprotocol/clientCapabilities"]` を必須とする。`_meta["io.modelcontextprotocol/clientInfo"]` は optional だが、client は送信することが推奨される。これらは request ごとの namespaced metadata であり、事前 handshake や session state の代替ではない。
+
+`tools/call` の失敗は次の 3 境界を混同しない。
+
+- ツールが正常に実行され、Prefab Sentinel の domain envelope が `success=false` を返す場合は、MCP `CallToolResult.isError=false` のまま `structuredContent` に envelope を保持する。domain failure は MCP execution failure ではない。
+- SDK の引数 schema 検証や tool handler の実行自体が失敗した場合は `CallToolResult.isError=true` とする。
+- protocol version / request metadata / request-method allowlist の違反は tool result に包まず、top-level JSON-RPC error とする。numeric code と HTTP status の正本は [api-reference.md「エラーコード規約」](./api-reference.md#エラーコード規約)。
 
 ## 1. 住所スキーム
 
@@ -88,6 +102,8 @@ patch v2 スキーマの op 内でコンポーネントを指す文字列フォ�
 ### 2.4 value 引数
 
 「値」を受け取る引数は、**「未指定」と「空値」を別の表現にする**。`value: str = ""` のように既定値が「未指定」のセンチネルを兼ねる設計を禁止する（空文字列を書けなくなる）。`value: str | None = None` のように、値が与えられたか否かを内容と独立に表せる型にする。
+
+0.9.x の narrow exception として、`editor_set_udonsharp_field.values_json` だけは非 nullable の `str = ""` を維持する。omitted または空文字列を「配列値なし」として扱い、explicit JSON `null` は SDK 2.x の公開 input schema で schema-invalid としてサポートしない。この例外を他の value 引数へ一般化してはならない。
 
 ### 2.5 単複
 

--- a/prefab_sentinel/mcp_http.py
+++ b/prefab_sentinel/mcp_http.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Final
+
+from mcp.server import MCPServer
+from mcp.server.transport_security import TransportSecurityMiddleware, TransportSecuritySettings
+from mcp.shared.inbound import (
+    ERROR_CODE_HTTP_STATUS,
+    MCP_PROTOCOL_VERSION_HEADER,
+    InboundLadderRejection,
+    classify_inbound_request,
+    find_duplicated_routing_header,
+)
+from mcp_types import (
+    HEADER_MISMATCH,
+    INVALID_PARAMS,
+    INVALID_REQUEST,
+    METHOD_NOT_FOUND,
+    PARSE_ERROR,
+    methods as mcp_methods,
+)
+from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS
+from pydantic import ValidationError
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from prefab_sentinel.mcp_protocol import (
+    ALLOWED_REQUEST_METHODS,
+    MCP_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    unsupported_protocol_version,
+)
+
+MCP_HTTP_PATH: Final = "/mcp"
+MAX_HTTP_REQUEST_BODY_SIZE: Final = 4 * 1024 * 1024
+
+
+def local_transport_security() -> TransportSecuritySettings:
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],
+        allowed_origins=[
+            "http://127.0.0.1:*",
+            "http://localhost:*",
+            "http://[::1]:*",
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class _GateError:
+    status_code: int
+    code: int
+    message: str
+    request_id: int | str | None
+    data: Any = None
+
+
+@dataclass(frozen=True)
+class _RequestTooLarge:
+    pass
+
+
+@dataclass(frozen=True)
+class _BufferedBody:
+    data: bytes
+    complete: bool
+
+
+_REQUEST_TOO_LARGE: Final = _RequestTooLarge()
+
+
+class MCP20260728HTTPGate:
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        path: str = MCP_HTTP_PATH,
+        max_request_body_size: int = MAX_HTTP_REQUEST_BODY_SIZE,
+        security_settings: TransportSecuritySettings,
+    ) -> None:
+        if max_request_body_size <= 0:
+            raise ValueError("max_request_body_size must be a positive number of bytes")
+        self._app = app
+        self._path = path
+        self._max_request_body_size = max_request_body_size
+        self._security = TransportSecurityMiddleware(security_settings)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope["path"] != self._path:
+            await self._app(scope, receive, send)
+            return
+
+        request = Request(scope, receive=receive)
+        method = request.method
+        security_error = await self._security.validate_request(request, is_post=method == "POST")
+        if security_error is not None:
+            await security_error(scope, receive, send)
+            return
+
+        if method != "POST":
+            response = Response("Method Not Allowed", status_code=405, headers={"Allow": "POST"})
+            await response(scope, receive, send)
+            return
+
+        buffered = await self._bounded_body(receive)
+        if isinstance(buffered, _RequestTooLarge):
+            response = Response("Request body too large", status_code=413)
+            await response(scope, receive, send)
+            return
+        if not buffered.complete:
+            return
+
+        decoded = self._decode_json_request(buffered.data)
+        if isinstance(decoded, _GateError):
+            await self._send_jsonrpc_error(decoded, scope, receive, send)
+            return
+
+        envelope_error = self._validate_request_envelope(decoded)
+        if envelope_error is not None:
+            await self._send_jsonrpc_error(envelope_error, scope, receive, send)
+            return
+
+        request_id = decoded.get("id")
+        method_name = decoded["method"]
+        if "id" not in decoded:
+            notification_error = _GateError(
+                status_code=400,
+                code=INVALID_REQUEST,
+                message="HTTP requests must carry a JSON-RPC request id",
+                request_id=None,
+            )
+            await self._send_jsonrpc_error(notification_error, scope, receive, send)
+            return
+
+        duplicated = find_duplicated_routing_header(request.headers.items())
+        if duplicated is not None:
+            duplicate_error = _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS[HEADER_MISMATCH],
+                code=HEADER_MISMATCH,
+                message=f"{duplicated} header appears more than once",
+                request_id=request_id,
+            )
+            await self._send_jsonrpc_error(duplicate_error, scope, receive, send)
+            return
+
+        header_version = request.headers.get(MCP_PROTOCOL_VERSION_HEADER)
+        exact_modern_header = (
+            header_version == MCP_PROTOCOL_VERSION and header_version not in HANDSHAKE_PROTOCOL_VERSIONS
+        )
+        verdict = classify_inbound_request(
+            decoded,
+            headers=dict(request.headers),
+            supported_modern_versions=SUPPORTED_PROTOCOL_VERSIONS,
+        )
+        if isinstance(verdict, InboundLadderRejection):
+            rejection = _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS.get(verdict.code, 400),
+                code=verdict.code,
+                message=verdict.message,
+                request_id=request_id,
+                data=verdict.data,
+            )
+            await self._send_jsonrpc_error(rejection, scope, receive, send)
+            return
+
+        if method_name not in ALLOWED_REQUEST_METHODS:
+            method_error = _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS[METHOD_NOT_FOUND],
+                code=METHOD_NOT_FOUND,
+                message=f"Method not found: {method_name}",
+                request_id=request_id,
+            )
+            await self._send_jsonrpc_error(method_error, scope, receive, send)
+            return
+
+        if not exact_modern_header:
+            protocol_error = unsupported_protocol_version(verdict.protocol_version)
+            rejection = _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS[protocol_error.code],
+                code=protocol_error.code,
+                message=protocol_error.message,
+                request_id=request_id,
+                data=protocol_error.data,
+            )
+            await self._send_jsonrpc_error(rejection, scope, receive, send)
+            return
+
+        try:
+            mcp_methods.validate_client_request(
+                method_name,
+                verdict.protocol_version,
+                decoded.get("params"),
+            )
+        except ValidationError:
+            params_error = _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS[INVALID_PARAMS],
+                code=INVALID_PARAMS,
+                message="Invalid method parameters",
+                request_id=request_id,
+            )
+            await self._send_jsonrpc_error(params_error, scope, receive, send)
+            return
+
+        await self._app(scope, self._replay_body(buffered, receive), send)
+
+    async def _bounded_body(self, receive: Receive) -> _BufferedBody | _RequestTooLarge:
+        body = bytearray()
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                return _BufferedBody(data=bytes(body), complete=False)
+            chunk = message.get("body", b"")
+            if len(body) + len(chunk) > self._max_request_body_size:
+                return _REQUEST_TOO_LARGE
+            body.extend(chunk)
+            if not message.get("more_body", False):
+                return _BufferedBody(data=bytes(body), complete=True)
+
+    @staticmethod
+    def _decode_json_request(body: bytes) -> dict[str, Any] | _GateError:
+        try:
+            decoded = json.loads(body)
+        except (ValueError, RecursionError):
+            return _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS[PARSE_ERROR],
+                code=PARSE_ERROR,
+                message="Parse error",
+                request_id=None,
+            )
+        if not isinstance(decoded, dict):
+            return _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS[INVALID_REQUEST],
+                code=INVALID_REQUEST,
+                message="Invalid Request",
+                request_id=None,
+            )
+        return decoded
+
+    @staticmethod
+    def _validate_request_envelope(decoded: dict[str, Any]) -> _GateError | None:
+        method = decoded.get("method")
+        request_id = decoded.get("id")
+        valid_id = isinstance(request_id, str | int) and not isinstance(request_id, bool)
+        if (
+            decoded.get("jsonrpc") != "2.0"
+            or not isinstance(method, str)
+            or not method
+            or ("id" in decoded and not valid_id)
+        ):
+            return _GateError(
+                status_code=ERROR_CODE_HTTP_STATUS[INVALID_REQUEST],
+                code=INVALID_REQUEST,
+                message="Invalid Request",
+                request_id=None,
+            )
+        return None
+
+    @staticmethod
+    def _replay_body(body: _BufferedBody, receive: Receive) -> Receive:
+        replayed = False
+
+        async def replay() -> Message:
+            nonlocal replayed
+            if not replayed:
+                replayed = True
+                return {"type": "http.request", "body": body.data, "more_body": False}
+            return await receive()
+
+        return replay
+
+    @staticmethod
+    async def _send_jsonrpc_error(
+        error: _GateError,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        error_payload: dict[str, Any] = {"code": error.code, "message": error.message}
+        if error.data is not None:
+            error_payload["data"] = error.data
+        response = JSONResponse(
+            {"jsonrpc": "2.0", "id": error.request_id, "error": error_payload},
+            status_code=error.status_code,
+        )
+        await response(scope, receive, send)
+
+
+def build_http_app(server: MCPServer[Any]) -> ASGIApp:
+    security = local_transport_security()
+    sdk_app = server.streamable_http_app(
+        streamable_http_path=MCP_HTTP_PATH,
+        json_response=True,
+        max_request_body_size=MAX_HTTP_REQUEST_BODY_SIZE,
+        transport_security=security,
+        host="127.0.0.1",
+    )
+    return MCP20260728HTTPGate(
+        sdk_app,
+        path=MCP_HTTP_PATH,
+        max_request_body_size=MAX_HTTP_REQUEST_BODY_SIZE,
+        security_settings=security,
+    )

--- a/prefab_sentinel/mcp_protocol.py
+++ b/prefab_sentinel/mcp_protocol.py
@@ -1,0 +1,103 @@
+"""Product-owned MCP protocol contract and process-local tool serialization."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Final
+
+import anyio
+from mcp import MCPError
+from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
+from mcp_types import METHOD_NOT_FOUND, UNSUPPORTED_PROTOCOL_VERSION
+
+MCP_PROTOCOL_VERSION: Final = "2026-07-28"
+SUPPORTED_PROTOCOL_VERSIONS: Final = (MCP_PROTOCOL_VERSION,)
+ALLOWED_REQUEST_METHODS: Final = frozenset(
+    {"server/discover", "tools/list", "tools/call"}
+)
+SERVER_INFO_META_KEY: Final = "io.modelcontextprotocol/serverInfo"
+
+
+def unsupported_protocol_version(requested: str) -> MCPError:
+    return MCPError(
+        code=UNSUPPORTED_PROTOCOL_VERSION,
+        message=f"Unsupported protocol version: {requested}",
+        data={"supported": list(SUPPORTED_PROTOCOL_VERSIONS), "requested": requested},
+    )
+
+
+class ProtocolContractMiddleware:
+    def __init__(
+        self,
+        *,
+        server_name: str,
+        server_version: str,
+        instructions: str,
+    ) -> None:
+        self.server_name = server_name
+        self.server_version = server_version
+        self.instructions = instructions
+
+    async def __call__(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        call_next: CallNext,
+    ) -> HandlerResult:
+        if ctx.request_id is None:
+            if ctx.method == "notifications/cancelled":
+                return await call_next(ctx)
+            return None
+
+        if ctx.protocol_version != MCP_PROTOCOL_VERSION:
+            raise unsupported_protocol_version(ctx.protocol_version)
+
+        if ctx.method not in ALLOWED_REQUEST_METHODS:
+            raise MCPError(
+                code=METHOD_NOT_FOUND,
+                message=f"Method not found: {ctx.method}",
+            )
+
+        result = await call_next(ctx)
+        if ctx.method == "server/discover":
+            return self._normalize_discovery(result)
+        return result
+
+    def _normalize_discovery(self, result: HandlerResult) -> dict[str, Any]:
+        if not isinstance(result, dict):
+            raise TypeError("server/discover handler must return a dictionary")
+
+        payload = result.copy()
+        existing_meta = payload.get("_meta")
+        if existing_meta is None:
+            normalized_meta: dict[str, Any] = {}
+        elif isinstance(existing_meta, Mapping):
+            normalized_meta = dict(existing_meta)
+        else:
+            raise TypeError("server/discover _meta must be a mapping")
+
+        payload["supportedVersions"] = [MCP_PROTOCOL_VERSION]
+        payload["capabilities"] = {"tools": {"listChanged": False}}
+        payload["instructions"] = self.instructions
+        payload["_meta"] = {
+            **normalized_meta,
+            SERVER_INFO_META_KEY: {
+                "name": self.server_name,
+                "version": self.server_version,
+            },
+        }
+        return payload
+
+
+class SerializeToolCallsMiddleware:
+    def __init__(self) -> None:
+        self._tool_lock = anyio.Lock()
+
+    async def __call__(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        call_next: CallNext,
+    ) -> HandlerResult:
+        if ctx.request_id is None or ctx.method != "tools/call":
+            return await call_next(ctx)
+        async with self._tool_lock:
+            return await call_next(ctx)

--- a/prefab_sentinel/mcp_server.py
+++ b/prefab_sentinel/mcp_server.py
@@ -11,18 +11,21 @@ Requires the ``mcp`` optional dependency::
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from importlib.metadata import version
 from pathlib import Path
 
 try:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 except ImportError as exc:
-    raise ImportError(
-        "MCP server requires the 'mcp' extra: "
-        "pip install prefab-sentinel[mcp]"
-    ) from exc
+    raise ImportError("MCP server requires the 'mcp' extra: pip install prefab-sentinel[mcp]") from exc
 
 import prefab_sentinel.editor_bridge as editor_bridge
+from prefab_sentinel.mcp_protocol import (
+    ProtocolContractMiddleware,
+    SerializeToolCallsMiddleware,
+)
 from prefab_sentinel.mcp_tools_components import register_component_tools
 from prefab_sentinel.mcp_tools_components_copy import register_copy_component_fields_tool
 from prefab_sentinel.mcp_tools_editor_advanced import register_editor_advanced_tools
@@ -55,50 +58,60 @@ __all__ = ["create_server"]
 
 logger = logging.getLogger(__name__)
 
+SERVER_NAME = "prefab-sentinel"
 
 
-
-
-
-
-
+def _server_instructions() -> str:
+    return (
+        "activate_project selects the process-wide active Unity project. "
+        "One process represents one logical client/project scope. "
+        "Tool calls execute serially. "
+        "Normal inspection, dry-run, and confirm entry points remain unchanged."
+    )
 
 
 def create_server(
     project_root: str | Path | None = None,
-) -> FastMCP:
+) -> MCPServer[ProjectSession]:
     """Create and configure the Prefab Sentinel MCP server.
 
     Args:
-        project_root: Unity project root. Auto-detected when ``None``.
+        project_root: Unity project root. Auto-detected when None.
 
     Returns:
-        A configured ``FastMCP`` server instance ready to run.
+        A configured MCPServer instance ready to run.
     """
-    _root = Path(project_root).resolve() if project_root else None
-    session = ProjectSession(project_root=_root)
+    root = Path(project_root).resolve() if project_root else None
+    session = ProjectSession(project_root=root)
+    server_version = version("prefab-sentinel")
+    instructions = _server_instructions()
 
     @asynccontextmanager
-    async def _lifespan(_app: FastMCP):  # type: ignore[type-arg]
+    async def lifespan(
+        _server: MCPServer[ProjectSession],
+    ) -> AsyncIterator[ProjectSession]:
         editor_bridge._set_expected_project_root_provider(
             lambda: str(session.project_root) if session.project_root is not None else None
         )
         try:
-            yield
+            yield session
         finally:
             editor_bridge._set_expected_project_root_provider(None)
             await session.shutdown()
 
-    server = FastMCP(
-        name="prefab-sentinel",
-        instructions=(
-            "Unity asset inspection and editing tools. "
-            "Use activate_project to set scope, "
-            "get_unity_symbols to explore asset structure, "
-            "find_unity_symbol to locate specific objects by name, "
-            "and validate_refs to check for broken references."
-        ),
-        lifespan=_lifespan,
+    server = MCPServer(
+        name=SERVER_NAME,
+        version=server_version,
+        instructions=instructions,
+        lifespan=lifespan,
+        middleware=[
+            ProtocolContractMiddleware(
+                server_name=SERVER_NAME,
+                server_version=server_version,
+                instructions=instructions,
+            ),
+            SerializeToolCallsMiddleware(),
+        ],
     )
 
     # Register tool modules
@@ -128,9 +141,26 @@ def create_server(
     return server
 
 
+def _port_number(value: str) -> int:
+    """Parse a TCP port accepted by the loopback HTTP CLI."""
+    import argparse
+
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("PORT must be an integer from 1 through 65535") from exc
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("PORT must be an integer from 1 through 65535")
+    return port
+
+
 def main() -> None:
     """Entry point for the MCP server."""
     import argparse
+
+    import uvicorn
+
+    from prefab_sentinel.mcp_http import build_http_app
 
     parser = argparse.ArgumentParser(description="Prefab Sentinel MCP Server")
     parser.add_argument(
@@ -144,10 +174,22 @@ def main() -> None:
         default=None,
         help="Unity project root directory (auto-detected if omitted)",
     )
+    parser.add_argument(
+        "--port",
+        type=_port_number,
+        default=8000,
+        metavar="PORT",
+        help="Streamable HTTP loopback port (default: %(default)s)",
+    )
     args = parser.parse_args()
 
     server = create_server(project_root=args.project_root)
-    server.run(transport=args.transport)
+    if args.transport == "stdio":
+        server.run("stdio")
+        return
+
+    app = build_http_app(server)
+    uvicorn.run(app, host="127.0.0.1", port=args.port)
 
 
 if __name__ == "__main__":

--- a/prefab_sentinel/mcp_tools_components.py
+++ b/prefab_sentinel/mcp_tools_components.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.mcp_helpers import (
     read_asset,
@@ -18,7 +18,7 @@ from prefab_sentinel.session import ProjectSession
 __all__ = ["register_component_tools"]
 
 
-def register_component_tools(server: FastMCP, session: ProjectSession) -> None:
+def register_component_tools(server: MCPServer, session: ProjectSession) -> None:
     """Register component manipulation tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_components_copy.py
+++ b/prefab_sentinel/mcp_tools_components_copy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.mcp_helpers import (
     COPY_SKIP_FIELDS,
@@ -20,7 +20,7 @@ from prefab_sentinel.yaml_field_extraction import extract_block_fields, parse_ya
 __all__ = ["register_copy_component_fields_tool"]
 
 
-def register_copy_component_fields_tool(server: FastMCP, session: ProjectSession) -> None:
+def register_copy_component_fields_tool(server: MCPServer, session: ProjectSession) -> None:
     """Register the copy_component_fields tool on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_editor_advanced.py
+++ b/prefab_sentinel/mcp_tools_editor_advanced.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 from prefab_sentinel.json_io import load_json
@@ -28,7 +28,7 @@ def _reflect_error(code: str, message: str) -> dict[str, Any]:
     }
 
 
-def register_editor_advanced_tools(server: FastMCP) -> None:
+def register_editor_advanced_tools(server: MCPServer) -> None:
     """Register VRC SDK and reflection tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_editor_animation.py
+++ b/prefab_sentinel/mcp_tools_editor_animation.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 from prefab_sentinel.json_io import dump_json
@@ -166,7 +166,7 @@ def editor_apply_animation_clip(
     )
 
 
-def register_editor_animation_tools(server: FastMCP) -> None:
+def register_editor_animation_tools(server: MCPServer) -> None:
     """Register the three AnimationClip tools on *server*."""
 
     @server.tool(name="editor_inspect_animation_clip")

--- a/prefab_sentinel/mcp_tools_editor_assets.py
+++ b/prefab_sentinel/mcp_tools_editor_assets.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 
@@ -883,7 +883,7 @@ def _report_write_failed(
     )
 
 
-def register_editor_asset_tools(server: FastMCP) -> None:
+def register_editor_asset_tools(server: MCPServer) -> None:
     @server.tool()
     def editor_create_generated_asset(
         asset_type: object,
@@ -894,6 +894,7 @@ def register_editor_asset_tools(server: FastMCP) -> None:
         out_report: object | None = None,
         change_reason: object | None = None,
     ) -> dict[str, Any]:
+        """Dry-run or create a validated RenderTexture asset through the Unity Editor."""
         create_tool = cast(
             Callable[..., dict[str, Any]],
             globals()["editor_create_generated_asset"],
@@ -917,6 +918,7 @@ def register_editor_asset_tools(server: FastMCP) -> None:
         out_report: object | None = None,
         change_reason: object | None = None,
     ) -> dict[str, Any]:
+        """Dry-run or move a Unity asset to a validated destination path."""
         move_tool = cast(
             Callable[..., dict[str, Any]],
             globals()["editor_move_asset"],

--- a/prefab_sentinel/mcp_tools_editor_batch.py
+++ b/prefab_sentinel/mcp_tools_editor_batch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 from prefab_sentinel.editor_bridge_builders import build_create_empty_kwargs
@@ -48,7 +48,7 @@ def editor_batch_set_blend_shape(
     )
 
 
-def register_editor_batch_tools(server: FastMCP) -> None:
+def register_editor_batch_tools(server: MCPServer) -> None:
     """Register editor batch and scene management tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_editor_exec.py
+++ b/prefab_sentinel/mcp_tools_editor_exec.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import DEFAULT_TIMEOUT_SEC, send_action
 from prefab_sentinel.mcp_validation import require_write_audit
@@ -290,7 +290,7 @@ def editor_run_script_poll(
     return _normalize_run_script_envelope(response)
 
 
-def register_editor_exec_tools(server: FastMCP) -> None:
+def register_editor_exec_tools(server: MCPServer) -> None:
     """Register ``editor_run_script`` on *server*."""
 
     @server.tool(name="editor_run_script")

--- a/prefab_sentinel/mcp_tools_editor_geometry.py
+++ b/prefab_sentinel/mcp_tools_editor_geometry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 
@@ -15,6 +15,7 @@ __all__ = [
 
 
 def editor_get_transform(hierarchy_path: str) -> dict[str, Any]:
+    """Read transform values for a Unity Editor hierarchy object."""
     return send_action(action="get_transform", hierarchy_path=hierarchy_path)
 
 
@@ -23,6 +24,7 @@ def editor_get_bounds(
     source: str = "auto",
     include_children: bool = True,
 ) -> dict[str, Any]:
+    """Read bounds for a Unity Editor hierarchy object, optionally including children."""
     return send_action(
         action="get_bounds",
         hierarchy_path=hierarchy_path,
@@ -37,6 +39,7 @@ def editor_measure_distance(
     mode: str = "pivot",
     bounds_source: str = "auto",
 ) -> dict[str, Any]:
+    """Measure pivot or bounds distance between two Unity Editor hierarchy objects."""
     return send_action(
         action="measure_distance",
         hierarchy_path=a,
@@ -46,7 +49,7 @@ def editor_measure_distance(
     )
 
 
-def register_editor_geometry_tools(server: FastMCP) -> None:
+def register_editor_geometry_tools(server: MCPServer) -> None:
     server.tool()(editor_get_transform)
     server.tool()(editor_get_bounds)
     server.tool()(editor_measure_distance)

--- a/prefab_sentinel/mcp_tools_editor_ops.py
+++ b/prefab_sentinel/mcp_tools_editor_ops.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 from prefab_sentinel.json_io import dump_json
@@ -13,7 +13,7 @@ from prefab_sentinel.mcp_validation import require_write_audit
 __all__ = ["register_editor_ops_tools"]
 
 
-def register_editor_ops_tools(server: FastMCP) -> None:
+def register_editor_ops_tools(server: MCPServer) -> None:
     """Register editor property and prefab operation tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_editor_prefab_stage.py
+++ b/prefab_sentinel/mcp_tools_editor_prefab_stage.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 from prefab_sentinel.mcp_validation import require_write_audit
@@ -64,7 +64,7 @@ def editor_close_prefab(
     return send_action(action="close_prefab", save_on_close=False)
 
 
-def register_editor_prefab_stage_tools(server: FastMCP) -> None:
+def register_editor_prefab_stage_tools(server: MCPServer) -> None:
     """Register the Prefab Stage open / close tools on *server*."""
 
     @server.tool(name="editor_open_prefab")

--- a/prefab_sentinel/mcp_tools_editor_serialized_property.py
+++ b/prefab_sentinel/mcp_tools_editor_serialized_property.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 
@@ -137,7 +137,7 @@ def _write_intent_error(intents: list[str], array_size: int | None) -> dict[str,
     return None
 
 
-def register_editor_serialized_property_tools(server: FastMCP) -> None:
+def register_editor_serialized_property_tools(server: MCPServer) -> None:
     """Register issue #112 SerializedProperty editor tools on *server*."""
 
     @server.tool()
@@ -147,6 +147,7 @@ def register_editor_serialized_property_tools(server: FastMCP) -> None:
         property_path: str,
         component_index: int | None = None,
     ) -> dict[str, Any]:
+        """Read one SerializedProperty from a Unity Editor hierarchy component."""
         err = _required_address_error(hierarchy_path, component_type, property_path)
         if err is not None:
             return err
@@ -170,6 +171,7 @@ def register_editor_serialized_property_tools(server: FastMCP) -> None:
         cap: int = DEFAULT_CAP,
         cursor: str | None = None,
     ) -> dict[str, Any]:
+        """List a bounded page of SerializedProperties for a Unity Editor component."""
         err = _required_address_error(hierarchy_path, component_type, None)
         if err is not None:
             return err
@@ -212,6 +214,7 @@ def register_editor_serialized_property_tools(server: FastMCP) -> None:
         confirm: bool = False,
         change_reason: str = "",
     ) -> dict[str, Any]:
+        """Dry-run or apply one typed SerializedProperty write in the Unity Editor."""
         err = _required_address_error(hierarchy_path, component_type, property_path)
         if err is not None:
             return err

--- a/prefab_sentinel/mcp_tools_editor_udonsharp.py
+++ b/prefab_sentinel/mcp_tools_editor_udonsharp.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 from prefab_sentinel.mcp_validation import require_write_audit
@@ -60,7 +60,7 @@ def _no_value_envelope() -> dict[str, Any]:
     }
 
 
-def register_editor_udonsharp_tools(server: FastMCP) -> None:
+def register_editor_udonsharp_tools(server: MCPServer) -> None:
     """Register the three UdonSharp authoring tools on *server*."""
 
     @server.tool()
@@ -136,14 +136,14 @@ def register_editor_udonsharp_tools(server: FastMCP) -> None:
         property_name: str,
         value: str | None = None,
         object_reference: str = "",
-        values_json: str | None = None,
+        values_json: str = "",
         expected_length: int | None = None,
         confirm: bool = False,
         change_reason: str | None = None,
     ) -> dict[str, Any]:
         """Write a serialized field on the unique UdonSharp behaviour."""
         input_count = sum(
-            [value is not None, bool(object_reference), values_json is not None]
+            [value is not None, bool(object_reference), bool(values_json)]
         )
         if input_count > 1:
             return _both_value_envelope()
@@ -162,7 +162,7 @@ def register_editor_udonsharp_tools(server: FastMCP) -> None:
         }
         if object_reference:
             kwargs["object_reference"] = object_reference
-        elif values_json is not None:
+        elif values_json:
             kwargs["values_json"] = values_json
             kwargs["values_json_present"] = True
             if expected_length is not None:

--- a/prefab_sentinel/mcp_tools_editor_view.py
+++ b/prefab_sentinel/mcp_tools_editor_view.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.bridge_constants import CONSOLE_LOG_BUFFER_MAX_ENTRIES
 from prefab_sentinel.editor_bridge import send_action
@@ -590,7 +590,7 @@ def editor_console(
     return send_action(**request)
 
 
-def register_editor_view_tools(server: FastMCP) -> None:
+def register_editor_view_tools(server: MCPServer) -> None:
     """Register view-oriented editor bridge tools on *server*."""
 
     @server.tool(name="editor_screenshot")

--- a/prefab_sentinel/mcp_tools_editor_write.py
+++ b/prefab_sentinel/mcp_tools_editor_write.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import send_action
 from prefab_sentinel.json_io import dump_json
@@ -92,7 +92,7 @@ def editor_get_blend_shapes(
     )
 
 
-def register_editor_write_tools(server: FastMCP) -> None:
+def register_editor_write_tools(server: MCPServer) -> None:
     """Register editor write/mutation tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_inspector_profiles.py
+++ b/prefab_sentinel/mcp_tools_inspector_profiles.py
@@ -4,20 +4,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.session import ProjectSession
 
 __all__ = ["register_inspector_profile_tools"]
 
 
-def register_inspector_profile_tools(server: FastMCP, session: ProjectSession) -> None:
+def register_inspector_profile_tools(server: MCPServer, session: ProjectSession) -> None:
     @server.tool()
     def inspect_serialized_surface(
         asset_path: str,
         symbol_path: str | None = None,
         include_override_origin: bool = False,
     ) -> dict[str, Any]:
+        """Inspect the last-saved serialized surface of a Unity asset target."""
         from prefab_sentinel.inspector_profiles.application import InspectorProfileApplication
 
         return InspectorProfileApplication(session).inspect_serialized_surface(
@@ -33,6 +34,7 @@ def register_inspector_profile_tools(server: FastMCP, session: ProjectSession) -
         symbol_path: str | None = None,
         include_override_origin: bool = False,
     ) -> dict[str, Any]:
+        """Render a named inspector view for a Unity asset using its matching profile."""
         if not view_name:
             return {
                 "success": False,
@@ -57,6 +59,7 @@ def register_inspector_profile_tools(server: FastMCP, session: ProjectSession) -
         asset_path: str,
         symbol_path: str | None = None,
     ) -> dict[str, Any]:
+        """Validate an inspector profile against a Unity asset's serialized surface."""
         from prefab_sentinel.inspector_profiles.application import InspectorProfileApplication
 
         return InspectorProfileApplication(session).validate_inspector_profile(

--- a/prefab_sentinel/mcp_tools_patch.py
+++ b/prefab_sentinel/mcp_tools_patch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.json_io import load_json
 from prefab_sentinel.mcp_validation import require_change_reason
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 
-def register_patch_tools(server: FastMCP, session: ProjectSession) -> None:
+def register_patch_tools(server: MCPServer, session: ProjectSession) -> None:
     """Register patch and asset operation tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_session.py
+++ b/prefab_sentinel/mcp_tools_session.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.contracts import Severity, max_severity
 from prefab_sentinel.editor_bridge import (
@@ -232,7 +232,7 @@ def _append_project_root_mismatch_diagnostic(
     )
 
 
-def register_session_tools(server: FastMCP, session: ProjectSession) -> None:
+def register_session_tools(server: MCPServer, session: ProjectSession) -> None:
     """Register session management tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_set_property.py
+++ b/prefab_sentinel/mcp_tools_set_property.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.contracts import ToolResponse, error_dict
 from prefab_sentinel.mcp_helpers import (
@@ -137,7 +137,7 @@ def _resolve_writer_target(
 
 
 
-def register_set_property_tools(server: FastMCP, session: ProjectSession) -> None:
+def register_set_property_tools(server: MCPServer, session: ProjectSession) -> None:
     """Register property-setting tools on *server*."""
 
     @server.tool()

--- a/prefab_sentinel/mcp_tools_symbols.py
+++ b/prefab_sentinel/mcp_tools_symbols.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prefab_sentinel.editor_bridge import bridge_status, send_action
 from prefab_sentinel.mcp_helpers import read_asset
@@ -55,7 +55,7 @@ def _offline_freshness_marker() -> dict[str, Any] | None:
     return None
 
 
-def register_symbol_tools(server: FastMCP, session: ProjectSession) -> None:
+def register_symbol_tools(server: MCPServer, session: ProjectSession) -> None:
     """Register symbol tree inspection tools on *server*."""
 
     def _annotate_origins(

--- a/prefab_sentinel/mcp_tools_validation.py
+++ b/prefab_sentinel/mcp_tools_validation.py
@@ -5,7 +5,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from prefab_sentinel.contracts import Severity, ToolResponse, error_response, success_response
 from prefab_sentinel.diagnostics_baseline import (
@@ -222,7 +223,7 @@ def _write_diagnostics_baseline_update(
         data=data,
     ).to_dict()
 
-def register_validation_tools(server: FastMCP, session: ProjectSession) -> None:
+def register_validation_tools(server: MCPServer, session: ProjectSession) -> None:
     """Register inspection and validation tools on *server*."""
 
     @server.tool()
@@ -246,7 +247,6 @@ def register_validation_tools(server: FastMCP, session: ProjectSession) -> None:
             max_usages=max_results,
         )
         if not step.success:
-            from mcp.server.fastmcp.exceptions import ToolError
             raise ToolError(f"{step.code}: {step.message}")
 
         usages = step.data.get("usages", [])
@@ -746,6 +746,7 @@ def register_validation_tools(server: FastMCP, session: ProjectSession) -> None:
         change_reason: str | None = None,
         allow_dirty_before_clientsim: bool = False,
     ) -> dict[str, Any]:
+        """Run the selected Unity runtime-validation pipeline for a scene."""
         orch = session.get_orchestrator()
         resp = orch.validate_runtime(
             scene_path=asset_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefab-sentinel"
-version = "0.8.9"
+version = "0.9.0"
 description = "Prefab Sentinel — Unity Prefab/Scene inspection and editing toolkit."
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = ["jsonschema>=4.25,<5"]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.12"]
+mcp = ["mcp>=2,<3"]
 watch = ["watchfiles>=1.0"]
-test = ["unittest-parallel>=1.6,<2"]
+test = ["unittest-parallel>=1.6,<2", "httpx>=0.27.0,<0.29.0"]
 lint = ["ruff>=0.8", "mypy>=1.13", "bump-my-version>=0.31"]
 
 [project.scripts]
@@ -86,7 +86,7 @@ cache-keys = [
 ]
 
 [tool.bumpversion]
-current_version = "0.8.9"
+current_version = "0.9.0"
 commit = false
 tag = false
 allow_dirty = true

--- a/tests/_mcp_test_support.py
+++ b/tests/_mcp_test_support.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any, TypeVar, cast
+
+from mcp.server import MCPServer
+from mcp_types import CallToolResult, InputRequiredResult
+
+_T = TypeVar("_T")
+
+
+def run(coro: Coroutine[Any, Any, _T]) -> _T:
+    return asyncio.run(coro)
+
+
+def call_tool_result(
+    server: MCPServer[Any],
+    name: str,
+    arguments: dict[str, Any],
+) -> CallToolResult:
+    result = run(server.call_tool(name, arguments))
+    if isinstance(result, InputRequiredResult):
+        raise AssertionError(f"{name} unexpectedly returned input_required")
+    return result
+
+
+def structured_payload(result: CallToolResult) -> dict[str, Any]:
+    if result.is_error is not False:
+        raise AssertionError(
+            f"expected CallToolResult with is_error=False, observed {result.is_error!r}"
+        )
+    if not isinstance(result.structured_content, dict):
+        raise AssertionError(f"expected structuredContent object, observed {result!r}")
+    return cast(dict[str, Any], result.structured_content)

--- a/tests/_mcp_wire_support.py
+++ b/tests/_mcp_wire_support.py
@@ -1,0 +1,446 @@
+"""Real-process helpers for MCP CLI wire-contract tests."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import queue
+import socket
+import subprocess
+import sys
+import threading
+import time
+import unittest
+import uuid
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+MCP_PROTOCOL_VERSION = "2026-07-28"
+LEGACY_PROTOCOL_VERSION = "2025-11-25"
+
+_PROCESS_TIMEOUT_SECONDS = 15.0
+_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+_HTTP_TIMEOUT_SECONDS = 1.0
+_READINESS_TIMEOUT_SECONDS = 10.0
+
+
+_STREAM_EOF = object()
+
+
+@dataclass
+class CLIProcess:
+    """A child process with one lifetime owner for each captured read pipe."""
+
+    process: subprocess.Popen[str]
+    _stdout_lines: queue.Queue[object] = field(init=False, repr=False)
+    _stdout_parts: list[str] = field(init=False, repr=False)
+    _stderr_parts: list[str] = field(init=False, repr=False)
+    _stdout_error: BaseException | None = field(init=False, default=None, repr=False)
+    _stderr_error: BaseException | None = field(init=False, default=None, repr=False)
+    _stdout_reader: threading.Thread = field(init=False, repr=False)
+    _stderr_reader: threading.Thread = field(init=False, repr=False)
+    _reaped: bool = field(init=False, default=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._stdout_lines = queue.Queue()
+        self._stdout_parts = []
+        self._stderr_parts = []
+        self._stdout_reader = threading.Thread(
+            target=self._drain_stdout,
+            name=f"mcp-stdout-{self.process.pid}",
+        )
+        self._stderr_reader = threading.Thread(
+            target=self._drain_stderr,
+            name=f"mcp-stderr-{self.process.pid}",
+        )
+        self._stdout_reader.start()
+        self._stderr_reader.start()
+
+    @property
+    def returncode(self) -> int | None:
+        return self.process.returncode
+
+    @property
+    def stdout(self) -> str:
+        return "".join(self._stdout_parts)
+
+    @property
+    def stderr(self) -> str:
+        return "".join(self._stderr_parts)
+
+    @property
+    def reader_threads_alive(self) -> bool:
+        return self._stdout_reader.is_alive() or self._stderr_reader.is_alive()
+
+    def _drain_stdout(self) -> None:
+        stream = self.process.stdout
+        if stream is None:
+            error = AssertionError("MCP CLI stdout is not piped")
+            self._stdout_error = error
+            self._stdout_lines.put(error)
+            self._stdout_lines.put(_STREAM_EOF)
+            return
+        try:
+            for line in stream:
+                self._stdout_parts.append(line)
+                self._stdout_lines.put(line)
+        except BaseException as exc:  # Preserve pipe-reader failures for the test thread.
+            self._stdout_error = exc
+            self._stdout_lines.put(exc)
+        finally:
+            self._stdout_lines.put(_STREAM_EOF)
+
+    def _drain_stderr(self) -> None:
+        stream = self.process.stderr
+        if stream is None:
+            self._stderr_error = AssertionError("MCP CLI stderr is not piped")
+            return
+        try:
+            for line in stream:
+                self._stderr_parts.append(line)
+        except BaseException as exc:  # Preserve pipe-reader failures for cleanup diagnostics.
+            self._stderr_error = exc
+
+    def _close_stdin(self) -> None:
+        stdin = self.process.stdin
+        if stdin is None or stdin.closed:
+            return
+        with suppress(BrokenPipeError):
+            stdin.close()
+
+    def _join_readers(self, *, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for reader in (self._stdout_reader, self._stderr_reader):
+            reader.join(timeout=max(0.0, deadline - time.monotonic()))
+        if self.reader_threads_alive:
+            raise AssertionError("MCP CLI pipe readers did not stop after child exit")
+        if self._stdout_error is not None:
+            raise AssertionError(f"stdout reader failed: {self._stdout_error}") from self._stdout_error
+        if self._stderr_error is not None:
+            raise AssertionError(f"stderr reader failed: {self._stderr_error}") from self._stderr_error
+
+    def _finish_reap(self) -> None:
+        self._join_readers(timeout=_SHUTDOWN_TIMEOUT_SECONDS)
+        for stream in (self.process.stdout, self.process.stderr):
+            if stream is not None:
+                stream.close()
+        self._reaped = True
+
+    def communicate(
+        self,
+        input_text: str | None = None,
+        *,
+        timeout: float = _PROCESS_TIMEOUT_SECONDS,
+    ) -> tuple[str, str]:
+        if self._reaped:
+            return self.stdout, self.stderr
+        stdin = self.process.stdin
+        if input_text and stdin is None:
+            raise AssertionError("MCP CLI stdin is not piped")
+        if input_text and stdin is not None:
+            stdin.write(input_text)
+            stdin.flush()
+        self._close_stdin()
+        self.process.wait(timeout=timeout)
+        self._finish_reap()
+        return self.stdout, self.stderr
+
+    def write_json_line(self, request: Mapping[str, object]) -> None:
+        stdin = self.process.stdin
+        if stdin is None or stdin.closed:
+            raise AssertionError("MCP CLI stdin is not piped")
+        stdin.write(json.dumps(request, separators=(",", ":")))
+        stdin.write("\n")
+        stdin.flush()
+
+    def read_json_line(
+        self,
+        *,
+        timeout: float = _PROCESS_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        try:
+            observed = self._stdout_lines.get(timeout=timeout)
+        except queue.Empty as exc:
+            raise AssertionError("timed out waiting for one MCP stdio response") from exc
+        if observed is _STREAM_EOF:
+            self._stdout_lines.put(_STREAM_EOF)
+            raise AssertionError(f"MCP CLI stdout closed before a response; returncode={self.process.poll()}")
+        if isinstance(observed, BaseException):
+            raise AssertionError(f"stdout reader failed: {observed}") from observed
+        if not isinstance(observed, str):
+            raise AssertionError(f"stdout reader returned an unexpected value: {observed!r}")
+        decoded = json.loads(observed)
+        if not isinstance(decoded, dict):
+            raise AssertionError(f"expected a JSON object response, observed {decoded!r}")
+        return cast(dict[str, Any], decoded)
+
+    def request_json_line(
+        self,
+        request: Mapping[str, object],
+        *,
+        timeout: float = _PROCESS_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        self.write_json_line(request)
+        return self.read_json_line(timeout=timeout)
+
+    def stop(self) -> None:
+        if self._reaped:
+            return
+        self._close_stdin()
+        if self.process.poll() is None:
+            self.process.terminate()
+        try:
+            self.process.wait(timeout=_SHUTDOWN_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=_SHUTDOWN_TIMEOUT_SECONDS)
+        self._finish_reap()
+
+
+@contextmanager
+def running_mcp_cli(
+    *arguments: str,
+    pipe_stdin: bool = False,
+) -> Iterator[CLIProcess]:
+    """Launch the installed module and always reap it with useful failure output."""
+
+    environment = os.environ.copy()
+    environment.pop("UNITYTOOL_BRIDGE_WATCH_DIR", None)
+    environment.pop("UNITYTOOL_UNITY_PROJECT_PATH", None)
+    environment["PYTHONUNBUFFERED"] = "1"
+    process = subprocess.Popen(
+        [sys.executable, "-m", "prefab_sentinel.mcp_server", *arguments],
+        stdin=subprocess.PIPE if pipe_stdin else subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        env=environment,
+    )
+    child = CLIProcess(process)
+    error: Exception | None = None
+    cleanup_error: Exception | None = None
+    try:
+        yield child
+    except Exception as exc:  # Assertions are re-raised with child diagnostics.
+        error = exc
+    finally:
+        try:
+            child.stop()
+        except Exception as exc:
+            cleanup_error = exc
+
+    if error is not None:
+        cleanup_note = f"\ncleanup error: {cleanup_error}" if cleanup_error else ""
+        raise AssertionError(f"{error}{cleanup_note}\nchild stderr:\n{child.stderr or '<empty>'}") from error
+    if cleanup_error is not None:
+        raise AssertionError(
+            f"child cleanup failed: {cleanup_error}\nchild stderr:\n{child.stderr or '<empty>'}"
+        ) from cleanup_error
+
+
+def reserve_loopback_port() -> int:
+    """Ask the OS for an unused IPv4 loopback port and release it for Uvicorn."""
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        return cast(int, reservation.getsockname()[1])
+
+
+@dataclass(frozen=True)
+class HTTPResult:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+    def json_object(self) -> dict[str, Any]:
+        decoded = json.loads(self.body)
+        if not isinstance(decoded, dict):
+            raise AssertionError(f"expected a JSON object, observed {decoded!r}")
+        return cast(dict[str, Any], decoded)
+
+
+def http_request(
+    port: int,
+    method: str,
+    path: str,
+    *,
+    body: Mapping[str, object] | bytes | None = None,
+    headers: Mapping[str, str] | None = None,
+) -> HTTPResult:
+    """Send one bounded standard-library HTTP request."""
+
+    connection = http.client.HTTPConnection(
+        "127.0.0.1",
+        port,
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    request_headers = dict(headers or {})
+    encoded_body: bytes | None
+    if body is None or isinstance(body, bytes):
+        encoded_body = body
+    else:
+        encoded_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        request_headers.setdefault("content-type", "application/json")
+    try:
+        connection.request(method, path, body=encoded_body, headers=request_headers)
+        response = connection.getresponse()
+        response_body = response.read()
+        response_headers = {name.lower(): value for name, value in response.getheaders()}
+        return HTTPResult(response.status, response_headers, response_body)
+    finally:
+        connection.close()
+
+
+def wait_for_http_ready(
+    child: CLIProcess,
+    port: int,
+    *,
+    timeout: float = _READINESS_TIMEOUT_SECONDS,
+) -> None:
+    """Poll an exact product discovery exchange until the launched child is ready."""
+
+    request_id = f"readiness-{uuid.uuid4().hex}"
+    request = modern_request("server/discover", request_id=request_id)
+    headers = modern_headers("server/discover")
+    deadline = time.monotonic() + timeout
+    last_observation = "no response"
+    while time.monotonic() < deadline:
+        if child.process.poll() is not None:
+            raise AssertionError(f"HTTP CLI exited during readiness with code {child.process.returncode}")
+        try:
+            response = http_request(
+                port,
+                "POST",
+                "/mcp",
+                body=request,
+                headers=headers,
+            )
+        except (OSError, http.client.HTTPException) as exc:
+            last_observation = repr(exc)
+        else:
+            content_type = response.headers.get("content-type", "").partition(";")[0].strip().lower()
+            if response.status != 200 or content_type != "application/json":
+                last_observation = f"status={response.status}, content-type={content_type!r}"
+            else:
+                try:
+                    payload = response.json_object()
+                except (ValueError, AssertionError) as exc:
+                    last_observation = f"invalid JSON-RPC body: {exc}"
+                else:
+                    result = payload.get("result")
+                    meta = result.get("_meta") if isinstance(result, Mapping) else None
+                    server_info = meta.get("io.modelcontextprotocol/serverInfo") if isinstance(meta, Mapping) else None
+                    is_product_discovery = (
+                        payload.get("jsonrpc") == "2.0"
+                        and payload.get("id") == request_id
+                        and "method" not in payload
+                        and ("result" in payload, "error" in payload) == (True, False)
+                        and isinstance(result, Mapping)
+                        and result.get("supportedVersions") == [MCP_PROTOCOL_VERSION]
+                        and result.get("capabilities") == {"tools": {"listChanged": False}}
+                        and isinstance(server_info, Mapping)
+                        and server_info.get("name") == "prefab-sentinel"
+                    )
+                    if is_product_discovery:
+                        if child.process.poll() is not None:
+                            raise AssertionError(
+                                f"HTTP CLI exited after readiness with code {child.process.returncode}"
+                            )
+                        return
+                    last_observation = f"unrecognized discovery response: {payload!r}"
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(min(0.05, remaining))
+    raise AssertionError(f"HTTP CLI did not become ready before timeout; last observation: {last_observation}")
+
+
+def assert_jsonrpc_result(
+    test: unittest.TestCase,
+    payload: Mapping[str, Any],
+    *,
+    request_id: int | str,
+) -> dict[str, Any]:
+    """Pin the JSON-RPC 2.0 success response envelope."""
+
+    test.assertEqual("2.0", payload.get("jsonrpc"))
+    test.assertEqual(request_id, payload.get("id"))
+    test.assertNotIn("method", payload)
+    test.assertEqual((True, False), ("result" in payload, "error" in payload))
+    result = payload["result"]
+    test.assertIsInstance(result, dict)
+    return cast(dict[str, Any], result)
+
+
+def assert_jsonrpc_error(
+    test: unittest.TestCase,
+    payload: Mapping[str, Any],
+    *,
+    request_id: int | str,
+    code: int,
+    message: str,
+) -> dict[str, Any]:
+    """Pin the JSON-RPC 2.0 error response envelope."""
+
+    test.assertEqual("2.0", payload.get("jsonrpc"))
+    test.assertEqual(request_id, payload.get("id"))
+    test.assertNotIn("method", payload)
+    test.assertEqual((False, True), ("result" in payload, "error" in payload))
+    error = payload["error"]
+    test.assertIsInstance(error, dict)
+    typed_error = cast(dict[str, Any], error)
+    test.assertEqual(code, typed_error.get("code"))
+    test.assertEqual(message, typed_error.get("message"))
+    return typed_error
+
+
+def modern_meta(version: str = MCP_PROTOCOL_VERSION) -> dict[str, object]:
+    return {
+        "io.modelcontextprotocol/protocolVersion": version,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "transport-tests",
+            "version": "1",
+        },
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+
+
+def modern_request(
+    method: str,
+    *,
+    request_id: int | str | None = 1,
+    version: str = MCP_PROTOCOL_VERSION,
+    params: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    request_params = {"_meta": modern_meta(version), **dict(params or {})}
+    request: dict[str, object] = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": request_params,
+    }
+    if request_id is not None:
+        request["id"] = request_id
+    return request
+
+
+def modern_headers(
+    method: str,
+    *,
+    version: str = MCP_PROTOCOL_VERSION,
+    name: str | None = None,
+    extra: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    headers = {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+        "mcp-protocol-version": version,
+        "mcp-method": method,
+    }
+    if name is not None:
+        headers["mcp-name"] = name
+    if extra is not None:
+        headers.update(extra)
+    return headers

--- a/tests/fixtures/mcp_v1_tool_schemas.json
+++ b/tests/fixtures/mcp_v1_tool_schemas.json
@@ -1,0 +1,4097 @@
+{
+  "_provenance": {
+    "canonicalization": {
+      "comparison": "Materialize missing type=object only on schema nodes that contain properties; no other structural normalization.",
+      "export": "Pydantic JSON serialization converts non-finite numeric schema defaults to JSON null."
+    },
+    "export_api": "create_server().list_tools()",
+    "mcp_sdk_version": "1.26.0",
+    "prefab_sentinel_version": "0.8.9"
+  },
+  "tools": [
+    {
+      "inputSchema": {
+        "properties": {
+          "project_root": {
+            "default": "",
+            "title": "Project Root",
+            "type": "string"
+          },
+          "scope": {
+            "title": "Scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope"
+        ],
+        "title": "activate_projectArguments",
+        "type": "object"
+      },
+      "name": "activate_project",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "activate_projectDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "symbol_path": {
+            "title": "Symbol Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "symbol_path",
+          "component_type"
+        ],
+        "title": "add_componentArguments",
+        "type": "object"
+      },
+      "name": "add_component",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "add_componentDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "scope": {
+            "title": "Scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope"
+        ],
+        "title": "check_field_coverageArguments",
+        "type": "object"
+      },
+      "name": "check_field_coverage",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "check_field_coverageDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "dest_path": {
+            "title": "Dest Path",
+            "type": "string"
+          },
+          "source_path": {
+            "title": "Source Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_path",
+          "dest_path"
+        ],
+        "title": "copy_assetArguments",
+        "type": "object"
+      },
+      "name": "copy_asset",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "copy_assetDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "dst_asset_path": {
+            "title": "Dst Asset Path",
+            "type": "string"
+          },
+          "dst_symbol_path": {
+            "title": "Dst Symbol Path",
+            "type": "string"
+          },
+          "fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Fields"
+          },
+          "src_asset_path": {
+            "title": "Src Asset Path",
+            "type": "string"
+          },
+          "src_symbol_path": {
+            "title": "Src Symbol Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "src_asset_path",
+          "src_symbol_path",
+          "dst_asset_path",
+          "dst_symbol_path"
+        ],
+        "title": "copy_component_fieldsArguments",
+        "type": "object"
+      },
+      "name": "copy_component_fields",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "copy_component_fieldsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "dry_run": {
+            "default": true,
+            "title": "Dry Run",
+            "type": "boolean"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scope"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "delete_assetArguments",
+        "type": "object"
+      },
+      "name": "delete_asset",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "delete_assetDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_paths": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Asset Paths",
+            "type": "array"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "dry_run": {
+            "default": true,
+            "title": "Dry Run",
+            "type": "boolean"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scope"
+          }
+        },
+        "required": [
+          "asset_paths"
+        ],
+        "title": "delete_assetsArguments",
+        "type": "object"
+      },
+      "name": "delete_assets",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "delete_assetsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "target_dir": {
+            "default": "",
+            "title": "Target Dir",
+            "type": "string"
+          }
+        },
+        "title": "deploy_bridgeArguments",
+        "type": "object"
+      },
+      "name": "deploy_bridge",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "deploy_bridgeDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "component_filter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Component Filter"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "diff_unity_symbolsArguments",
+        "type": "object"
+      },
+      "name": "diff_unity_symbols",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "diff_unity_symbolsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "properties": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Properties"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "component_type"
+        ],
+        "title": "editor_add_componentArguments",
+        "type": "object"
+      },
+      "name": "editor_add_component",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_add_componentDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "fields_json": {
+            "default": "",
+            "title": "Fields Json",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "type_full_name": {
+            "title": "Type Full Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "type_full_name"
+        ],
+        "title": "editor_add_udonsharp_componentArguments",
+        "type": "object"
+      },
+      "name": "editor_add_udonsharp_component",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_add_udonsharp_componentDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "target_hierarchy_path": {
+            "title": "Target Hierarchy Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "target_hierarchy_path"
+        ],
+        "title": "_editor_apply_animation_clipArguments",
+        "type": "object"
+      },
+      "name": "editor_apply_animation_clip",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_apply_animation_clipDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "operations": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Operations",
+            "type": "array"
+          }
+        },
+        "required": [
+          "operations"
+        ],
+        "title": "editor_batch_add_componentArguments",
+        "type": "object"
+      },
+      "name": "editor_batch_add_component",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_batch_add_componentDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "objects": {
+            "items": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            "title": "Objects",
+            "type": "array"
+          }
+        },
+        "required": [
+          "objects"
+        ],
+        "title": "editor_batch_createArguments",
+        "type": "object"
+      },
+      "name": "editor_batch_create",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_batch_createDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "shapes": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Shapes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "shapes"
+        ],
+        "title": "editor_batch_set_blend_shapeArguments",
+        "type": "object"
+      },
+      "name": "editor_batch_set_blend_shape",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_batch_set_blend_shapeDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "default": "",
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "material_asset_guid": {
+            "default": "",
+            "title": "Material Asset Guid",
+            "type": "string"
+          },
+          "material_asset_path": {
+            "default": "",
+            "title": "Material Asset Path",
+            "type": "string"
+          },
+          "material_index": {
+            "default": -1,
+            "title": "Material Index",
+            "type": "integer"
+          },
+          "properties": {
+            "items": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "items": {},
+                    "type": "array"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            "title": "Properties",
+            "type": "array"
+          }
+        },
+        "required": [
+          "properties"
+        ],
+        "title": "editor_batch_set_material_propertyArguments",
+        "type": "object"
+      },
+      "name": "editor_batch_set_material_property",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_batch_set_material_propertyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "operations": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Operations",
+            "type": "array"
+          }
+        },
+        "required": [
+          "operations"
+        ],
+        "title": "editor_batch_set_propertyArguments",
+        "type": "object"
+      },
+      "name": "editor_batch_set_property",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_batch_set_propertyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "save": {
+            "default": true,
+            "title": "Save",
+            "type": "boolean"
+          }
+        },
+        "title": "_editor_close_prefabArguments",
+        "type": "object"
+      },
+      "name": "editor_close_prefab",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_close_prefabDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "classification_filter": {
+            "default": "all",
+            "title": "Classification Filter",
+            "type": "string"
+          },
+          "cursor": {
+            "default": "",
+            "title": "Cursor",
+            "type": "string"
+          },
+          "log_type_filter": {
+            "default": "all",
+            "title": "Log Type Filter",
+            "type": "string"
+          },
+          "max_entries": {
+            "default": 200,
+            "title": "Max Entries",
+            "type": "integer"
+          },
+          "order": {
+            "default": "newest_first",
+            "title": "Order",
+            "type": "string"
+          },
+          "phase_filter": {
+            "default": "all",
+            "title": "Phase Filter",
+            "type": "string"
+          },
+          "since_request_id": {
+            "default": "",
+            "title": "Since Request Id",
+            "type": "string"
+          },
+          "since_seconds": {
+            "default": 60.0,
+            "title": "Since Seconds",
+            "type": "number"
+          },
+          "since_sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Since Sequence"
+          }
+        },
+        "title": "_editor_consoleArguments",
+        "type": "object"
+      },
+      "name": "editor_console",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_consoleDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "curves": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Curves",
+            "type": "array"
+          }
+        },
+        "required": [
+          "asset_path",
+          "curves"
+        ],
+        "title": "_editor_create_animation_clipArguments",
+        "type": "object"
+      },
+      "name": "editor_create_animation_clip",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_create_animation_clipDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "parent_hierarchy_path": {
+            "default": "",
+            "title": "Parent Hierarchy Path",
+            "type": "string"
+          },
+          "position": {
+            "default": "",
+            "title": "Position",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "editor_create_emptyArguments",
+        "type": "object"
+      },
+      "name": "editor_create_empty",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_create_emptyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path"
+          },
+          "asset_type": {
+            "title": "Asset Type"
+          },
+          "change_reason": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "title": "Confirm"
+          },
+          "out_report": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Out Report"
+          },
+          "parameters": {
+            "title": "Parameters"
+          },
+          "project_root": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Project Root"
+          }
+        },
+        "required": [
+          "asset_type",
+          "asset_path",
+          "parameters",
+          "confirm"
+        ],
+        "title": "editor_create_generated_assetArguments",
+        "type": "object"
+      },
+      "name": "editor_create_generated_asset",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_create_generated_assetDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "default": "",
+            "title": "Name",
+            "type": "string"
+          },
+          "parent_hierarchy_path": {
+            "default": "",
+            "title": "Parent Hierarchy Path",
+            "type": "string"
+          },
+          "position": {
+            "default": "",
+            "title": "Position",
+            "type": "string"
+          },
+          "primitive_type": {
+            "title": "Primitive Type",
+            "type": "string"
+          },
+          "rotation": {
+            "default": "",
+            "title": "Rotation",
+            "type": "string"
+          },
+          "scale": {
+            "default": "",
+            "title": "Scale",
+            "type": "string"
+          }
+        },
+        "required": [
+          "primitive_type"
+        ],
+        "title": "editor_create_primitiveArguments",
+        "type": "object"
+      },
+      "name": "editor_create_primitive",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_create_primitiveDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "editor_create_sceneArguments",
+        "type": "object"
+      },
+      "name": "editor_create_scene",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_create_sceneDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "output_asset_path": {
+            "default": "",
+            "title": "Output Asset Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "editor_create_udon_program_assetArguments",
+        "type": "object"
+      },
+      "name": "editor_create_udon_program_asset",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_create_udon_program_assetDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "parent_hierarchy_path": {
+            "default": "",
+            "title": "Parent Hierarchy Path",
+            "type": "string"
+          },
+          "properties": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Properties"
+          },
+          "rect": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Rect"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "editor_create_ui_elementArguments",
+        "type": "object"
+      },
+      "name": "editor_create_ui_element",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_create_ui_elementDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "editor_deleteArguments",
+        "type": "object"
+      },
+      "name": "editor_delete",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_deleteDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "assume_compiled": {
+            "default": false,
+            "title": "Assume Compiled",
+            "type": "boolean"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "menu_path": {
+            "title": "Menu Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "menu_path"
+        ],
+        "title": "editor_execute_menu_itemArguments",
+        "type": "object"
+      },
+      "name": "editor_execute_menu_item",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_execute_menu_itemDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "material_asset_guid": {
+            "default": "",
+            "title": "Material Asset Guid",
+            "type": "string"
+          },
+          "material_asset_path": {
+            "default": "",
+            "title": "Material Asset Path",
+            "type": "string"
+          }
+        },
+        "title": "editor_find_renderers_by_materialArguments",
+        "type": "object"
+      },
+      "name": "editor_find_renderers_by_material",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_find_renderers_by_materialDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {},
+        "title": "_editor_force_scene_view_refreshArguments",
+        "type": "object"
+      },
+      "name": "editor_force_scene_view_refresh",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_force_scene_view_refreshDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "bounds_policy": {
+            "default": "all_visible_renderers",
+            "title": "Bounds Policy",
+            "type": "string"
+          },
+          "zoom": {
+            "default": 0.0,
+            "title": "Zoom",
+            "type": "number"
+          }
+        },
+        "title": "editor_frameArguments",
+        "type": "object"
+      },
+      "name": "editor_frame",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_frameDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "filter": {
+            "default": "",
+            "title": "Filter",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "limit": {
+            "default": 200,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "default": 0,
+            "title": "Offset",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "_editor_get_blend_shapesArguments",
+        "type": "object"
+      },
+      "name": "editor_get_blend_shapes",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_get_blend_shapesDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "include_children": {
+            "default": true,
+            "title": "Include Children",
+            "type": "boolean"
+          },
+          "source": {
+            "default": "auto",
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "editor_get_boundsArguments",
+        "type": "object"
+      },
+      "name": "editor_get_bounds",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_get_boundsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {},
+        "title": "editor_get_cameraArguments",
+        "type": "object"
+      },
+      "name": "editor_get_camera",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_get_cameraDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "material_index": {
+            "title": "Material Index",
+            "type": "integer"
+          },
+          "property_name": {
+            "default": "",
+            "title": "Property Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "material_index"
+        ],
+        "title": "editor_get_material_propertyArguments",
+        "type": "object"
+      },
+      "name": "editor_get_material_property",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_get_material_propertyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "editor_get_transformArguments",
+        "type": "object"
+      },
+      "name": "editor_get_transform",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_get_transformDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "_editor_inspect_animation_clipArguments",
+        "type": "object"
+      },
+      "name": "editor_inspect_animation_clip",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_inspect_animation_clipDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "default": "",
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "position": {
+            "default": "",
+            "title": "Position",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "editor_instantiateArguments",
+        "type": "object"
+      },
+      "name": "editor_instantiate",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_instantiateDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "depth": {
+            "default": 1,
+            "title": "Depth",
+            "type": "integer"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "editor_list_childrenArguments",
+        "type": "object"
+      },
+      "name": "editor_list_children",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_list_childrenDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "editor_list_materialsArguments",
+        "type": "object"
+      },
+      "name": "editor_list_materials",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_list_materialsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "prefix": {
+            "default": "",
+            "title": "Prefix",
+            "type": "string"
+          }
+        },
+        "title": "editor_list_menu_itemsArguments",
+        "type": "object"
+      },
+      "name": "editor_list_menu_items",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_list_menu_itemsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {},
+        "title": "editor_list_rootsArguments",
+        "type": "object"
+      },
+      "name": "editor_list_roots",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_list_rootsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "a": {
+            "title": "A",
+            "type": "string"
+          },
+          "b": {
+            "title": "B",
+            "type": "string"
+          },
+          "bounds_source": {
+            "default": "auto",
+            "title": "Bounds Source",
+            "type": "string"
+          },
+          "mode": {
+            "default": "pivot",
+            "title": "Mode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
+        "title": "editor_measure_distanceArguments",
+        "type": "object"
+      },
+      "name": "editor_measure_distance",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_measure_distanceDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "title": "Confirm"
+          },
+          "destination_asset_path": {
+            "title": "Destination Asset Path"
+          },
+          "out_report": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Out Report"
+          },
+          "project_root": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Project Root"
+          },
+          "source_asset_path": {
+            "title": "Source Asset Path"
+          }
+        },
+        "required": [
+          "source_asset_path",
+          "destination_asset_path",
+          "confirm"
+        ],
+        "title": "editor_move_assetArguments",
+        "type": "object"
+      },
+      "name": "editor_move_asset",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_move_assetDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "_editor_open_prefabArguments",
+        "type": "object"
+      },
+      "name": "editor_open_prefab",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_open_prefabDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "mode": {
+            "default": "single",
+            "title": "Mode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "editor_open_sceneArguments",
+        "type": "object"
+      },
+      "name": "editor_open_scene",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_open_sceneDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "timeout_sec": {
+            "default": 60.0,
+            "title": "Timeout Sec",
+            "type": "number"
+          }
+        },
+        "title": "_editor_recompileArguments",
+        "type": "object"
+      },
+      "name": "editor_recompile",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_recompileDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "class_name": {
+            "default": "",
+            "title": "Class Name",
+            "type": "string"
+          },
+          "member_name": {
+            "default": "",
+            "title": "Member Name",
+            "type": "string"
+          },
+          "query": {
+            "default": "",
+            "title": "Query",
+            "type": "string"
+          },
+          "scope": {
+            "default": "all",
+            "title": "Scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "title": "editor_reflectArguments",
+        "type": "object"
+      },
+      "name": "editor_reflect",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_reflectDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {},
+        "title": "_editor_refreshArguments",
+        "type": "object"
+      },
+      "name": "editor_refresh",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_refreshDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Index"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "component_type"
+        ],
+        "title": "editor_remove_componentArguments",
+        "type": "object"
+      },
+      "name": "editor_remove_component",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_remove_componentDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "new_name": {
+            "title": "New Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "new_name"
+        ],
+        "title": "editor_renameArguments",
+        "type": "object"
+      },
+      "name": "editor_rename",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_renameDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "compile_timeout_ms": {
+            "default": 15000,
+            "title": "Compile Timeout Ms",
+            "type": "integer"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "_editor_run_scriptArguments",
+        "type": "object"
+      },
+      "name": "editor_run_script",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_run_scriptDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "cleanup_on_timeout": {
+            "default": false,
+            "title": "Cleanup On Timeout",
+            "type": "boolean"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "request_id"
+        ],
+        "title": "_editor_run_script_pollArguments",
+        "type": "object"
+      },
+      "name": "editor_run_script_poll",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_run_script_pollDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "compile_timeout_ms": {
+            "default": 15000,
+            "title": "Compile Timeout Ms",
+            "type": "integer"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "_editor_run_script_submitArguments",
+        "type": "object"
+      },
+      "name": "editor_run_script_submit",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_run_script_submitDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "timeout_sec": {
+            "default": 300,
+            "title": "Timeout Sec",
+            "type": "integer"
+          }
+        },
+        "title": "editor_run_testsArguments",
+        "type": "object"
+      },
+      "name": "editor_run_tests",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_run_testsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "force_original": {
+            "default": false,
+            "title": "Force Original",
+            "type": "boolean"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "protect_components": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Protect Components",
+            "type": "array"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "asset_path",
+          "protect_components"
+        ],
+        "title": "editor_safe_save_prefabArguments",
+        "type": "object"
+      },
+      "name": "editor_safe_save_prefab",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_safe_save_prefabDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "default": "",
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          }
+        },
+        "title": "editor_save_sceneArguments",
+        "type": "object"
+      },
+      "name": "editor_save_scene",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_save_sceneDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "angle": {
+            "default": "",
+            "title": "Angle",
+            "type": "string"
+          },
+          "bounds_policy": {
+            "default": "all_visible_renderers",
+            "title": "Bounds Policy",
+            "type": "string"
+          },
+          "crop_roi": {
+            "default": "",
+            "title": "Crop Roi",
+            "type": "string"
+          },
+          "fit_mode": {
+            "default": "max_axis",
+            "title": "Fit Mode",
+            "type": "string"
+          },
+          "height": {
+            "default": 0,
+            "title": "Height",
+            "type": "integer"
+          },
+          "padding_ratio": {
+            "default": 0.1,
+            "title": "Padding Ratio",
+            "type": "number"
+          },
+          "projection": {
+            "default": "auto",
+            "title": "Projection",
+            "type": "string"
+          },
+          "refresh": {
+            "default": true,
+            "title": "Refresh",
+            "type": "boolean"
+          },
+          "target": {
+            "default": "",
+            "title": "Target",
+            "type": "string"
+          },
+          "target_mode": {
+            "default": "auto",
+            "title": "Target Mode",
+            "type": "string"
+          },
+          "view": {
+            "default": "scene",
+            "title": "View",
+            "type": "string"
+          },
+          "width": {
+            "default": 0,
+            "title": "Width",
+            "type": "integer"
+          }
+        },
+        "title": "_editor_screenshotArguments",
+        "type": "object"
+      },
+      "name": "editor_screenshot",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "_editor_screenshotDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "prefab_asset_path": {
+            "default": "",
+            "title": "Prefab Asset Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "editor_selectArguments",
+        "type": "object"
+      },
+      "name": "editor_select",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_selectDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "cap": {
+            "default": 50,
+            "title": "Cap",
+            "type": "integer"
+          },
+          "component_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Component Index"
+          },
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Cursor"
+          },
+          "depth": {
+            "default": 1,
+            "title": "Depth",
+            "type": "integer"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "root_property_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Root Property Path"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "component_type"
+        ],
+        "title": "editor_serialized_property_listArguments",
+        "type": "object"
+      },
+      "name": "editor_serialized_property_list",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_serialized_property_listDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "component_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Component Index"
+          },
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "property_path": {
+            "title": "Property Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "component_type",
+          "property_path"
+        ],
+        "title": "editor_serialized_property_readArguments",
+        "type": "object"
+      },
+      "name": "editor_serialized_property_read",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_serialized_property_readDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "array_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Array Size"
+          },
+          "bool_value": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Bool Value"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "component_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Component Index"
+          },
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "enum_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Enum Index"
+          },
+          "enum_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Enum Name"
+          },
+          "float_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Float Value"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "int_value": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Int Value"
+          },
+          "long_value": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Long Value"
+          },
+          "object_reference_asset_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Object Reference Asset Path"
+          },
+          "object_reference_hierarchy_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Object Reference Hierarchy Path"
+          },
+          "object_reference_null": {
+            "default": false,
+            "title": "Object Reference Null",
+            "type": "boolean"
+          },
+          "property_path": {
+            "title": "Property Path",
+            "type": "string"
+          },
+          "string_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "String Value"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "component_type",
+          "property_path"
+        ],
+        "title": "editor_serialized_property_writeArguments",
+        "type": "object"
+      },
+      "name": "editor_serialized_property_write",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_serialized_property_writeDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "weight": {
+            "title": "Weight",
+            "type": "number"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "name",
+          "weight"
+        ],
+        "title": "editor_set_blend_shapeArguments",
+        "type": "object"
+      },
+      "name": "editor_set_blend_shape",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_blend_shapeDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "look_at": {
+            "default": "",
+            "title": "Look At",
+            "type": "string"
+          },
+          "orthographic": {
+            "default": -1,
+            "title": "Orthographic",
+            "type": "integer"
+          },
+          "pitch": {
+            "default": null,
+            "title": "Pitch",
+            "type": "number"
+          },
+          "pivot": {
+            "default": "",
+            "title": "Pivot",
+            "type": "string"
+          },
+          "position": {
+            "default": "",
+            "title": "Position",
+            "type": "string"
+          },
+          "reset_to_defaults": {
+            "default": false,
+            "title": "Reset To Defaults",
+            "type": "boolean"
+          },
+          "size": {
+            "default": -1.0,
+            "title": "Size",
+            "type": "number"
+          },
+          "yaw": {
+            "default": null,
+            "title": "Yaw",
+            "type": "number"
+          }
+        },
+        "title": "editor_set_cameraArguments",
+        "type": "object"
+      },
+      "name": "editor_set_camera",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_cameraDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "material_asset_guid": {
+            "default": "",
+            "title": "Material Asset Guid",
+            "type": "string"
+          },
+          "material_asset_path": {
+            "default": "",
+            "title": "Material Asset Path",
+            "type": "string"
+          },
+          "material_index": {
+            "title": "Material Index",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "material_index"
+        ],
+        "title": "editor_set_materialArguments",
+        "type": "object"
+      },
+      "name": "editor_set_material",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_materialDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "material_index": {
+            "title": "Material Index",
+            "type": "integer"
+          },
+          "property_name": {
+            "title": "Property Name",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "material_index",
+          "property_name",
+          "value"
+        ],
+        "title": "editor_set_material_propertyArguments",
+        "type": "object"
+      },
+      "name": "editor_set_material_property",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_material_propertyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "parent_hierarchy_path": {
+            "default": "",
+            "title": "Parent Hierarchy Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path"
+        ],
+        "title": "editor_set_parentArguments",
+        "type": "object"
+      },
+      "name": "editor_set_parent",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_parentDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "properties": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Properties",
+            "type": "array"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "component_type",
+          "properties"
+        ],
+        "title": "editor_set_propertiesArguments",
+        "type": "object"
+      },
+      "name": "editor_set_properties",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_propertiesDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "object_reference": {
+            "default": "",
+            "title": "Object Reference",
+            "type": "string"
+          },
+          "property_name": {
+            "title": "Property Name",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Value"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "component_type",
+          "property_name"
+        ],
+        "title": "editor_set_propertyArguments",
+        "type": "object"
+      },
+      "name": "editor_set_property",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_propertyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "expected_length": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Expected Length"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "object_reference": {
+            "default": "",
+            "title": "Object Reference",
+            "type": "string"
+          },
+          "property_name": {
+            "title": "Property Name",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Value"
+          },
+          "values_json": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Values Json"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "property_name"
+        ],
+        "title": "editor_set_udonsharp_fieldArguments",
+        "type": "object"
+      },
+      "name": "editor_set_udonsharp_field",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_set_udonsharp_fieldDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "arg": {
+            "title": "Arg",
+            "type": "string"
+          },
+          "change_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "hierarchy_path": {
+            "title": "Hierarchy Path",
+            "type": "string"
+          },
+          "method": {
+            "title": "Method",
+            "type": "string"
+          },
+          "property_name": {
+            "title": "Property Name",
+            "type": "string"
+          },
+          "target_hierarchy_path": {
+            "title": "Target Hierarchy Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hierarchy_path",
+          "property_name",
+          "target_hierarchy_path",
+          "method",
+          "arg"
+        ],
+        "title": "editor_wire_persistent_listenerArguments",
+        "type": "object"
+      },
+      "name": "editor_wire_persistent_listener",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "editor_wire_persistent_listenerDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_or_guid": {
+            "title": "Asset Or Guid",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 100,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scope"
+          }
+        },
+        "required": [
+          "asset_or_guid"
+        ],
+        "title": "find_referencing_assetsArguments",
+        "type": "object"
+      },
+      "name": "find_referencing_assets",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "find_referencing_assetsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "depth": {
+            "default": 0,
+            "title": "Depth",
+            "type": "integer"
+          },
+          "expand_nested": {
+            "default": false,
+            "title": "Expand Nested",
+            "type": "boolean"
+          },
+          "include_fields": {
+            "default": false,
+            "title": "Include Fields",
+            "type": "boolean"
+          },
+          "show_origin": {
+            "default": false,
+            "title": "Show Origin",
+            "type": "boolean"
+          },
+          "symbol_path": {
+            "title": "Symbol Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "symbol_path"
+        ],
+        "title": "find_unity_symbolArguments",
+        "type": "object"
+      },
+      "name": "find_unity_symbol",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "find_unity_symbolDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {},
+        "title": "get_project_statusArguments",
+        "type": "object"
+      },
+      "name": "get_project_status",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "get_project_statusDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "depth": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Depth"
+          },
+          "detail": {
+            "default": "full",
+            "enum": [
+              "summary",
+              "fields",
+              "full"
+            ],
+            "title": "Detail",
+            "type": "string"
+          },
+          "expand_nested": {
+            "default": false,
+            "title": "Expand Nested",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "get_unity_symbolsArguments",
+        "type": "object"
+      },
+      "name": "get_unity_symbols",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "get_unity_symbolsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "depth": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Depth"
+          },
+          "expand_monobehaviour": {
+            "default": false,
+            "title": "Expand Monobehaviour",
+            "type": "boolean"
+          },
+          "expand_prefab_instances": {
+            "default": false,
+            "title": "Expand Prefab Instances",
+            "type": "boolean"
+          },
+          "show_components": {
+            "default": true,
+            "title": "Show Components",
+            "type": "boolean"
+          },
+          "timeout_sec": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Timeout Sec"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "inspect_hierarchyArguments",
+        "type": "object"
+      },
+      "name": "inspect_hierarchy",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_hierarchyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "mode": {
+            "default": "full",
+            "title": "Mode",
+            "type": "string"
+          },
+          "property_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Property Names"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "inspect_material_assetArguments",
+        "type": "object"
+      },
+      "name": "inspect_material_asset",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_material_assetDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "inspect_materialsArguments",
+        "type": "object"
+      },
+      "name": "inspect_materials",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_materialsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "include_override_origin": {
+            "default": false,
+            "title": "Include Override Origin",
+            "type": "boolean"
+          },
+          "symbol_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Symbol Path"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "inspect_serialized_surfaceArguments",
+        "type": "object"
+      },
+      "name": "inspect_serialized_surface",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_serialized_surfaceDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "symbol_path": {
+            "title": "Symbol Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "symbol_path"
+        ],
+        "title": "inspect_transform_effective_valuesArguments",
+        "type": "object"
+      },
+      "name": "inspect_transform_effective_values",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_transform_effective_valuesDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "component_type": {
+            "title": "Component Type",
+            "type": "string"
+          },
+          "property_name": {
+            "title": "Property Name",
+            "type": "string"
+          },
+          "symbol_path": {
+            "title": "Symbol Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "symbol_path",
+          "component_type",
+          "property_name"
+        ],
+        "title": "inspect_unity_event_listenersArguments",
+        "type": "object"
+      },
+      "name": "inspect_unity_event_listeners",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_unity_event_listenersDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "component_filter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Component Filter"
+          },
+          "show_origin": {
+            "default": false,
+            "title": "Show Origin",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "inspect_variantArguments",
+        "type": "object"
+      },
+      "name": "inspect_variant",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_variantDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "cursor": {
+            "default": "",
+            "title": "Cursor",
+            "type": "string"
+          },
+          "include_out_of_scope_diagnostics": {
+            "default": false,
+            "title": "Include Out Of Scope Diagnostics",
+            "type": "boolean"
+          },
+          "page_size": {
+            "default": 50,
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "script_filter": {
+            "default": "",
+            "title": "Script Filter",
+            "type": "string"
+          },
+          "summary_only": {
+            "default": false,
+            "title": "Summary Only",
+            "type": "boolean"
+          },
+          "timeout_sec": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Timeout Sec"
+          },
+          "udon_only": {
+            "default": false,
+            "title": "Udon Only",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "inspect_wiringArguments",
+        "type": "object"
+      },
+      "name": "inspect_wiring",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_wiringDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "include_override_origin": {
+            "default": false,
+            "title": "Include Override Origin",
+            "type": "boolean"
+          },
+          "symbol_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Symbol Path"
+          },
+          "view_name": {
+            "title": "View Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "view_name"
+        ],
+        "title": "inspect_with_profileArguments",
+        "type": "object"
+      },
+      "name": "inspect_with_profile",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "inspect_with_profileDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "include_inherited": {
+            "default": false,
+            "title": "Include Inherited",
+            "type": "boolean"
+          },
+          "script_or_guid": {
+            "title": "Script Or Guid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "script_or_guid"
+        ],
+        "title": "list_serialized_fieldsArguments",
+        "type": "object"
+      },
+      "name": "list_serialized_fields",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "list_serialized_fieldsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "out_report": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Out Report"
+          },
+          "plan": {
+            "title": "Plan"
+          },
+          "runtime_allow_warnings": {
+            "default": false,
+            "title": "Runtime Allow Warnings",
+            "type": "boolean"
+          },
+          "runtime_log_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Runtime Log File"
+          },
+          "runtime_max_diagnostics": {
+            "default": 200,
+            "title": "Runtime Max Diagnostics",
+            "type": "integer"
+          },
+          "runtime_profile": {
+            "default": "default",
+            "title": "Runtime Profile",
+            "type": "string"
+          },
+          "runtime_scene": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Runtime Scene"
+          },
+          "runtime_since_timestamp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Runtime Since Timestamp"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scope"
+          }
+        },
+        "required": [
+          "plan"
+        ],
+        "title": "patch_applyArguments",
+        "type": "object"
+      },
+      "name": "patch_apply",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "patch_applyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "symbol_path": {
+            "title": "Symbol Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "symbol_path"
+        ],
+        "title": "remove_componentArguments",
+        "type": "object"
+      },
+      "name": "remove_component",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "remove_componentDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "new_name": {
+            "title": "New Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "new_name"
+        ],
+        "title": "rename_assetArguments",
+        "type": "object"
+      },
+      "name": "rename_asset",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "rename_assetDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "property_path": {
+            "title": "Property Path",
+            "type": "string"
+          },
+          "target_file_id": {
+            "title": "Target File Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "target_file_id",
+          "property_path"
+        ],
+        "title": "revert_overridesArguments",
+        "type": "object"
+      },
+      "name": "revert_overrides",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "revert_overridesDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "property_name": {
+            "title": "Property Name",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "property_name",
+          "value"
+        ],
+        "title": "set_material_propertyArguments",
+        "type": "object"
+      },
+      "name": "set_material_property",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "set_material_propertyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "dry_run": {
+            "default": false,
+            "title": "Dry Run",
+            "type": "boolean"
+          },
+          "out_report": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Out Report"
+          },
+          "properties": {
+            "additionalProperties": true,
+            "title": "Properties",
+            "type": "object"
+          },
+          "symbol_path": {
+            "title": "Symbol Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path",
+          "symbol_path",
+          "properties"
+        ],
+        "title": "set_propertiesArguments",
+        "type": "object"
+      },
+      "name": "set_properties",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "set_propertiesDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "property_path": {
+            "title": "Property Path",
+            "type": "string"
+          },
+          "symbol_path": {
+            "title": "Symbol Path",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value"
+          }
+        },
+        "required": [
+          "asset_path",
+          "symbol_path",
+          "property_path",
+          "value"
+        ],
+        "title": "set_propertyArguments",
+        "type": "object"
+      },
+      "name": "set_property",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "set_propertyDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "details": {
+            "default": false,
+            "title": "Details",
+            "type": "boolean"
+          },
+          "include_details": {
+            "default": false,
+            "title": "Include Details",
+            "type": "boolean"
+          },
+          "mode": {
+            "default": "preview",
+            "title": "Mode",
+            "type": "string"
+          },
+          "prune_resolved": {
+            "default": false,
+            "title": "Prune Resolved",
+            "type": "boolean"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "target": {
+            "title": "Target",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "target"
+        ],
+        "title": "update_diagnostics_baselineArguments",
+        "type": "object"
+      },
+      "name": "update_diagnostics_baseline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "update_diagnostics_baselineDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "default": "",
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "timeout_sec": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Timeout Sec"
+          }
+        },
+        "title": "validate_all_wiringArguments",
+        "type": "object"
+      },
+      "name": "validate_all_wiring",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "validate_all_wiringDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "new_name": {
+            "title": "New Name",
+            "type": "string"
+          },
+          "old_name": {
+            "title": "Old Name",
+            "type": "string"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scope"
+          },
+          "script_or_guid": {
+            "title": "Script Or Guid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "script_or_guid",
+          "old_name",
+          "new_name"
+        ],
+        "title": "validate_field_renameArguments",
+        "type": "object"
+      },
+      "name": "validate_field_rename",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "validate_field_renameDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "profile_path": {
+            "title": "Profile Path",
+            "type": "string"
+          },
+          "symbol_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Symbol Path"
+          }
+        },
+        "required": [
+          "profile_path",
+          "asset_path"
+        ],
+        "title": "validate_inspector_profileArguments",
+        "type": "object"
+      },
+      "name": "validate_inspector_profile",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "validate_inspector_profileDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "include_details": {
+            "default": false,
+            "title": "Include Details",
+            "type": "boolean"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scope"
+          },
+          "timeout_sec": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Timeout Sec"
+          }
+        },
+        "title": "validate_materialsArguments",
+        "type": "object"
+      },
+      "name": "validate_materials",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "validate_materialsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "details": {
+            "default": false,
+            "title": "Details",
+            "type": "boolean"
+          },
+          "ignore_asset_guids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Ignore Asset Guids"
+          },
+          "max_diagnostics": {
+            "default": 200,
+            "title": "Max Diagnostics",
+            "type": "integer"
+          },
+          "refresh_guid_index": {
+            "default": false,
+            "title": "Refresh Guid Index",
+            "type": "boolean"
+          },
+          "scope": {
+            "title": "Scope",
+            "type": "string"
+          },
+          "snapshot_diff": {
+            "default": "",
+            "title": "Snapshot Diff",
+            "type": "string"
+          },
+          "snapshot_save": {
+            "default": "",
+            "title": "Snapshot Save",
+            "type": "string"
+          },
+          "top_missing_breakdown": {
+            "default": false,
+            "title": "Top Missing Breakdown",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "scope"
+        ],
+        "title": "validate_refsArguments",
+        "type": "object"
+      },
+      "name": "validate_refs",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "validate_refsDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "allow_dirty_before_clientsim": {
+            "default": false,
+            "title": "Allow Dirty Before Clientsim",
+            "type": "boolean"
+          },
+          "allow_warnings": {
+            "default": false,
+            "title": "Allow Warnings",
+            "type": "boolean"
+          },
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "change_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Change Reason"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "log_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Log File"
+          },
+          "max_diagnostics": {
+            "default": 200,
+            "title": "Max Diagnostics",
+            "type": "integer"
+          },
+          "profile": {
+            "default": "compile_only",
+            "title": "Profile",
+            "type": "string"
+          },
+          "since_timestamp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Since Timestamp"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "validate_runtimeArguments",
+        "type": "object"
+      },
+      "name": "validate_runtime",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "validate_runtimeDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_path"
+        ],
+        "title": "validate_structureArguments",
+        "type": "object"
+      },
+      "name": "validate_structure",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "validate_structureDictOutput",
+        "type": "object"
+      }
+    },
+    {
+      "inputSchema": {
+        "properties": {
+          "asset_path": {
+            "title": "Asset Path",
+            "type": "string"
+          },
+          "blueprint_id": {
+            "title": "Blueprint Id",
+            "type": "string"
+          },
+          "change_reason": {
+            "default": "",
+            "title": "Change Reason",
+            "type": "string"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "platforms": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Platforms"
+          },
+          "release_status": {
+            "default": "",
+            "title": "Release Status",
+            "type": "string"
+          },
+          "tags": {
+            "default": "",
+            "title": "Tags",
+            "type": "string"
+          },
+          "target_type": {
+            "title": "Target Type",
+            "type": "string"
+          },
+          "timeout_sec": {
+            "default": 600,
+            "title": "Timeout Sec",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "target_type",
+          "asset_path",
+          "blueprint_id"
+        ],
+        "title": "vrcsdk_uploadArguments",
+        "type": "object"
+      },
+      "name": "vrcsdk_upload",
+      "outputSchema": {
+        "additionalProperties": true,
+        "title": "vrcsdk_uploadDictOutput",
+        "type": "object"
+      }
+    }
+  ]
+}

--- a/tests/test_editor_bridge.py
+++ b/tests/test_editor_bridge.py
@@ -562,7 +562,9 @@ class TestSendAction(unittest.TestCase):
                     },
                     "diagnostics": [],
                 }
-                resp_path.write_text(json.dumps(resp), encoding="utf-8")
+                tmp_resp_path = Path(str(resp_path) + ".tmp")
+                tmp_resp_path.write_text(json.dumps(resp), encoding="utf-8")
+                tmp_resp_path.rename(resp_path)
 
             with (
                 patch.dict(
@@ -638,7 +640,9 @@ class TestSendAction(unittest.TestCase):
                     },
                     "diagnostics": [],
                 }
-                resp_path.write_text(json.dumps(resp), encoding="utf-8")
+                tmp_resp_path = Path(str(resp_path) + ".tmp")
+                tmp_resp_path.write_text(json.dumps(resp), encoding="utf-8")
+                tmp_resp_path.rename(resp_path)
 
             with (
                 patch.dict(os.environ, {BRIDGE_WATCH_DIR_ENV: tmpdir}, clear=False),

--- a/tests/test_editor_bridge.py
+++ b/tests/test_editor_bridge.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import tempfile
@@ -1135,6 +1134,10 @@ class TestEditorSetCameraForwardsResetToDefaults(unittest.TestCase):
     def test_editor_set_camera_forwards_reset_to_defaults(self) -> None:
         from prefab_sentinel import mcp_tools_editor_view  # noqa: PLC0415
         from prefab_sentinel.mcp_server import create_server  # noqa: PLC0415
+        from tests._mcp_test_support import (  # noqa: PLC0415
+            call_tool_result,
+            structured_payload,
+        )
 
         with patch.object(mcp_tools_editor_view, "send_action") as send:
             send.return_value = {
@@ -1146,11 +1149,22 @@ class TestEditorSetCameraForwardsResetToDefaults(unittest.TestCase):
                 "diagnostics": [],
             }
             server = create_server()
-            asyncio.run(
-                server.call_tool(
-                    "editor_set_camera",
-                    {"reset_to_defaults": True},
-                )
+            result = call_tool_result(
+                server,
+                "editor_set_camera",
+                {"reset_to_defaults": True},
+            )
+            self.assertIs(result.is_error, False)
+            self.assertEqual(
+                {
+                    "success": True,
+                    "severity": "info",
+                    "code": "EDITOR_CTRL_SET_CAMERA_OK",
+                    "message": "ok",
+                    "data": {},
+                    "diagnostics": [],
+                },
+                structured_payload(result),
             )
         kwargs = send.call_args.kwargs
         self.assertEqual("set_camera", kwargs["action"])
@@ -1163,6 +1177,10 @@ class TestEditorConsoleForwardsClassificationFilter(unittest.TestCase):
     def test_editor_console_classification_filter_forwarded(self) -> None:
         from prefab_sentinel import mcp_tools_editor_view  # noqa: PLC0415
         from prefab_sentinel.mcp_server import create_server  # noqa: PLC0415
+        from tests._mcp_test_support import (  # noqa: PLC0415
+            call_tool_result,
+            structured_payload,
+        )
 
         with patch.object(mcp_tools_editor_view, "send_action") as send:
             send.return_value = {
@@ -1174,11 +1192,22 @@ class TestEditorConsoleForwardsClassificationFilter(unittest.TestCase):
                 "diagnostics": [],
             }
             server = create_server()
-            asyncio.run(
-                server.call_tool(
-                    "editor_console",
-                    {"classification_filter": "non_fatal"},
-                )
+            result = call_tool_result(
+                server,
+                "editor_console",
+                {"classification_filter": "non_fatal"},
+            )
+            self.assertIs(result.is_error, False)
+            self.assertEqual(
+                {
+                    "success": True,
+                    "severity": "info",
+                    "code": "EDITOR_CTRL_CONSOLE_OK",
+                    "message": "ok",
+                    "data": {"entries": []},
+                    "diagnostics": [],
+                },
+                structured_payload(result),
             )
         kwargs = send.call_args.kwargs
         self.assertEqual("capture_console_logs", kwargs["action"])

--- a/tests/test_editor_reflect.py
+++ b/tests/test_editor_reflect.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import patch
 
 from prefab_sentinel.mcp_server import create_server
-from tests.test_mcp_server import _run
+from tests._mcp_test_support import call_tool_result, structured_payload
 
 
 class TestEditorReflectValidation(unittest.TestCase):
@@ -19,15 +19,14 @@ class TestEditorReflectValidation(unittest.TestCase):
 
     def test_should_reject_unknown_action(self) -> None:
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(self.server.call_tool("editor_reflect", {"action": "bogus"}))
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "bogus"}))
         mock_send.assert_not_called()
         self.assertFalse(result["success"])
         self.assertEqual("EDITOR_REFLECT_UNKNOWN_ACTION", result["code"])
 
     def test_should_reject_invalid_scope(self) -> None:
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(
-                self.server.call_tool("editor_reflect", {"action": "search", "query": "Foo", "scope": "invalid"})
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "search", "query": "Foo", "scope": "invalid"})
             )
         mock_send.assert_not_called()
         self.assertFalse(result["success"])
@@ -35,22 +34,21 @@ class TestEditorReflectValidation(unittest.TestCase):
 
     def test_should_reject_search_without_query(self) -> None:
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(self.server.call_tool("editor_reflect", {"action": "search"}))
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "search"}))
         mock_send.assert_not_called()
         self.assertFalse(result["success"])
         self.assertEqual("EDITOR_REFLECT_MISSING_PARAM", result["code"])
 
     def test_should_reject_get_type_without_class_name(self) -> None:
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(self.server.call_tool("editor_reflect", {"action": "get_type"}))
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "get_type"}))
         mock_send.assert_not_called()
         self.assertFalse(result["success"])
         self.assertEqual("EDITOR_REFLECT_MISSING_PARAM", result["code"])
 
     def test_should_reject_get_member_without_class_name(self) -> None:
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(
-                self.server.call_tool("editor_reflect", {"action": "get_member", "member_name": "Position"})
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "get_member", "member_name": "Position"})
             )
         mock_send.assert_not_called()
         self.assertFalse(result["success"])
@@ -58,8 +56,7 @@ class TestEditorReflectValidation(unittest.TestCase):
 
     def test_should_reject_get_member_without_member_name(self) -> None:
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(
-                self.server.call_tool("editor_reflect", {"action": "get_member", "class_name": "Transform"})
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "get_member", "class_name": "Transform"})
             )
         mock_send.assert_not_called()
         self.assertFalse(result["success"])
@@ -86,8 +83,7 @@ class TestEditorReflectResponseUnwrap(unittest.TestCase):
         inner = {"found": True, "name": "Transform", "full_name": "UnityEngine.Transform"}
         bridge_resp = self._make_bridge_response(inner)
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value=bridge_resp):
-            _, result = _run(
-                self.server.call_tool("editor_reflect", {"action": "get_type", "class_name": "Transform"})
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "get_type", "class_name": "Transform"})
             )
         self.assertTrue(result["success"])
         self.assertEqual("Transform", result["data"]["name"])
@@ -103,8 +99,7 @@ class TestEditorReflectResponseUnwrap(unittest.TestCase):
             "diagnostics": [],
         }
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value=bridge_resp):
-            _, result = _run(
-                self.server.call_tool("editor_reflect", {"action": "get_type", "class_name": "Transform"})
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "get_type", "class_name": "Transform"})
             )
         self.assertFalse(result["success"])
         self.assertEqual("EDITOR_REFLECT_PARSE", result["code"])
@@ -119,8 +114,7 @@ class TestEditorReflectResponseUnwrap(unittest.TestCase):
             "diagnostics": [],
         }
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value=bridge_resp):
-            _, result = _run(
-                self.server.call_tool("editor_reflect", {"action": "search", "query": "Foo"})
+            result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "search", "query": "Foo"})
             )
         self.assertFalse(result["success"])
         self.assertEqual("EDITOR_BRIDGE_TIMEOUT", result["code"])
@@ -136,8 +130,7 @@ class TestEditorReflectResponseUnwrap(unittest.TestCase):
             }
             bridge_resp = self._make_bridge_response(inner)
             with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value=bridge_resp):
-                _, result = _run(
-                    self.server.call_tool("editor_reflect", {"action": "search", "query": "Foo", "scope": scope})
+                result = structured_payload(call_tool_result(self.server,"editor_reflect", {"action": "search", "query": "Foo", "scope": scope})
                 )
             self.assertTrue(result["success"], f"scope={scope} should be accepted")
 

--- a/tests/test_mcp_distribution_contract.py
+++ b/tests/test_mcp_distribution_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import tomllib
+import unittest
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.source_text_invariant
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MCP_CONSTRAINT = "mcp>=2,<3"
+
+
+class TestMCPDistributionContract(unittest.TestCase):
+    def test_sdk_major_range_is_synchronized(self) -> None:
+        pyproject = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        self.assertEqual([_MCP_CONSTRAINT], pyproject["project"]["optional-dependencies"]["mcp"])
+
+        codex = json.loads((_ROOT / ".codex-plugin/mcp.json").read_text(encoding="utf-8"))
+        self.assertIn(_MCP_CONSTRAINT, codex["prefab-sentinel"]["args"])
+
+        claude = json.loads((_ROOT / ".claude-plugin/plugin.json").read_text(encoding="utf-8"))
+        self.assertIn(_MCP_CONSTRAINT, claude["mcpServers"]["prefab-sentinel"]["args"])
+
+    def test_http_boundary_test_dependency_is_declared(self) -> None:
+        pyproject = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+        self.assertIn(
+            "httpx>=0.27.0,<0.29.0",
+            pyproject["project"]["optional-dependencies"]["test"],
+        )

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -1,0 +1,652 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from typing import Any
+
+from httpx import Response
+from mcp.server import MCPServer
+from starlette.testclient import TestClient
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from prefab_sentinel.mcp_http import MCP20260728HTTPGate, build_http_app, local_transport_security
+from prefab_sentinel.mcp_protocol import MCP_PROTOCOL_VERSION, ProtocolContractMiddleware
+
+_EXPECTED_BODY_LIMIT = 4 * 1024 * 1024
+_LEGACY_VERSION = "2025-11-25"
+_UNKNOWN_VERSION = "2099-01-01"
+
+
+def modern_meta(version: str = "2026-07-28") -> dict[str, object]:
+    return {
+        "io.modelcontextprotocol/protocolVersion": version,
+        "io.modelcontextprotocol/clientInfo": {"name": "tests", "version": "1"},
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+
+
+def _request(
+    method: str,
+    *,
+    request_id: int | str | None = 1,
+    version: str = MCP_PROTOCOL_VERSION,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": {"_meta": modern_meta(version), **(params or {})},
+    }
+    if request_id is not None:
+        payload["id"] = request_id
+    return payload
+
+
+def _headers(
+    method: str,
+    *,
+    version: str = MCP_PROTOCOL_VERSION,
+    name: str | None = None,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    headers = {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+        "mcp-protocol-version": version,
+        "mcp-method": method,
+    }
+    if name is not None:
+        headers["mcp-name"] = name
+    if extra is not None:
+        headers.update(extra)
+    return headers
+
+
+def _client(app: ASGIApp) -> TestClient:
+    return TestClient(app, base_url="http://localhost:8000")
+
+
+def _assert_jsonrpc_error(
+    testcase: unittest.TestCase,
+    response: Response,
+    *,
+    status: int,
+    code: int,
+    request_id: int | str | None,
+    data: Any = None,
+) -> None:
+    testcase.assertEqual(status, response.status_code)
+    payload = response.json()
+    testcase.assertEqual("2.0", payload["jsonrpc"])
+    testcase.assertIn("id", payload)
+    testcase.assertEqual(request_id, payload["id"])
+    testcase.assertEqual(code, payload["error"]["code"])
+    testcase.assertEqual(data, payload["error"].get("data"))
+    testcase.assertNotIn("mcp-session-id", response.headers)
+
+
+class _SpyASGI:
+    def __init__(self) -> None:
+        self.http_scopes: list[Scope] = []
+        self.bodies: list[bytes] = []
+        self.lifespan_started = False
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    self.lifespan_started = True
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+
+        self.http_scopes.append(scope)
+        chunks: list[bytes] = []
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            chunks.append(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        body = b"".join(chunks)
+        self.bodies.append(body)
+        request_id = json.loads(body).get("id") if body else None
+        response_body = json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "result": {"resultType": "complete"}},
+            separators=(",", ":"),
+        ).encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": response_body})
+
+
+def _spy_gate(spy: _SpyASGI) -> MCP20260728HTTPGate:
+    return MCP20260728HTTPGate(spy, security_settings=local_transport_security())
+
+
+def _product_app() -> ASGIApp:
+    server = MCPServer(
+        "http-test",
+        version="1",
+        instructions="HTTP test server",
+        middleware=[
+            ProtocolContractMiddleware(
+                server_name="http-test",
+                server_version="1",
+                instructions="HTTP test server",
+            )
+        ],
+    )
+
+    @server.tool()
+    def echo(value: str) -> str:
+        return value
+
+    return build_http_app(server)
+
+
+def _body_of_size(size: int) -> bytes:
+    payload = _request("tools/list")
+    payload["padding"] = ""
+    empty = json.dumps(payload, separators=(",", ":")).encode()
+    padding_size = size - len(empty)
+    if padding_size < 0:
+        raise ValueError("requested body size is smaller than the JSON envelope")
+    payload["padding"] = "x" * padding_size
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    if len(body) != size:
+        raise AssertionError("test body construction drifted from the requested size")
+    return body
+
+
+class TestMCPHTTPModernBoundary(unittest.TestCase):
+    def test_exact_endpoint_rejects_every_non_post_method_after_security(self) -> None:
+        spy = _SpyASGI()
+        with _client(_spy_gate(spy)) as client:
+            for method in ("GET", "DELETE", "PUT", "PATCH"):
+                with self.subTest(method=method):
+                    response = client.request(method, "/mcp")
+                    self.assertEqual(405, response.status_code)
+                    self.assertEqual("POST", response.headers["allow"])
+                    self.assertNotIn("mcp-session-id", response.headers)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_sdk_app_lifespan_serves_the_three_product_methods(self) -> None:
+        requests: tuple[tuple[str, dict[str, Any], str | None], ...] = (
+            ("server/discover", {}, None),
+            ("tools/list", {}, None),
+            ("tools/call", {"name": "echo", "arguments": {"value": "ok"}}, "echo"),
+        )
+        with _client(_product_app()) as client:
+            for index, (method, params, name) in enumerate(requests, start=1):
+                with self.subTest(method=method):
+                    response = client.post(
+                        "/mcp",
+                        json=_request(method, request_id=index, params=params),
+                        headers=_headers(method, name=name),
+                    )
+                    self.assertEqual(200, response.status_code)
+                    self.assertEqual(index, response.json()["id"])
+                    self.assertIn("result", response.json())
+                    self.assertNotIn("mcp-session-id", response.headers)
+
+    def test_legacy_transport_headers_are_ignored_and_never_echoed(self) -> None:
+        with _client(_product_app()) as client:
+            response = client.post(
+                "/mcp",
+                json=_request("tools/list"),
+                headers=_headers(
+                    "tools/list",
+                    extra={"mcp-session-id": "legacy-session", "last-event-id": "legacy-event"},
+                ),
+            )
+        self.assertEqual(200, response.status_code)
+        self.assertNotIn("mcp-session-id", response.headers)
+        self.assertNotIn("last-event-id", response.headers)
+
+    def test_only_the_exact_mcp_path_is_gated(self) -> None:
+        spy = _SpyASGI()
+        with _client(_spy_gate(spy)) as client:
+            slash_response = client.get("/mcp/")
+            other_response = client.get("/other")
+        self.assertEqual((200, 200), (slash_response.status_code, other_response.status_code))
+        self.assertTrue(spy.lifespan_started)
+        self.assertEqual(["/mcp/", "/other"], [scope["path"] for scope in spy.http_scopes])
+
+
+class TestMCPHTTPGateErrors(unittest.TestCase):
+    def test_parse_error_and_invalid_request_shapes_are_jsonrpc_errors(self) -> None:
+        spy = _SpyASGI()
+        with _client(_spy_gate(spy)) as client:
+            parse_response = client.post(
+                "/mcp",
+                content=b'{"jsonrpc":',
+                headers=_headers("tools/list"),
+            )
+            _assert_jsonrpc_error(self, parse_response, status=400, code=-32700, request_id=None)
+
+            invalid_values: tuple[Any, ...] = (
+                [],
+                None,
+                "request",
+                {"jsonrpc": "2.0", "id": 7, "params": {}},
+            )
+            for value in invalid_values:
+                with self.subTest(value=value):
+                    response = client.post(
+                        "/mcp",
+                        content=json.dumps(value).encode(),
+                        headers=_headers("tools/list"),
+                    )
+                    _assert_jsonrpc_error(self, response, status=400, code=-32600, request_id=None)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_value_error_and_recursion_error_json_boundaries_are_parse_errors(self) -> None:
+        spy = _SpyASGI()
+        oversized_integer = b'{"jsonrpc":"2.0","id":' + (b"9" * 5000) + b',"method":"tools/list","params":{"_meta":{}}}'
+        deeply_nested = (b"[" * 100_000) + b"0" + (b"]" * 100_000)
+
+        with TestClient(
+            _spy_gate(spy),
+            base_url="http://localhost:8000",
+            raise_server_exceptions=False,
+        ) as client:
+            for body in (oversized_integer, deeply_nested):
+                with self.subTest(kind="integer" if body is oversized_integer else "nesting"):
+                    response = client.post("/mcp", content=body, headers=_headers("tools/list"))
+                    _assert_jsonrpc_error(self, response, status=400, code=-32700, request_id=None)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_modern_initialize_is_removed_method_without_delegation(self) -> None:
+        spy = _SpyASGI()
+        requests: tuple[dict[str, Any], ...] = (
+            {
+                "jsonrpc": "2.0",
+                "id": 500,
+                "method": "initialize",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "conformance-client",
+                            "version": "1.0.0",
+                        },
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    },
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 501,
+                "method": "initialize",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "conformance-client",
+                            "version": "1.0.0",
+                        },
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    },
+                    "protocolVersion": _LEGACY_VERSION,
+                },
+            },
+        )
+
+        with _client(_spy_gate(spy)) as client:
+            for body in requests:
+                with self.subTest(request_id=body["id"]):
+                    response = client.post(
+                        "/mcp",
+                        json=body,
+                        headers=_headers("initialize"),
+                    )
+                    _assert_jsonrpc_error(
+                        self,
+                        response,
+                        status=404,
+                        code=-32601,
+                        request_id=body["id"],
+                    )
+        self.assertEqual([], spy.http_scopes)
+
+
+    def test_initialize_version_errors_precede_removed_method_resolution(self) -> None:
+        spy = _SpyASGI()
+        cases = (
+            (
+                _request(
+                    "initialize",
+                    version=_UNKNOWN_VERSION,
+                    params={"protocolVersion": _LEGACY_VERSION},
+                ),
+                _headers("initialize", version=_UNKNOWN_VERSION),
+                -32022,
+                {
+                    "supported": ["2026-07-28"],
+                    "requested": _UNKNOWN_VERSION,
+                },
+            ),
+            (
+                _request("initialize", version=_UNKNOWN_VERSION),
+                _headers("initialize"),
+                -32020,
+                None,
+            ),
+        )
+
+        with _client(_spy_gate(spy)) as client:
+            for body, headers, code, data in cases:
+                with self.subTest(code=code):
+                    response = client.post("/mcp", json=body, headers=headers)
+                    _assert_jsonrpc_error(
+                        self,
+                        response,
+                        status=400,
+                        code=code,
+                        request_id=1,
+                        data=data,
+                    )
+        self.assertEqual([], spy.http_scopes)
+
+    def test_initialize_requires_namespaced_metadata_before_method_resolution(self) -> None:
+        spy = _SpyASGI()
+        malformed_params: tuple[dict[str, Any], ...] = (
+            {},
+            {"_meta": []},
+            {
+                "_meta": {
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                },
+            },
+            {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": MCP_PROTOCOL_VERSION,
+                },
+            },
+        )
+
+        with _client(_spy_gate(spy)) as client:
+            for params in malformed_params:
+                with self.subTest(params=params):
+                    body = {
+                        "jsonrpc": "2.0",
+                        "id": 502,
+                        "method": "initialize",
+                        "params": params,
+                    }
+                    response = client.post(
+                        "/mcp",
+                        json=body,
+                        headers=_headers("initialize"),
+                    )
+                    _assert_jsonrpc_error(
+                        self,
+                        response,
+                        status=400,
+                        code=-32602,
+                        request_id=502,
+                    )
+        self.assertEqual([], spy.http_scopes)
+
+    def test_classifier_rejections_pin_status_code_and_data(self) -> None:
+        spy = _SpyASGI()
+        cases = (
+            (
+                _request("tools/list", version=_UNKNOWN_VERSION),
+                _headers("tools/list", version=_UNKNOWN_VERSION),
+                -32022,
+                {"supported": ["2026-07-28"], "requested": _UNKNOWN_VERSION},
+            ),
+            (
+                _request("tools/list", version=_LEGACY_VERSION),
+                _headers("tools/list", version=_LEGACY_VERSION),
+                -32022,
+                {"supported": ["2026-07-28"], "requested": _LEGACY_VERSION},
+            ),
+            (_request("tools/list", version=_UNKNOWN_VERSION), _headers("tools/list"), -32020, None),
+            (_request("tools/list"), {"content-type": "application/json", "mcp-method": "tools/list"}, -32020, None),
+            (
+                {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+                {"content-type": "application/json"},
+                -32602,
+                None,
+            ),
+        )
+
+        with _client(_spy_gate(spy)) as client:
+            for body, headers, code, data in cases:
+                with self.subTest(code=code, body=body, headers=headers):
+                    response = client.post("/mcp", json=body, headers=headers)
+                    _assert_jsonrpc_error(self, response, status=400, code=code, request_id=1, data=data)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_method_and_name_headers_must_match_the_body(self) -> None:
+        spy = _SpyASGI()
+        body = _request("tools/call", params={"name": "echo", "arguments": {}})
+        cases = (
+            {"mcp-protocol-version": MCP_PROTOCOL_VERSION},
+            _headers("tools/list"),
+            _headers("tools/call"),
+            _headers("tools/call", name="different"),
+        )
+
+        with _client(_spy_gate(spy)) as client:
+            for headers in cases:
+                with self.subTest(headers=headers):
+                    normalized = {"content-type": "application/json", **headers}
+                    response = client.post("/mcp", json=body, headers=normalized)
+                    _assert_jsonrpc_error(self, response, status=400, code=-32020, request_id=1)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_schema_invalid_allowed_calls_are_rejected_before_delegation(self) -> None:
+        spy = _SpyASGI()
+        cases = (
+            (
+                _request("tools/list", params={"cursor": 17}),
+                _headers("tools/list"),
+            ),
+            (
+                _request("tools/call", params={"name": "echo", "arguments": "not-an-object"}),
+                _headers("tools/call", name="echo"),
+            ),
+        )
+
+        with _client(_spy_gate(spy)) as client:
+            for body, headers in cases:
+                with self.subTest(method=body["method"]):
+                    response = client.post("/mcp", json=body, headers=headers)
+                    _assert_jsonrpc_error(self, response, status=400, code=-32602, request_id=1)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_every_sdk_default_non_tools_request_is_product_method_not_found(self) -> None:
+        rejected_methods = (
+            "resources/list",
+            "resources/read",
+            "resources/templates/list",
+            "prompts/get",
+            "prompts/list",
+            "subscriptions/listen",
+            "ping",
+            "completion/complete",
+        )
+        spy = _SpyASGI()
+        with _client(_spy_gate(spy)) as client:
+            for method in rejected_methods:
+                with self.subTest(method=method):
+                    response = client.post(
+                        "/mcp",
+                        json=_request(method),
+                        headers=_headers(method),
+                    )
+                    _assert_jsonrpc_error(self, response, status=404, code=-32601, request_id=1)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_http_notifications_are_rejected_without_delegation(self) -> None:
+        spy = _SpyASGI()
+        with _client(_spy_gate(spy)) as client:
+            for method in ("notifications/cancelled", "notifications/initialized"):
+                with self.subTest(method=method):
+                    response = client.post(
+                        "/mcp",
+                        json=_request(method, request_id=None),
+                        headers=_headers(method),
+                    )
+                    _assert_jsonrpc_error(self, response, status=400, code=-32600, request_id=None)
+        self.assertEqual([], spy.http_scopes)
+
+
+class TestMCPHTTPSecurityAndLimits(unittest.TestCase):
+    def test_security_prevalidation_precedes_gate_owned_responses(self) -> None:
+        spy = _SpyASGI()
+        legacy = {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "initialize",
+            "params": {"protocolVersion": _LEGACY_VERSION},
+        }
+        with _client(_spy_gate(spy)) as client:
+            invalid_host_method = client.get("/mcp", headers={"host": "evil.example"})
+            self.assertEqual(421, invalid_host_method.status_code)
+
+            invalid_content_type = client.post(
+                "/mcp",
+                content=json.dumps(legacy).encode(),
+                headers={"mcp-protocol-version": _LEGACY_VERSION, "mcp-method": "initialize"},
+            )
+            self.assertEqual(400, invalid_content_type.status_code)
+            self.assertEqual("Invalid Content-Type header", invalid_content_type.text)
+
+            legacy_invalid_host = client.post(
+                "/mcp",
+                json=legacy,
+                headers={**_headers("initialize", version=_LEGACY_VERSION), "host": "evil.example"},
+            )
+            self.assertEqual(421, legacy_invalid_host.status_code)
+
+            legacy_invalid_origin = client.post(
+                "/mcp",
+                json=legacy,
+                headers={**_headers("initialize", version=_LEGACY_VERSION), "origin": "https://evil.example"},
+            )
+            self.assertEqual(403, legacy_invalid_origin.status_code)
+
+            oversized_invalid_origin = client.post(
+                "/mcp",
+                content=b"x" * (_EXPECTED_BODY_LIMIT + 1),
+                headers={**_headers("tools/list"), "origin": "https://evil.example"},
+            )
+            self.assertEqual(403, oversized_invalid_origin.status_code)
+        self.assertEqual([], spy.http_scopes)
+
+    def test_default_four_mib_limit_admits_cap_minus_one_and_cap_but_rejects_cap_plus_one(self) -> None:
+        spy = _SpyASGI()
+        gate = _spy_gate(spy)
+        admitted = (_EXPECTED_BODY_LIMIT - 1, _EXPECTED_BODY_LIMIT)
+
+        with _client(gate) as client:
+            expected_bodies = []
+            for size in admitted:
+                with self.subTest(size=size):
+                    body = _body_of_size(size)
+                    expected_bodies.append(body)
+                    response = client.post("/mcp", content=body, headers=_headers("tools/list"))
+                    self.assertEqual(200, response.status_code)
+                    self.assertNotIn("mcp-session-id", response.headers)
+
+            oversized = client.post(
+                "/mcp",
+                content=_body_of_size(_EXPECTED_BODY_LIMIT + 1),
+                headers=_headers("tools/list"),
+            )
+            self.assertEqual(413, oversized.status_code)
+            self.assertNotIn("mcp-session-id", oversized.headers)
+
+        self.assertEqual(expected_bodies, spy.bodies)
+
+
+class TestMCPHTTPDirectASGIBoundary(unittest.TestCase):
+    @staticmethod
+    def _scope(headers: list[tuple[bytes, bytes]]) -> Scope:
+        return {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/mcp",
+            "raw_path": b"/mcp",
+            "query_string": b"",
+            "root_path": "",
+            "headers": headers,
+            "client": ("127.0.0.1", 50000),
+            "server": ("localhost", 8000),
+        }
+
+    def test_incomplete_body_followed_by_disconnect_never_reaches_downstream(self) -> None:
+        spy = _SpyASGI()
+        gate = _spy_gate(spy)
+        body = json.dumps(_request("tools/list"), separators=(",", ":")).encode()
+        incoming: list[Message] = [
+            {"type": "http.request", "body": body, "more_body": True},
+            {"type": "http.disconnect"},
+        ]
+        sent: list[Message] = []
+        headers = [(key.encode(), value.encode()) for key, value in _headers("tools/list").items()]
+        headers.append((b"host", b"localhost:8000"))
+
+        async def receive() -> Message:
+            return incoming.pop(0)
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        asyncio.run(gate(self._scope(headers), receive, send))
+
+        self.assertEqual([], spy.http_scopes)
+        self.assertEqual([], spy.bodies)
+
+    def test_duplicate_routing_header_is_rejected_before_dict_folding(self) -> None:
+        spy = _SpyASGI()
+        gate = _spy_gate(spy)
+        body = json.dumps(_request("tools/list"), separators=(",", ":")).encode()
+        incoming: list[Message] = [{"type": "http.request", "body": body, "more_body": False}]
+        sent: list[Message] = []
+        headers = [(key.encode(), value.encode()) for key, value in _headers("tools/list").items()]
+        headers.extend(
+            (
+                (b"host", b"localhost:8000"),
+                (b"mcp-method", b"tools/list"),
+            )
+        )
+
+        async def receive() -> Message:
+            return incoming.pop(0)
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        asyncio.run(gate(self._scope(headers), receive, send))
+
+        self.assertEqual(400, sent[0]["status"])
+        response_body = b"".join(message.get("body", b"") for message in sent[1:])
+        payload = json.loads(response_body)
+        self.assertEqual("2.0", payload["jsonrpc"])
+        self.assertIn("id", payload)
+        self.assertEqual(1, payload["id"])
+        self.assertEqual(-32020, payload["error"]["code"])
+        self.assertEqual([], spy.http_scopes)
+        self.assertEqual([], spy.bodies)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -1,0 +1,287 @@
+"""Subprocess contract tests for the real MCP Streamable HTTP CLI transport."""
+
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from tests._mcp_wire_support import (
+    HTTPResult,
+    assert_jsonrpc_error,
+    assert_jsonrpc_result,
+    http_request,
+    modern_headers,
+    modern_request,
+    reserve_loopback_port,
+    running_mcp_cli,
+    wait_for_http_ready,
+)
+
+
+class _UnrelatedJSONRPCHandler(BaseHTTPRequestHandler):
+    """Return a valid-looking but unrelated JSON-RPC response."""
+
+    def do_GET(self) -> None:
+        self._respond()
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("content-length", "0"))
+        self.rfile.read(content_length)
+        self._respond()
+
+    def _respond(self) -> None:
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": "unrelated-listener",
+                "result": {"supportedVersions": ["2026-07-28"]},
+            }
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+
+@contextmanager
+def _unrelated_http_listener() -> Iterator[int]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _UnrelatedJSONRPCHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(
+        target=server.serve_forever,
+        kwargs={"poll_interval": 0.01},
+    )
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+    if thread.is_alive():
+        raise AssertionError("unrelated HTTP listener did not stop")
+
+
+def _assert_no_session_headers(test: unittest.TestCase, response: HTTPResult) -> None:
+    test.assertNotIn("mcp-session-id", response.headers)
+    test.assertNotIn("last-event-id", response.headers)
+
+
+def _assert_jsonrpc_error(
+    test: unittest.TestCase,
+    response: HTTPResult,
+    *,
+    code: int,
+    message: str,
+    request_id: int | str,
+    status: int = 400,
+) -> None:
+    test.assertEqual(status, response.status)
+    assert_jsonrpc_error(
+        test,
+        response.json_object(),
+        request_id=request_id,
+        code=code,
+        message=message,
+    )
+    _assert_no_session_headers(test, response)
+
+
+class TestMCPHTTPTransport(unittest.TestCase):
+    def test_readiness_rejects_an_unrelated_http_listener(self) -> None:
+        with _unrelated_http_listener() as port:
+            with running_mcp_cli("--transport", "stdio", pipe_stdin=True) as child:
+                with self.assertRaisesRegex(AssertionError, "did not become ready before timeout"):
+                    wait_for_http_ready(child, port, timeout=0.1)
+
+    def test_modern_product_methods_are_served_without_sessions(self) -> None:
+        port = reserve_loopback_port()
+        with running_mcp_cli(
+            "--transport",
+            "streamable-http",
+            "--port",
+            str(port),
+        ) as child:
+            wait_for_http_ready(child, port)
+            cases: tuple[tuple[str, dict[str, object], str | None], ...] = (
+                ("server/discover", {}, None),
+                ("tools/list", {}, None),
+                (
+                    "tools/call",
+                    {"name": "get_project_status", "arguments": {}},
+                    "get_project_status",
+                ),
+            )
+            responses: dict[str, dict[str, Any]] = {}
+            for request_id, (method, params, name) in enumerate(cases, start=1):
+                response = http_request(
+                    port,
+                    "POST",
+                    "/mcp",
+                    body=modern_request(method, request_id=request_id, params=params),
+                    headers=modern_headers(method, name=name),
+                )
+                self.assertEqual(200, response.status)
+                result = assert_jsonrpc_result(
+                    self,
+                    response.json_object(),
+                    request_id=request_id,
+                )
+                _assert_no_session_headers(self, response)
+                responses[method] = result
+
+            self.assertEqual(
+                ["2026-07-28"],
+                responses["server/discover"]["supportedVersions"],
+            )
+            self.assertIn(
+                "get_project_status",
+                {tool["name"] for tool in responses["tools/list"]["tools"]},
+            )
+            self.assertIs(responses["tools/call"]["isError"], False)
+            self.assertEqual(
+                "SESSION_STATUS",
+                responses["tools/call"]["structuredContent"]["code"],
+            )
+
+    def test_initialize_and_routing_mismatches_are_product_errors(self) -> None:
+        port = reserve_loopback_port()
+        with running_mcp_cli(
+            "--transport",
+            "streamable-http",
+            "--port",
+            str(port),
+        ) as child:
+            wait_for_http_ready(child, port)
+            modern_initialize = {
+                "jsonrpc": "2.0",
+                "id": 500,
+                "method": "initialize",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "conformance-client",
+                            "version": "1.0.0",
+                        },
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    },
+                },
+            }
+            initialize = http_request(
+                port,
+                "POST",
+                "/mcp",
+                body=modern_initialize,
+                headers=modern_headers("initialize"),
+            )
+            _assert_jsonrpc_error(
+                self,
+                initialize,
+                status=404,
+                code=-32601,
+                message="Method not found: initialize",
+                request_id=500,
+            )
+
+            version_mismatch = http_request(
+                port,
+                "POST",
+                "/mcp",
+                body=modern_request("tools/list", request_id=2, version="2099-01-01"),
+                headers=modern_headers("tools/list", version="2099-01-01"),
+            )
+            _assert_jsonrpc_error(
+                self,
+                version_mismatch,
+                code=-32022,
+                message="Unsupported protocol version",
+                request_id=2,
+            )
+
+            method_mismatch = http_request(
+                port,
+                "POST",
+                "/mcp",
+                body=modern_request("tools/list", request_id=3),
+                headers=modern_headers("server/discover"),
+            )
+            _assert_jsonrpc_error(
+                self,
+                method_mismatch,
+                code=-32020,
+                message="mcp-method header does not match the request body's method",
+                request_id=3,
+            )
+
+            name_mismatch = http_request(
+                port,
+                "POST",
+                "/mcp",
+                body=modern_request(
+                    "tools/call",
+                    request_id=4,
+                    params={"name": "get_project_status", "arguments": {}},
+                ),
+                headers=modern_headers("tools/call", name="different-tool"),
+            )
+            _assert_jsonrpc_error(
+                self,
+                name_mismatch,
+                code=-32020,
+                message="mcp-name header does not match the request body's 'name' parameter",
+                request_id=4,
+            )
+
+    def test_security_and_route_mapping_are_enforced_without_sessions(self) -> None:
+        port = reserve_loopback_port()
+        with running_mcp_cli(
+            "--transport",
+            "streamable-http",
+            "--port",
+            str(port),
+        ) as child:
+            wait_for_http_ready(child, port)
+
+            invalid_host = http_request(
+                port,
+                "GET",
+                "/mcp",
+                headers={"host": "evil.example"},
+            )
+            self.assertEqual(421, invalid_host.status)
+
+            invalid_origin = http_request(
+                port,
+                "POST",
+                "/mcp",
+                body=modern_request("tools/list", request_id=1),
+                headers=modern_headers(
+                    "tools/list",
+                    extra={"origin": "https://evil.example"},
+                ),
+            )
+            self.assertEqual(403, invalid_origin.status)
+
+            missing_route = http_request(port, "GET", "/missing")
+            self.assertEqual(404, missing_route.status)
+
+            wrong_method = http_request(port, "GET", "/mcp")
+            self.assertEqual(405, wrong_method.status)
+            self.assertEqual("POST", wrong_method.headers["allow"])
+
+            for response in (invalid_host, invalid_origin, missing_route, wrong_method):
+                _assert_no_session_headers(self, response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_inspector_profiles.py
+++ b/tests/test_mcp_inspector_profiles.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import tempfile
@@ -9,14 +8,11 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, call, patch
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from prefab_sentinel.inspector_profiles import application
 from prefab_sentinel.mcp_server import create_server
-
-
-def _run(coro: Any) -> Any:
-    return asyncio.run(coro)
+from tests._mcp_test_support import call_tool_result, run, structured_payload
 
 
 def _assert_component_surface_request(
@@ -103,7 +99,7 @@ class TestInspectorProfileToolRegistration(unittest.TestCase):
 
         names = {
             tool.name
-            for tool in _run(server.list_tools())
+            for tool in run(server.list_tools())
             if tool.name
             in {
                 "inspect_serialized_surface",
@@ -125,7 +121,7 @@ class TestInspectorProfileToolRegistration(unittest.TestCase):
     def test_tool_schemas_require_the_authority_named_inputs(self) -> None:
         server = create_server()
 
-        tools = {tool.name: tool for tool in _run(server.list_tools())}
+        tools = {tool.name: tool for tool in run(server.list_tools())}
 
         self.assertEqual(
             {
@@ -134,22 +130,21 @@ class TestInspectorProfileToolRegistration(unittest.TestCase):
                 "validate_inspector_profile": ["asset_path", "profile_path"],
             },
             {
-                name: sorted(tools[name].inputSchema["required"])
+                name: sorted(tools[name].input_schema["required"])
                 for name in (
                     "inspect_serialized_surface",
                     "inspect_with_profile",
                     "validate_inspector_profile",
                 )
             },
-            msg="FastMCP required-field schemas drifted from MC-003 through MC-005",
+            msg="MCPServer required-field schemas drifted from MC-003 through MC-005",
         )
 
     def test_empty_view_name_precedes_malformed_target_resolution(self) -> None:
         server = create_server()
 
         try:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_with_profile",
                     {"asset_path": "", "view_name": ""},
                 )
@@ -183,8 +178,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
     def test_inactive_project_returns_before_bridge_dispatch(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {
                         "asset_path": "Assets/Test.prefab",
@@ -203,8 +197,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             server = create_server(project_root=Path(temporary))
             try:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_serialized_surface",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -270,8 +263,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
                     return_value=bridge_response,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_serialized_surface",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -347,8 +339,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {
                         "asset_path": "Assets/Test.prefab",
@@ -417,8 +408,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {
                         "asset_path": "Assets/Test.prefab",
@@ -459,8 +449,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {
                         "asset_path": "Assets/Test.prefab",
@@ -598,8 +587,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
                     "prefab_sentinel.inspector_profiles.application.send_action",
                     return_value=bridge_response,
                 ) as mock_send:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "inspect_serialized_surface",
                             {
                                 "asset_path": "Assets/Test.prefab",
@@ -646,8 +634,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {
                         "asset_path": "Assets/Test.prefab",
@@ -703,8 +690,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
                 ),
                 patch.object(Path, "rename", publish_invalid_response),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_serialized_surface",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -822,8 +808,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
                     "prefab_sentinel.inspector_profiles.application.send_action",
                     return_value=bridge_response,
                 ) as mock_send:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "inspect_serialized_surface",
                             {
                                 "asset_path": "Assets/Test.prefab",
@@ -940,8 +925,7 @@ class TestSerializedSurfaceTool(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {
                         "asset_path": "Assets/Test.prefab",
@@ -1026,8 +1010,7 @@ class TestProfileWorkflow(unittest.TestCase):
                 return_value=bridge_response,
             ) as mock_send:
                 try:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "inspect_with_profile",
                             {
                                 "asset_path": "Assets/Test.prefab",
@@ -1163,8 +1146,7 @@ class TestProfileWorkflow(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -1257,8 +1239,7 @@ class TestProfileWorkflow(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -1337,8 +1318,7 @@ class TestProfileWorkflow(unittest.TestCase):
                     return_value=bridge_response,
                 ) as mock_send,
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -1428,8 +1408,7 @@ class TestProfileWorkflow(unittest.TestCase):
                 return_value=bridge_response,
             ) as mock_send:
                 try:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "inspect_with_profile",
                             {
                                 "asset_path": "Assets/Test.prefab",
@@ -1512,8 +1491,7 @@ class TestProfileWorkflow(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -1609,8 +1587,7 @@ class TestProfileWorkflow(unittest.TestCase):
                     return_value=bridge_response,
                 ) as mock_send,
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -1694,8 +1671,7 @@ class TestInspectorCandidateDiscovery(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -1769,8 +1745,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
                 try:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "validate_inspector_profile",
                             {
                                 "profile_path": str(outside_profile),
@@ -1830,8 +1805,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
                             ),
                             patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send,
                         ):
-                            _, result = _run(
-                                server.call_tool(
+                            result = structured_payload(call_tool_result(server,
                                     "validate_inspector_profile",
                                     {
                                         "profile_path": str(unsafe_profile),
@@ -1903,8 +1877,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(profile_path),
@@ -2012,8 +1985,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(profile_path),
@@ -2065,8 +2037,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
             server = create_server(project_root=project_root)
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(profile_path),
@@ -2100,8 +2071,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
             server = create_server(project_root=project_root)
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(profile_path),
@@ -2192,8 +2162,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
                     return_value=orchestrator,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(profile_path),
@@ -2346,8 +2315,7 @@ class TestValidateInspectorProfile(unittest.TestCase):
                     return_value=orchestrator,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(profile_path),
@@ -2470,8 +2438,7 @@ class TestInspectorSurfaceBlockers(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {"asset_path": "Assets/Test.asset"},
                 )
@@ -2548,8 +2515,7 @@ class TestInspectorSurfaceBlockers(unittest.TestCase):
                     "prefab_sentinel.inspector_profiles.application.send_action",
                     return_value=bridge_response,
                 ) as mock_send:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "inspect_serialized_surface",
                             {"asset_path": "Assets/Test.asset"},
                         )
@@ -2598,7 +2564,7 @@ class TestInspectSerializedSurfaceAddresses(unittest.TestCase):
             arguments["symbol_path"] = symbol_path
 
         with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-            _, result = _run(server.call_tool("inspect_serialized_surface", arguments))
+            result = structured_payload(call_tool_result(server,"inspect_serialized_surface", arguments))
 
         self.assertEqual(
             (False, "error", "INSPECTOR_SURFACE_ADDRESS_INVALID", field),
@@ -2646,8 +2612,7 @@ class TestInspectSerializedSurfaceAddresses(unittest.TestCase):
             server = create_server(project_root=project_root)
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_serialized_surface",
                         {
                             "asset_path": "Assets/Linked.prefab",
@@ -2679,8 +2644,7 @@ class TestInspectSerializedSurfaceAddresses(unittest.TestCase):
             server = create_server(project_root=project_root)
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_serialized_surface",
                         {
                             "asset_path": "Assets/Linked/Test.prefab",
@@ -2752,8 +2716,7 @@ class TestInspectSerializedSurfaceAddresses(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_serialized_surface",
                     {
                         "asset_path": "Assets/Settings.asset",
@@ -2802,8 +2765,7 @@ class TestInspectorProfileWorkflowStates(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -2887,8 +2849,7 @@ class TestInspectorProfileWorkflowStates(unittest.TestCase):
                     "prefab_sentinel.inspector_profiles.application.send_action",
                     return_value=bridge_response,
                 ) as mock_send:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "inspect_with_profile",
                             {
                                 "asset_path": "Assets/Test.prefab",
@@ -2974,8 +2935,7 @@ class TestInspectorProfileWorkflowStates(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -3074,8 +3034,7 @@ class TestInspectorProfileWorkflowStates(unittest.TestCase):
                     return_value=orchestrator,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -3213,8 +3172,7 @@ class TestInspectorProfileWorkflowPartitions(unittest.TestCase):
             "prefab_sentinel.inspector_profiles.application.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_with_profile",
                     {
                         "asset_path": "Assets/Test.prefab",
@@ -3469,8 +3427,7 @@ class TestInspectorProfileRecommendationPaths(unittest.TestCase):
 
     @staticmethod
     def _call(server: Any) -> dict[str, Any]:
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "inspect_with_profile",
                 {
                     "asset_path": "Assets/Missing.prefab",
@@ -3594,8 +3551,7 @@ class TestInspectWithProfileAddresses(unittest.TestCase):
         server = create_server()
 
         with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_with_profile",
                     {
                         "asset_path": "../outside.prefab",
@@ -3632,8 +3588,7 @@ class TestInspectWithProfileAddresses(unittest.TestCase):
             server = create_server(project_root=project_root)
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Test.prefab",
@@ -3673,8 +3628,7 @@ class TestInspectWithProfileAddresses(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_with_profile",
                         {
                             "asset_path": "Assets/Missing.prefab",
@@ -3739,8 +3693,7 @@ class TestValidateInspectorProfileSurfaceBlocker(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(draft),
@@ -3812,8 +3765,7 @@ class TestValidateInspectorProfileAddresses(unittest.TestCase):
             server = create_server(project_root=project_root)
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(draft),
@@ -3855,8 +3807,7 @@ class TestValidateInspectorProfileAddresses(unittest.TestCase):
                 "prefab_sentinel.inspector_profiles.application.send_action",
                 return_value=bridge_response,
             ) as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(draft),
@@ -3899,8 +3850,7 @@ class TestValidateInspectorProfileAddresses(unittest.TestCase):
             server = create_server(project_root=project_root)
 
             with patch("prefab_sentinel.inspector_profiles.application.send_action") as mock_send:
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "validate_inspector_profile",
                         {
                             "profile_path": str(outside),

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,0 +1,756 @@
+"""Protocol-boundary and process-local tool serialization tests."""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+import unittest
+from collections.abc import Callable, Mapping
+from importlib.metadata import version
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+import anyio
+from mcp import Client, MCPError
+from mcp.server import MCPServer
+from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
+from mcp.server.session import ServerSession
+from mcp_types import EmptyResult, Request, TextContent
+
+from prefab_sentinel.mcp_protocol import (
+    MCP_PROTOCOL_VERSION,
+    ProtocolContractMiddleware,
+    SerializeToolCallsMiddleware,
+)
+from prefab_sentinel.mcp_server import create_server
+
+
+def _context(
+    method: str,
+    *,
+    protocol_version: str = "2026-07-28",
+    params: Mapping[str, Any] | None = None,
+    request_id: int | str | None = 1,
+) -> ServerRequestContext[Any, Any]:
+    return ServerRequestContext(
+        session=cast(ServerSession, None),
+        lifespan_context={},
+        protocol_version=protocol_version,
+        method=method,
+        params=params,
+        request_id=request_id,
+    )
+
+
+def _contract() -> ProtocolContractMiddleware:
+    return ProtocolContractMiddleware(
+        server_name="prefab-sentinel-test",
+        server_version="9.8.7",
+        instructions="Use only the advertised tools.",
+    )
+
+
+
+class TestCreateServerComposition(unittest.TestCase):
+    def test_public_discovery_is_tools_only_with_complete_tool_surface(self) -> None:
+        fixture_path = (
+            Path(__file__).parent / "fixtures" / "mcp_v1_tool_schemas.json"
+        )
+        golden = json.loads(fixture_path.read_text(encoding="utf-8"))
+        provenance = golden["_provenance"]
+        self.assertNotIn("source_commit", provenance)
+        self.assertEqual("1.26.0", provenance["mcp_sdk_version"])
+        expected_tools = golden["tools"]
+        expected_by_name = {tool["name"]: tool for tool in expected_tools}
+
+        def materialize_implicit_object_types(schema: Any) -> None:
+            if not isinstance(schema, dict):
+                return
+            if "properties" in schema:
+                schema.setdefault("type", "object")
+                for property_schema in schema["properties"].values():
+                    materialize_implicit_object_types(property_schema)
+            for definitions_key in ("$defs", "definitions"):
+                definitions = schema.get(definitions_key, {})
+                for definition in definitions.values():
+                    materialize_implicit_object_types(definition)
+            for branch_key in ("anyOf", "oneOf", "allOf"):
+                for branch in schema.get(branch_key, []):
+                    materialize_implicit_object_types(branch)
+            materialize_implicit_object_types(schema.get("items"))
+            materialize_implicit_object_types(
+                schema.get("additionalProperties")
+            )
+
+        async def scenario() -> None:
+            server = create_server()
+            self.assertIsInstance(server, MCPServer)
+            self.assertIsInstance(
+                server.middleware[-2],
+                ProtocolContractMiddleware,
+            )
+            self.assertIsInstance(
+                server.middleware[-1],
+                SerializeToolCallsMiddleware,
+            )
+
+            async with Client(
+                server,
+                mode=MCP_PROTOCOL_VERSION,
+                raise_exceptions=True,
+            ) as client:
+                discovery_payload = await client.session.send_discover(
+                    MCP_PROTOCOL_VERSION
+                )
+                public_tools = (await client.list_tools()).tools
+                self.assertEqual(MCP_PROTOCOL_VERSION, client.protocol_version)
+                self.assertEqual(
+                    [MCP_PROTOCOL_VERSION],
+                    discovery_payload["supportedVersions"],
+                )
+                self.assertEqual(
+                    {"tools": {"listChanged": False}},
+                    discovery_payload["capabilities"],
+                )
+                self.assertEqual(
+                    {
+                        "name": "prefab-sentinel",
+                        "version": version("prefab-sentinel"),
+                    },
+                    discovery_payload["_meta"][
+                        "io.modelcontextprotocol/serverInfo"
+                    ],
+                )
+                instructions = discovery_payload["instructions"]
+                for statement in (
+                    "activate_project selects the process-wide active Unity project",
+                    "One process represents one logical client/project scope",
+                    "Tool calls execute serially",
+                    "inspection, dry-run, and confirm entry points remain unchanged",
+                ):
+                    self.assertIn(statement, instructions)
+
+            self.assertEqual(101, len(expected_tools))
+            self.assertEqual(101, len(public_tools))
+            self.assertEqual(
+                set(expected_by_name),
+                {tool.name for tool in public_tools},
+            )
+            missing_descriptions = [
+                tool.name
+                for tool in public_tools
+                if not (tool.description and tool.description.strip())
+            ]
+            self.assertEqual([], missing_descriptions)
+            for public_tool in public_tools:
+                expected = expected_by_name[public_tool.name]
+                expected_input_schema = copy.deepcopy(expected["inputSchema"])
+                materialize_implicit_object_types(expected_input_schema)
+                if public_tool.name == "editor_set_udonsharp_field":
+                    expected_input_schema["properties"]["values_json"] = {
+                        "default": "",
+                        "title": "Values Json",
+                        "type": "string",
+                    }
+                self.assertEqual(
+                    expected_input_schema,
+                    public_tool.input_schema,
+                    f"{public_tool.name} input schema",
+                )
+                expected_output_schema = copy.deepcopy(expected["outputSchema"])
+                materialize_implicit_object_types(expected_output_schema)
+                self.assertEqual(
+                    expected_output_schema,
+                    public_tool.output_schema,
+                    f"{public_tool.name} output schema",
+                )
+
+        anyio.run(scenario)
+
+    def test_domain_failure_and_validation_failure_keep_distinct_error_flags(self) -> None:
+        async def scenario() -> None:
+            server = create_server()
+            async with Client(
+                server,
+                mode=MCP_PROTOCOL_VERSION,
+                raise_exceptions=True,
+            ) as client:
+                domain_failure = await client.call_tool(
+                    "activate_project",
+                    {
+                        "scope": "Assets",
+                        "project_root": "/path/that/does/not/exist",
+                    },
+                )
+                validation_failure = await client.call_tool(
+                    "activate_project",
+                    {},
+                )
+
+            self.assertIs(domain_failure.is_error, False)
+            self.assertEqual(
+                False,
+                domain_failure.structured_content["success"],
+            )
+            self.assertTrue(validation_failure.is_error)
+
+        anyio.run(scenario)
+
+    def test_forbidden_non_tools_method_is_a_top_level_mcp_error(self) -> None:
+        async def scenario() -> None:
+            server = create_server()
+            async with Client(
+                server,
+                mode=MCP_PROTOCOL_VERSION,
+                raise_exceptions=True,
+            ) as client:
+                with self.assertRaises(MCPError) as caught:
+                    await client.session.send_request(
+                        Request(method="resources/list", params={}),
+                        EmptyResult,
+                    )
+                error = caught.exception
+
+            self.assertEqual(-32601, error.code)
+            self.assertEqual("Method not found: resources/list", error.message)
+            self.assertIsNone(error.data)
+
+        anyio.run(scenario)
+
+    def test_public_client_lifespan_clears_provider_before_failed_shutdown(self) -> None:
+        expected_root = str(Path("/workspace/ExpectedProject").resolve())
+        provider_events: list[Callable[[], str | None] | None] = []
+        shutdown_sessions: list[object] = []
+
+        def capture_provider(
+            provider: Callable[[], str | None] | None,
+        ) -> None:
+            provider_events.append(provider)
+
+        async def fail_shutdown(session: object) -> None:
+            self.assertIsNone(provider_events[-1])
+            shutdown_sessions.append(session)
+            raise RuntimeError("shutdown failed")
+
+        async def scenario() -> None:
+            server = create_server(project_root=expected_root)
+            with (
+                patch(
+                    "prefab_sentinel.mcp_server."
+                    "editor_bridge._set_expected_project_root_provider",
+                    capture_provider,
+                ),
+                patch(
+                    "prefab_sentinel.session.ProjectSession.shutdown",
+                    fail_shutdown,
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "shutdown failed"):
+                    async with Client(
+                        server,
+                        mode=MCP_PROTOCOL_VERSION,
+                        raise_exceptions=True,
+                    ):
+                        self.assertEqual(1, len(provider_events))
+                        provider = provider_events[0]
+                        self.assertIsNotNone(provider)
+                        assert provider is not None
+                        self.assertEqual(expected_root, provider())
+
+        anyio.run(scenario)
+
+        self.assertEqual(2, len(provider_events))
+        self.assertIsNone(provider_events[1])
+        self.assertEqual(1, len(shutdown_sessions))
+
+class TestProtocolContractMiddleware(unittest.TestCase):
+    def test_allowlisted_2026_request_reaches_handler(self) -> None:
+        async def scenario() -> None:
+            server = MCPServer("modern-contract", middleware=[_contract()])
+            async with Client(
+                server,
+                mode=MCP_PROTOCOL_VERSION,
+                raise_exceptions=True,
+            ) as client:
+                result = await client.list_tools()
+
+            self.assertEqual([], result.tools)
+
+        anyio.run(scenario)
+
+    def test_initialize_version_is_validated_before_method_resolution(self) -> None:
+        async def scenario() -> None:
+            delegated = False
+
+            async def call_next(
+                _: ServerRequestContext[Any, Any],
+            ) -> HandlerResult:
+                nonlocal delegated
+                delegated = True
+                return EmptyResult()
+
+            with self.assertRaises(MCPError) as caught:
+                await _contract()(
+                    _context(
+                        "initialize",
+                        protocol_version="2026-08-01",
+                        params={"protocolVersion": "2025-11-25"},
+                    ),
+                    call_next,
+                )
+            error = caught.exception
+
+            self.assertFalse(delegated)
+            self.assertEqual(-32022, error.code)
+            self.assertEqual(
+                "Unsupported protocol version: 2026-08-01",
+                error.message,
+            )
+            self.assertEqual(
+                {"supported": ["2026-07-28"], "requested": "2026-08-01"},
+                error.data,
+            )
+
+        anyio.run(scenario)
+
+    def test_modern_initialize_is_method_not_found_without_handler_reach(self) -> None:
+        modern_meta = {
+            "io.modelcontextprotocol/protocolVersion": MCP_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "conformance-client",
+                "version": "1.0.0",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
+        }
+        parameter_sets = (
+            {"_meta": modern_meta},
+            {
+                "_meta": modern_meta,
+                "protocolVersion": "2025-11-25",
+            },
+        )
+
+        for params in parameter_sets:
+            with self.subTest(params=params):
+
+                async def scenario(
+                    bound_params: Mapping[str, Any] = params,
+                ) -> None:
+                    async def call_next(_: ServerRequestContext[Any, Any]) -> HandlerResult:
+                        self.fail("removed initialize must not reach the SDK handler")
+
+                    await _contract()(
+                        _context("initialize", params=bound_params),
+                        call_next,
+                    )
+
+                with self.assertRaises(MCPError) as caught:
+                    anyio.run(scenario)
+                self.assertEqual(-32601, caught.exception.code)
+                self.assertEqual(
+                    "Method not found: initialize",
+                    caught.exception.message,
+                )
+                self.assertIsNone(caught.exception.data)
+
+    def test_non_allowlisted_modern_version_is_rejected(self) -> None:
+        async def scenario() -> None:
+            async def call_next(_: ServerRequestContext[Any, Any]) -> HandlerResult:
+                self.fail("unsupported modern version must not reach the handler")
+
+            await _contract()(
+                _context("tools/list", protocol_version="2026-08-01"),
+                call_next,
+            )
+
+        with self.assertRaises(MCPError) as caught:
+            anyio.run(scenario)
+        self.assertEqual(-32022, caught.exception.code)
+        self.assertEqual(
+            {"supported": ["2026-07-28"], "requested": "2026-08-01"},
+            caught.exception.data,
+        )
+
+    def test_non_product_request_methods_are_method_not_found(self) -> None:
+        rejected_methods = (
+            "initialize",
+            "resources/list",
+            "prompts/list",
+            "subscriptions/listen",
+            "ping",
+            "completion/complete",
+        )
+
+        for method in rejected_methods:
+            with self.subTest(method=method):
+
+                async def scenario(bound_method: str) -> None:
+                    server = MCPServer(
+                        "method-contract",
+                        middleware=[_contract()],
+                    )
+                    async with Client(
+                        server,
+                        mode=MCP_PROTOCOL_VERSION,
+                        raise_exceptions=True,
+                    ) as client:
+                        with self.assertRaises(MCPError) as caught:
+                            await client.session.send_request(
+                                Request(method=bound_method, params={}),
+                                EmptyResult,
+                            )
+                        error = caught.exception
+
+                    self.assertEqual(-32601, error.code)
+                    self.assertEqual(
+                        f"Method not found: {bound_method}",
+                        error.message,
+                    )
+                    self.assertIsNone(error.data)
+
+                anyio.run(scenario, method)
+
+    def test_discovery_replaces_only_product_owned_fields(self) -> None:
+        sdk_discovery = {
+            "resultType": "complete",
+            "ttlMs": 4321,
+            "cacheScope": "private",
+            "supportedVersions": ["2025-11-25", "2026-07-28"],
+            "capabilities": {"resources": {"subscribe": True}},
+            "instructions": "SDK instructions",
+            "_meta": {
+                "vendor.example/cacheTag": "preserve-me",
+                "io.modelcontextprotocol/serverInfo": {
+                    "name": "sdk-name",
+                    "version": "0.0.0",
+                },
+            },
+            "vendorExtension": {"enabled": True},
+        }
+        original_discovery = copy.deepcopy(sdk_discovery)
+
+        async def scenario() -> None:
+            async def call_next(_: ServerRequestContext[Any, Any]) -> HandlerResult:
+                return sdk_discovery
+
+            result = await _contract()(_context("server/discover"), call_next)
+
+            self.assertEqual(
+                {
+                    "resultType": "complete",
+                    "ttlMs": 4321,
+                    "cacheScope": "private",
+                    "supportedVersions": ["2026-07-28"],
+                    "capabilities": {"tools": {"listChanged": False}},
+                    "instructions": "Use only the advertised tools.",
+                    "_meta": {
+                        "vendor.example/cacheTag": "preserve-me",
+                        "io.modelcontextprotocol/serverInfo": {
+                            "name": "prefab-sentinel-test",
+                            "version": "9.8.7",
+                        },
+                    },
+                    "vendorExtension": {"enabled": True},
+                },
+                result,
+            )
+            self.assertEqual(original_discovery, sdk_discovery)
+
+        anyio.run(scenario)
+
+    def test_non_dictionary_discovery_result_is_an_invariant_error(self) -> None:
+        async def scenario() -> None:
+            async def call_next(_: ServerRequestContext[Any, Any]) -> HandlerResult:
+                return None
+
+            await _contract()(_context("server/discover"), call_next)
+
+        with self.assertRaises(TypeError) as caught:
+            anyio.run(scenario)
+        self.assertEqual("server/discover handler must return a dictionary", str(caught.exception))
+
+    def test_cancellation_notification_delegates_to_sdk_dispatcher(self) -> None:
+        async def scenario() -> None:
+            delegated = False
+
+            async def call_next(_: ServerRequestContext[Any, Any]) -> HandlerResult:
+                nonlocal delegated
+                delegated = True
+                return None
+
+            result = await _contract()(
+                _context(
+                    "notifications/cancelled",
+                    protocol_version="2025-11-25",
+                    request_id=None,
+                ),
+                call_next,
+            )
+
+            self.assertTrue(delegated)
+            self.assertIsNone(result)
+
+        anyio.run(scenario)
+
+    def test_other_notifications_are_ignored(self) -> None:
+        async def scenario() -> None:
+            delegated = False
+
+            async def call_next(_: ServerRequestContext[Any, Any]) -> HandlerResult:
+                nonlocal delegated
+                delegated = True
+                return None
+
+            result = await _contract()(
+                _context(
+                    "notifications/roots/list_changed",
+                    protocol_version="2025-11-25",
+                    request_id=None,
+                ),
+                call_next,
+            )
+
+            self.assertFalse(delegated)
+            self.assertIsNone(result)
+
+        anyio.run(scenario)
+
+
+class TestSerializeToolCallsMiddleware(unittest.TestCase):
+    def test_two_clients_never_run_tool_handlers_concurrently(self) -> None:
+        async def scenario() -> None:
+            active = 0
+            maximum_active = 0
+            first_entered = anyio.Event()
+            two_active = anyio.Event()
+            release = anyio.Event()
+            second_dispatched = anyio.Event()
+
+            server = MCPServer("serialize-test", middleware=[SerializeToolCallsMiddleware()])
+
+            @server.tool()
+            async def gated_tool() -> str:
+                nonlocal active, maximum_active
+                active += 1
+                maximum_active = max(maximum_active, active)
+                if active == 1:
+                    first_entered.set()
+                if active == 2:
+                    two_active.set()
+                try:
+                    await release.wait()
+                    return "done"
+                finally:
+                    active -= 1
+
+            async with (
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as first,
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as second,
+            ):
+
+                async def first_call() -> None:
+                    await first.call_tool("gated_tool", {})
+
+                async def second_call() -> None:
+                    second_dispatched.set()
+                    await second.call_tool("gated_tool", {})
+
+                async with anyio.create_task_group() as task_group:
+                    task_group.start_soon(first_call)
+                    await first_entered.wait()
+                    task_group.start_soon(second_call)
+                    await second_dispatched.wait()
+                    with anyio.move_on_after(0.05):
+                        await two_active.wait()
+                    release.set()
+
+            self.assertFalse(two_active.is_set())
+            self.assertEqual(1, maximum_active)
+
+        anyio.run(scenario)
+
+    def test_list_and_discovery_bypass_a_held_tool_lock(self) -> None:
+        async def scenario() -> None:
+            tool_entered = anyio.Event()
+            release = anyio.Event()
+            server = MCPServer("non-tool-concurrency", middleware=[SerializeToolCallsMiddleware()])
+
+            @server.tool()
+            async def gated_tool() -> str:
+                tool_entered.set()
+                await release.wait()
+                return "done"
+
+            async with (
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as first,
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as second,
+            ):
+
+                async def tool_call() -> None:
+                    await first.call_tool("gated_tool", {})
+
+                async with anyio.create_task_group() as task_group:
+                    task_group.start_soon(tool_call)
+                    await tool_entered.wait()
+                    with anyio.fail_after(0.5):
+                        listed = await second.list_tools()
+                        discovered = await second.session.discover()
+                    self.assertEqual(["gated_tool"], [tool.name for tool in listed.tools])
+                    self.assertIn(MCP_PROTOCOL_VERSION, discovered.supported_versions)
+                    release.set()
+
+        anyio.run(scenario)
+
+    def test_handler_exception_releases_tool_lock(self) -> None:
+        async def scenario() -> None:
+            attempts = 0
+            server = MCPServer("handler-exception", middleware=[SerializeToolCallsMiddleware()])
+
+            @server.tool()
+            async def flaky_tool() -> str:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise RuntimeError("handler failed")
+                return "recovered"
+
+            async with Client(
+                server,
+                mode=MCP_PROTOCOL_VERSION,
+                raise_exceptions=True,
+            ) as client:
+                failed = await client.call_tool("flaky_tool", {})
+                self.assertTrue(failed.is_error)
+                self.assertIsInstance(failed.content[0], TextContent)
+                error_content = cast(TextContent, failed.content[0])
+                self.assertEqual(
+                    "Error executing tool flaky_tool: handler failed",
+                    error_content.text,
+                )
+
+                with anyio.fail_after(0.5):
+                    recovered = await client.call_tool("flaky_tool", {})
+
+            self.assertIs(recovered.is_error, False)
+            self.assertEqual({"result": "recovered"}, recovered.structured_content)
+            self.assertEqual(2, attempts)
+
+        anyio.run(scenario)
+
+    def test_async_handler_cancellation_releases_tool_lock(self) -> None:
+        async def scenario() -> None:
+            first_entered = anyio.Event()
+            second_entered = anyio.Event()
+            first_scope_ready = anyio.Event()
+            first_scope: list[anyio.CancelScope] = []
+            server = MCPServer("async-cancellation", middleware=[SerializeToolCallsMiddleware()])
+
+            @server.tool()
+            async def cancellable_tool(label: str) -> str:
+                if label == "first":
+                    first_entered.set()
+                    await anyio.sleep_forever()
+                second_entered.set()
+                return label
+
+            async with (
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as first,
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as second,
+            ):
+
+                async def cancelled_call() -> None:
+                    with anyio.CancelScope() as scope:
+                        first_scope.append(scope)
+                        first_scope_ready.set()
+                        await first.call_tool("cancellable_tool", {"label": "first"})
+
+                async with anyio.create_task_group() as task_group:
+                    task_group.start_soon(cancelled_call)
+                    await first_scope_ready.wait()
+                    await first_entered.wait()
+                    first_scope[0].cancel()
+                    with anyio.fail_after(0.5):
+                        result = await second.call_tool("cancellable_tool", {"label": "second"})
+                    self.assertIs(result.is_error, False)
+                    self.assertEqual({"result": "second"}, result.structured_content)
+                    self.assertTrue(second_entered.is_set())
+
+        anyio.run(scenario)
+
+    def test_cancelled_sync_worker_holds_lock_until_worker_returns(self) -> None:
+        async def scenario() -> None:
+            worker_entered = threading.Event()
+            release_worker = threading.Event()
+            worker_returned = threading.Event()
+            second_entered = threading.Event()
+            second_observations: list[bool] = []
+            first_scope_ready = anyio.Event()
+            second_reached_boundary = anyio.Event()
+            second_completed = anyio.Event()
+            first_scope: list[anyio.CancelScope] = []
+            requests_at_boundary = 0
+
+            async def boundary_probe(
+                ctx: ServerRequestContext[Any, Any],
+                call_next: CallNext,
+            ) -> HandlerResult:
+                nonlocal requests_at_boundary
+                if ctx.method == "tools/call":
+                    requests_at_boundary += 1
+                    if requests_at_boundary == 2:
+                        second_reached_boundary.set()
+                return await call_next(ctx)
+
+            server = MCPServer(
+                "sync-cancellation",
+                middleware=[boundary_probe, SerializeToolCallsMiddleware()],
+            )
+
+            @server.tool()
+            def sync_tool(label: str) -> str:
+                if label == "first":
+                    worker_entered.set()
+                    if not release_worker.wait(timeout=2.0):
+                        raise RuntimeError("test worker release timed out")
+                    worker_returned.set()
+                else:
+                    second_observations.append(worker_returned.is_set())
+                    second_entered.set()
+                return label
+
+            async with (
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as first,
+                Client(server, mode=MCP_PROTOCOL_VERSION, raise_exceptions=True) as second,
+            ):
+
+                async def cancelled_call() -> None:
+                    with anyio.CancelScope() as scope:
+                        first_scope.append(scope)
+                        first_scope_ready.set()
+                        await first.call_tool("sync_tool", {"label": "first"})
+
+                async def second_call() -> None:
+                    await second.call_tool("sync_tool", {"label": "second"})
+                    second_completed.set()
+
+                async with anyio.create_task_group() as task_group:
+                    task_group.start_soon(cancelled_call)
+                    await first_scope_ready.wait()
+                    with anyio.fail_after(0.5):
+                        self.assertTrue(await anyio.to_thread.run_sync(worker_entered.wait, 0.5))
+                    first_scope[0].cancel()
+                    task_group.start_soon(second_call)
+                    with anyio.fail_after(0.5):
+                        await second_reached_boundary.wait()
+                    self.assertFalse(second_entered.is_set())
+                    release_worker.set()
+                    with anyio.fail_after(0.5):
+                        await second_completed.wait()
+
+            self.assertTrue(worker_returned.is_set())
+            self.assertTrue(second_entered.is_set())
+            self.assertEqual([True], second_observations)
+
+        anyio.run(scenario)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import shutil
@@ -15,6 +14,8 @@ from typing import Any, cast
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from mcp import Client
+from mcp_types import CallToolResult, TextContent
 
 import prefab_sentinel.editor_bridge as editor_bridge
 from prefab_sentinel.contracts import Severity, ToolResponse
@@ -25,6 +26,7 @@ from prefab_sentinel.mcp_validation import require_change_reason
 from prefab_sentinel.session import ProjectSession
 from prefab_sentinel.symbol_tree_builder import build_symbol_tree
 from tests._assertion_helpers import assert_error_envelope
+from tests._mcp_test_support import call_tool_result, run, structured_payload
 from tests.yaml_helpers import (
     YAML_HEADER,
     make_gameobject,
@@ -33,27 +35,6 @@ from tests.yaml_helpers import (
     make_monobehaviour,
     make_transform,
 )
-
-
-def _run(coro: Any) -> Any:
-    """Run an async coroutine synchronously.
-
-    When the result is a call_tool response (list[TextContent]), normalises
-    across MCP versions to always return a 2-tuple (content_list, parsed_dict)
-    so tests can use ``_, result = _run(server.call_tool(...))``.
-
-    For other coroutines (e.g. list_tools), returns the raw result unchanged.
-    """
-    raw = asyncio.run(coro)
-    if isinstance(raw, tuple) and len(raw) == 2 and isinstance(raw[1], dict):
-        # MCP 1.6+ Python 3.11 venv: (content_list, dict)
-        return raw
-    if isinstance(raw, list) and raw and hasattr(raw[0], "text"):
-        # MCP 1.6+ Python 3.12: list[TextContent] from call_tool
-        parsed = json.loads(raw[0].text)
-        return raw, parsed
-    # list_tools() or other coroutines: return as-is
-    return raw
 
 
 def _simple_prefab() -> str:
@@ -148,12 +129,29 @@ class TestRequireChangeReason(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestMcpTestSupport(unittest.TestCase):
+    def test_structured_payload_rejects_error_before_missing_payload(self) -> None:
+        result = CallToolResult(
+            content=[],
+            structured_content=None,
+            is_error=True,
+        )
+
+        with self.assertRaises(AssertionError) as cm:
+            structured_payload(result)
+
+        self.assertEqual(
+            "expected CallToolResult with is_error=False, observed True",
+            str(cm.exception),
+        )
+
+
 class TestToolRegistration(unittest.TestCase):
     """Verify all expected tools are registered on the server."""
 
     def test_all_tools_registered(self) -> None:
         server = create_server()
-        tools = _run(server.list_tools())
+        tools = run(server.list_tools())
         tool_names = {t.name for t in tools}
         expected = {
             # Existing 15 tools
@@ -276,7 +274,7 @@ class TestToolRegistration(unittest.TestCase):
 
     def test_tool_count(self) -> None:
         server = create_server()
-        tools = _run(server.list_tools())
+        tools = run(server.list_tools())
         # Issue #195 added the dedicated ``editor_create_ui_element``
         # tool, bringing the registered surface from 75 to 76; issues
         # #233 / #236 / #240 / #242 / #243 add 9 more tools, bringing
@@ -323,7 +321,7 @@ class TestToolsCatalogDoc(unittest.TestCase):
     def test_catalog_header_count_equals_registered_surface(self) -> None:
         import re
 
-        registered = len(_run(create_server().list_tools()))
+        registered = len(run(create_server().list_tools()))
         header = self._TOOLS_MD.read_text(encoding="utf-8").splitlines()[2]
         match = re.search(r"現在 (\d+) 件", header)
         assert match is not None, "docs/tools.md header must state the tool count as '現在 N 件'."
@@ -610,8 +608,7 @@ class TestSymbolTools(unittest.TestCase):
     def test_get_unity_symbols_depth0(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab), "depth": 0},
                 )
@@ -629,8 +626,7 @@ class TestSymbolTools(unittest.TestCase):
     def test_get_unity_symbols_depth1(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab), "depth": 1},
                 )
@@ -644,8 +640,7 @@ class TestSymbolTools(unittest.TestCase):
     def test_find_unity_symbol_found(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "find_unity_symbol",
                     {"asset_path": str(prefab), "symbol_path": "Cube"},
                 )
@@ -658,8 +653,7 @@ class TestSymbolTools(unittest.TestCase):
     def test_find_unity_symbol_not_found(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "find_unity_symbol",
                     {"asset_path": str(prefab), "symbol_path": "NonExistent"},
                 )
@@ -671,8 +665,7 @@ class TestSymbolTools(unittest.TestCase):
     def test_find_unity_symbol_component_path(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "find_unity_symbol",
                     {"asset_path": str(prefab), "symbol_path": "Cube/MeshRenderer"},
                 )
@@ -681,27 +674,32 @@ class TestSymbolTools(unittest.TestCase):
             self.assertEqual("MeshRenderer", result["matches"][0]["name"])
 
     def test_get_unity_symbols_file_not_found(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError
+        from mcp.server.mcpserver.exceptions import ToolError
 
         with self.assertRaises(ToolError) as cm:
-            _run(
-                self.server.call_tool(
-                    "get_unity_symbols",
-                    {"asset_path": "/nonexistent/test.prefab"},
-                )
+            call_tool_result(
+                self.server,
+                "get_unity_symbols",
+                {"asset_path": "/nonexistent/test.prefab"},
             )
+
         self.assertIsInstance(cm.exception, ToolError)
-        self.assertTrue(str(cm.exception))
+        self.assertEqual(
+            (
+                "Error executing tool get_unity_symbols: "
+                "File not found: /nonexistent/test.prefab"
+            ),
+            str(cm.exception),
+        )
 
     def test_get_unity_symbols_resolution_failure_raises_tool_error(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError
+        from mcp.server.mcpserver.exceptions import ToolError
 
         with tempfile.TemporaryDirectory() as td:
             server = create_server(project_root=td)
             with patch.object(Path, "resolve", side_effect=OSError("resolve failed")):
                 with self.assertRaises(ToolError) as cm:
-                    _run(
-                        server.call_tool(
+                    (call_tool_result(server,
                             "get_unity_symbols",
                             {"asset_path": "Assets/Test.prefab"},
                         )
@@ -735,8 +733,7 @@ class TestGetUnitySymbolsDetail(unittest.TestCase):
     def test_detail_summary_returns_minimal_nodes(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab), "depth": 1, "detail": "summary"},
                 )
@@ -751,8 +748,7 @@ class TestGetUnitySymbolsDetail(unittest.TestCase):
     def test_detail_fields_returns_field_names(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab), "depth": 1, "detail": "fields"},
                 )
@@ -768,8 +764,7 @@ class TestGetUnitySymbolsDetail(unittest.TestCase):
     def test_default_depth_none_returns_full_tree(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab)},
                 )
@@ -781,8 +776,7 @@ class TestGetUnitySymbolsDetail(unittest.TestCase):
     def test_explicit_depth_1_limits_children(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab), "depth": 1},
                 )
@@ -796,8 +790,7 @@ class TestGetUnitySymbolsDetail(unittest.TestCase):
     def test_response_includes_detail_key(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab), "detail": "summary"},
                 )
@@ -807,8 +800,7 @@ class TestGetUnitySymbolsDetail(unittest.TestCase):
     def test_response_detail_key_defaults_to_full(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "get_unity_symbols",
                     {"asset_path": str(prefab)},
                 )
@@ -841,8 +833,7 @@ class TestFindUnitySymbolIncludeFields(unittest.TestCase):
     def test_include_fields_false_default_no_properties(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "find_unity_symbol",
                     {"asset_path": str(prefab), "symbol_path": "Player/MonoBehaviour"},
                 )
@@ -853,8 +844,7 @@ class TestFindUnitySymbolIncludeFields(unittest.TestCase):
     def test_include_fields_true_has_properties(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             prefab = self._write_prefab_with_mb(Path(td))
-            _, result = _run(
-                self.server.call_tool(
+            result = structured_payload(call_tool_result(self.server,
                     "find_unity_symbol",
                     {
                         "asset_path": str(prefab),
@@ -889,8 +879,7 @@ class TestFindUnitySymbolIncludeFields(unittest.TestCase):
                 mock_orch = MagicMock()
                 mock_orch.prefab_variant.resolve_chain_values_with_origin.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "find_unity_symbol",
                         {
                             "asset_path": str(p),
@@ -919,8 +908,7 @@ class TestSymbolToolsWithMonoBehaviour(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / "player.prefab"
             p.write_text(text, encoding="utf-8")
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "find_unity_symbol",
                     {
                         "asset_path": str(p),
@@ -942,8 +930,7 @@ class TestGetUnitySymbolsExpandNested(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
             with patch("prefab_sentinel.session_cache.build_symbol_tree", wraps=build_symbol_tree) as mock_build:
-                _run(
-                    server.call_tool(
+                (call_tool_result(server,
                         "get_unity_symbols",
                         {"asset_path": str(p), "expand_nested": True},
                     )
@@ -982,8 +969,7 @@ class TestGetUnitySymbolsExpandNested(unittest.TestCase):
                 "prefab_sentinel.session_cache.collect_project_guid_index",
                 return_value={child_guid: child_path},
             ):
-                _, discovery = _run(
-                    server.call_tool(
+                discovery = structured_payload(call_tool_result(server,
                         "get_unity_symbols",
                         {"asset_path": str(parent_path), "depth": 3, "expand_nested": True},
                     )
@@ -992,8 +978,7 @@ class TestGetUnitySymbolsExpandNested(unittest.TestCase):
                     child for child in discovery["symbols"][0]["children"] if child["kind"] == "prefab_instance"
                 )
                 lookup = marker["children"][0]["children"][1]["lookup"]
-                _, found = _run(
-                    server.call_tool(
+                found = structured_payload(call_tool_result(server,
                         "find_unity_symbol",
                         {
                             "asset_path": lookup["asset_path"],
@@ -1045,8 +1030,7 @@ class TestOrchestratorTools(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "validate_refs",
                     {"scope": "/some/path"},
                 )
@@ -1089,8 +1073,7 @@ class TestOrchestratorTools(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "validate_refs",
                     {"scope": "/some/path", "refresh_guid_index": True},
                 )
@@ -1112,8 +1095,7 @@ class TestOrchestratorTools(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_wiring",
                     {"asset_path": "/some/test.prefab"},
                 )
@@ -1149,8 +1131,7 @@ class TestOrchestratorTools(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "inspect_wiring",
                     {
                         "asset_path": "/some/test.prefab",
@@ -1195,8 +1176,7 @@ class TestOrchestratorTools(unittest.TestCase):
                 patch.object(ProjectSession, "project_root", project_root),
             ):
                 mock_cls.default.return_value = mock_orch
-                _run(
-                    server.call_tool(
+                (call_tool_result(server,
                         "inspect_wiring",
                         {
                             "asset_path": "Assets/Base.prefab",
@@ -1232,8 +1212,7 @@ class TestOrchestratorTools(unittest.TestCase):
                 patch.object(ProjectSession, "project_root", project_root),
             ):
                 mock_cls.default.return_value = mock_orch
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "inspect_wiring",
                         {"asset_path": "Assets/Base.prefab"},
                     )
@@ -1258,8 +1237,7 @@ class TestOrchestratorTools(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_wiring",
                     {
                         "asset_path": "/some/test.prefab",
@@ -1302,8 +1280,7 @@ class TestOrchestratorTools(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "find_referencing_assets",
                     {"asset_or_guid": "abcd1234abcd1234abcd1234abcd1234"},
                 )
@@ -1327,8 +1304,7 @@ class TestOrchestratorTools(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_variant",
                     {"asset_path": "/some/variant.prefab", "show_origin": True},
                 )
@@ -1358,8 +1334,7 @@ class TestDiffUnitySymbolsTool(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "diff_unity_symbols",
                     {"asset_path": "/some/variant.prefab"},
                 )
@@ -1381,8 +1356,7 @@ class TestDiffUnitySymbolsTool(unittest.TestCase):
 
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "diff_unity_symbols",
                     {"asset_path": "/v.prefab", "component_filter": "speed"},
                 )
@@ -1411,8 +1385,7 @@ class TestFindUnitySymbolShowOrigin(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "find_unity_symbol",
                     {
                         "asset_path": str(p),
@@ -1473,8 +1446,7 @@ class TestFindUnitySymbolShowOrigin(unittest.TestCase):
                 mock_orch.prefab_variant.resolve_chain_values_with_origin.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "find_unity_symbol",
                         {
                             "asset_path": str(p),
@@ -1527,8 +1499,7 @@ class TestFindUnitySymbolShowOrigin(unittest.TestCase):
                 mock_orch.prefab_variant.resolve_chain_values_with_origin.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "find_unity_symbol",
                         {
                             "asset_path": str(p),
@@ -1579,8 +1550,7 @@ class TestFindUnitySymbolShowOrigin(unittest.TestCase):
                 mock_orch.prefab_variant.resolve_chain_values_with_origin.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "find_unity_symbol",
                         {
                             "asset_path": str(p),
@@ -1623,8 +1593,7 @@ class TestFindUnitySymbolShowOrigin(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 with self.assertLogs("prefab_sentinel.mcp_tools_symbols", level="DEBUG") as cm:
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "find_unity_symbol",
                             {
                                 "asset_path": str(p),
@@ -1690,8 +1659,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -1723,8 +1691,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -1769,8 +1736,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = failed_response
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=temporary)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(asset_path),
@@ -1844,8 +1810,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 ) as invalidate_symbol_tree,
             ):
                 server = create_server(project_root=temporary)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(asset_path),
@@ -1883,8 +1848,7 @@ class TestSetPropertyTool(unittest.TestCase):
             escaped_target = (Path(project_directory).parent / "secret.prefab").resolve()
             with patch.object(ProjectSession, "get_orchestrator") as get_orchestrator:
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": "../secret.prefab",
@@ -1932,8 +1896,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 )
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=temporary)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(asset_path),
@@ -2009,8 +1972,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 )
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=temporary)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(asset_path),
@@ -2072,8 +2034,7 @@ class TestSetPropertyTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_property",
                     {
                         "asset_path": str(p),
@@ -2098,8 +2059,7 @@ class TestSetPropertyTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_property",
                     {
                         "asset_path": str(p),
@@ -2129,8 +2089,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -2175,8 +2134,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server_with_root.call_tool(
+                result = structured_payload(call_tool_result(server_with_root,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -2200,8 +2158,7 @@ class TestSetPropertyTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_property",
                     {
                         "asset_path": str(p),
@@ -2230,8 +2187,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _run(
-                    server.call_tool(
+                (call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -2261,8 +2217,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _run(
-                    server.call_tool(
+                (call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -2301,8 +2256,7 @@ class TestSetPropertyTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -2322,8 +2276,7 @@ class TestSetPropertyTool(unittest.TestCase):
     def test_confirm_requires_change_reason(self) -> None:
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "set_property",
                 {
                     "asset_path": "Assets/DoesNotExist.prefab",
@@ -2365,8 +2318,7 @@ class TestListSerializedFieldsTool(unittest.TestCase):
         )
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_orch_cls:
             mock_orch_cls.default.return_value.list_serialized_fields.return_value = mock_resp
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "list_serialized_fields",
                     {"script_or_guid": "aabb"},
                 )
@@ -2388,8 +2340,7 @@ class TestListSerializedFieldsTool(unittest.TestCase):
         )
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_orch_cls:
             mock_orch_cls.default.return_value.list_serialized_fields.return_value = mock_resp
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "list_serialized_fields",
                     {"script_or_guid": "missing.cs"},
                 )
@@ -2424,8 +2375,7 @@ class TestValidateFieldRenameTool(unittest.TestCase):
         )
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_orch_cls:
             mock_orch_cls.default.return_value.validate_field_rename.return_value = mock_resp
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "validate_field_rename",
                     {
                         "script_or_guid": "aabb",
@@ -2452,8 +2402,7 @@ class TestValidateFieldRenameTool(unittest.TestCase):
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_orch_cls:
             mock_orch = mock_orch_cls.default.return_value
             mock_orch.validate_field_rename.return_value = mock_resp
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "validate_field_rename",
                     {
                         "script_or_guid": "aabb",
@@ -2498,8 +2447,7 @@ class TestCheckFieldCoverageTool(unittest.TestCase):
         )
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_orch_cls:
             mock_orch_cls.default.return_value.check_field_coverage.return_value = mock_resp
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "check_field_coverage",
                     {"scope": "Assets/"},
                 )
@@ -2516,7 +2464,7 @@ class TestSessionTools(unittest.TestCase):
 
     def test_get_project_status_before_activation(self) -> None:
         server = create_server()
-        _, result = _run(server.call_tool("get_project_status", {}))
+        result = structured_payload(call_tool_result(server,"get_project_status", {}))
 
         self.assertTrue(result["success"])
         self.assertEqual("SESSION_STATUS", result["code"])
@@ -2547,8 +2495,7 @@ class TestSessionTools(unittest.TestCase):
         mock_build.return_value = {"g1": "ScriptA"}
 
         server = create_server()
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "activate_project",
                 {"scope": "Assets/MyScope"},
             )
@@ -2585,14 +2532,14 @@ class TestSessionTools(unittest.TestCase):
         server = create_server()
 
         # Before: not activated
-        _, before = _run(server.call_tool("get_project_status", {}))
+        before = structured_payload(call_tool_result(server,"get_project_status", {}))
         self.assertFalse(before["data"]["orchestrator_cached"])
 
         # Activate
-        _run(server.call_tool("activate_project", {"scope": "Assets/Scope"}))
+        (call_tool_result(server,"activate_project", {"scope": "Assets/Scope"}))
 
         # After: caches warm
-        _, after = _run(server.call_tool("get_project_status", {}))
+        after = structured_payload(call_tool_result(server,"get_project_status", {}))
         self.assertTrue(after["data"]["orchestrator_cached"])
         self.assertTrue(after["data"]["script_map_cached"])
 
@@ -2612,8 +2559,7 @@ class TestSessionTools(unittest.TestCase):
             mock_resolve.return_value = assets / "MyScope"
 
             server = create_server()
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "activate_project",
                     {"scope": "Assets/MyScope", "project_root": tmpdir},
                 )
@@ -2625,8 +2571,7 @@ class TestSessionTools(unittest.TestCase):
     def test_activate_project_with_invalid_project_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             server = create_server()
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "activate_project",
                     {"scope": "Assets/X", "project_root": tmpdir},
                 )
@@ -2651,8 +2596,7 @@ class TestSessionTools(unittest.TestCase):
         mock_build.return_value = {"g1": "ScriptA"}
 
         server = create_server()
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "activate_project",
                 {"scope": "Assets/MyScope"},
             )
@@ -2706,8 +2650,7 @@ class TestAddComponentTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "add_component",
                         {
                             "asset_path": str(p),
@@ -2740,8 +2683,7 @@ class TestAddComponentTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "add_component",
                         {
                             "asset_path": str(p),
@@ -2765,8 +2707,7 @@ class TestAddComponentTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "add_component",
                     {
                         "asset_path": str(p),
@@ -2790,8 +2731,7 @@ class TestAddComponentTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "add_component",
                     {
                         "asset_path": str(p),
@@ -2818,8 +2758,7 @@ class TestAddComponentTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "add_component",
                         {
                             "asset_path": str(p),
@@ -2850,8 +2789,7 @@ class TestAddComponentTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "add_component",
                         {
                             "asset_path": str(p),
@@ -2870,8 +2808,7 @@ class TestAddComponentTool(unittest.TestCase):
     def test_confirm_requires_change_reason(self) -> None:
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "add_component",
                 {
                     "asset_path": "Assets/DoesNotExist.prefab",
@@ -2926,8 +2863,7 @@ class TestRemoveComponentTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "remove_component",
                         {
                             "asset_path": str(p),
@@ -2958,8 +2894,7 @@ class TestRemoveComponentTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "remove_component",
                         {
                             "asset_path": str(p),
@@ -2983,8 +2918,7 @@ class TestRemoveComponentTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "remove_component",
                     {
                         "asset_path": str(p),
@@ -3007,8 +2941,7 @@ class TestRemoveComponentTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "remove_component",
                     {
                         "asset_path": str(p),
@@ -3034,8 +2967,7 @@ class TestRemoveComponentTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "remove_component",
                         {
                             "asset_path": str(p),
@@ -3052,8 +2984,7 @@ class TestRemoveComponentTool(unittest.TestCase):
     def test_confirm_requires_change_reason(self) -> None:
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "remove_component",
                 {
                     "asset_path": "Assets/DoesNotExist.prefab",
@@ -3081,7 +3012,7 @@ class TestScopeFallback(unittest.TestCase):
         ):
             mock_orch = mock_cls.default.return_value
             mock_orch.validate_refs.return_value = mock_resp
-            _run(server.call_tool("validate_refs", {"scope": "Assets/Explicit"}))
+            (call_tool_result(server,"validate_refs", {"scope": "Assets/Explicit"}))
             self.assertEqual(
                 "Assets/Resolved",
                 mock_orch.validate_refs.call_args.kwargs["scope"],
@@ -3104,8 +3035,7 @@ class TestScopeFallback(unittest.TestCase):
         ):
             mock_orch = mock_cls.default.return_value
             mock_orch.reference_resolver.where_used.return_value = mock_step
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "find_referencing_assets",
                     {"asset_or_guid": "abcd1234abcd1234abcd1234abcd1234"},
                 )
@@ -3125,8 +3055,7 @@ class TestScopeFallback(unittest.TestCase):
         ):
             mock_orch = mock_cls.default.return_value
             mock_orch.validate_field_rename.return_value = mock_resp
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "validate_field_rename",
                     {
                         "script_or_guid": "aabb",
@@ -3150,7 +3079,7 @@ class TestScopeFallback(unittest.TestCase):
         ):
             mock_orch = mock_cls.default.return_value
             mock_orch.check_field_coverage.return_value = mock_resp
-            _run(server.call_tool("check_field_coverage", {"scope": "Assets/Explicit"}))
+            (call_tool_result(server,"check_field_coverage", {"scope": "Assets/Explicit"}))
             self.assertEqual(
                 "Assets/Resolved",
                 mock_orch.check_field_coverage.call_args.kwargs["scope"],
@@ -3182,8 +3111,7 @@ class TestFindReferencingAssetsDirectPayload(unittest.TestCase):
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_orch = mock_cls.default.return_value
             mock_orch.reference_resolver.where_used.return_value = mock_step
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "find_referencing_assets",
                     {"asset_or_guid": "abcd1234abcd1234abcd1234abcd1234"},
                 )
@@ -3221,8 +3149,7 @@ class TestFindReferencingAssetsDirectPayload(unittest.TestCase):
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_orch = mock_cls.default.return_value
             mock_orch.reference_resolver.where_used.return_value = mock_step
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "find_referencing_assets",
                     {"asset_or_guid": "f" * 32},
                 )
@@ -3259,8 +3186,7 @@ class TestFindReferencingAssetsDirectPayload(unittest.TestCase):
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_orch = mock_cls.default.return_value
             mock_orch.reference_resolver.where_used.return_value = mock_step
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "find_referencing_assets",
                     {"asset_or_guid": "x" * 32, "max_results": 1},
                 )
@@ -3270,7 +3196,7 @@ class TestFindReferencingAssetsDirectPayload(unittest.TestCase):
         self.assertEqual(50, result["metadata"]["total_count"])
 
     def test_error_raises_tool_error(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError
+        from mcp.server.mcpserver.exceptions import ToolError
 
         server = create_server()
         mock_step = ToolResponse(
@@ -3285,8 +3211,7 @@ class TestFindReferencingAssetsDirectPayload(unittest.TestCase):
             mock_orch = mock_cls.default.return_value
             mock_orch.reference_resolver.where_used.return_value = mock_step
             with self.assertRaises(ToolError) as ctx:
-                _run(
-                    server.call_tool(
+                (call_tool_result(server,
                         "find_referencing_assets",
                         {"asset_or_guid": "x" * 32},
                     )
@@ -3305,7 +3230,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
         server = create_server()
         mock_response = {"success": True, "data": {"output_path": "/tmp/shot.png"}}
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value=mock_response) as mock_send:
-            _, result = _run(server.call_tool("editor_screenshot", {"view": "game", "width": 1920}))
+            result = structured_payload(call_tool_result(server,"editor_screenshot", {"view": "game", "width": 1920}))
         self.assertEqual(mock_response, result)
         # Default refresh=True: refresh + capture = 2 calls
         self.assertEqual(mock_send.call_count, 2)
@@ -3313,7 +3238,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_screenshot_defaults(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_screenshot", {}))
+            (call_tool_result(server,"editor_screenshot", {}))
         # Default refresh=True means 2 calls: refresh + capture
         self.assertEqual(mock_send.call_count, 2)
         mock_send.assert_any_call(action="capture_screenshot", view="scene", width=0, height=0)
@@ -3321,7 +3246,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_screenshot_refresh_true_calls_refresh_then_capture(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_screenshot", {"refresh": True}))
+            (call_tool_result(server,"editor_screenshot", {"refresh": True}))
         self.assertEqual(mock_send.call_count, 2)
         calls = mock_send.call_args_list
         self.assertEqual(calls[0], call(action="refresh_asset_database"))
@@ -3330,11 +3255,11 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_screenshot_refresh_false_skips_refresh(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_screenshot", {"refresh": False}))
+            (call_tool_result(server,"editor_screenshot", {"refresh": False}))
         mock_send.assert_called_once_with(action="capture_screenshot", view="scene", width=0, height=0)
 
     def test_editor_screenshot_refresh_failure_stops_before_capture(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError
+        from mcp.server.mcpserver.exceptions import ToolError
 
         server = create_server()
         with patch(
@@ -3342,7 +3267,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
             side_effect=Exception("refresh failed"),
         ) as mock_send:
             with self.assertRaises(ToolError) as ctx:
-                _run(server.call_tool("editor_screenshot", {"refresh": True}))
+                (call_tool_result(server,"editor_screenshot", {"refresh": True}))
 
         mock_send.assert_called_once_with(action="refresh_asset_database")
         self.assertIn("refresh failed", str(ctx.exception))
@@ -3350,8 +3275,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_select_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_select",
                     {
                         "hierarchy_path": "/Canvas/Panel",
@@ -3369,14 +3293,14 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_select_omits_empty_prefab_asset_path(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_select", {"hierarchy_path": "/Root/Child"}))
+            (call_tool_result(server,"editor_select", {"hierarchy_path": "/Root/Child"}))
         _, kwargs = mock_send.call_args
         self.assertNotIn("prefab_asset_path", kwargs)
 
     def test_editor_frame_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_frame", {"zoom": 2.5}))
+            (call_tool_result(server,"editor_frame", {"zoom": 2.5}))
         mock_send.assert_called_once_with(
             action="frame_selected",
             zoom=2.5,
@@ -3386,7 +3310,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_frame_defaults(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_frame", {}))
+            (call_tool_result(server,"editor_frame", {}))
         mock_send.assert_called_once_with(
             action="frame_selected",
             zoom=0.0,
@@ -3419,7 +3343,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_view.send_action",
             return_value=bridge_response,
         ):
-            _, result = _run(server.call_tool("editor_frame", {"zoom": 1.0}))
+            result = structured_payload(call_tool_result(server,"editor_frame", {"zoom": 1.0}))
         # Wrapper must preserve the bounds payload byte-for-byte.
         self.assertEqual(bridge_response, result)
         self.assertEqual([0.0, 1.5, 0.0], result["data"]["bounds_center"])
@@ -3428,7 +3352,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_get_camera_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_get_camera", {}))
+            (call_tool_result(server,"editor_get_camera", {}))
         mock_send.assert_called_once_with(action="get_camera")
 
     def test_editor_set_camera_mode_b(self) -> None:
@@ -3437,22 +3361,21 @@ class TestEditorReadOnlyTools(unittest.TestCase):
         # MCP surface and must not appear on the bridge call kwargs.
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_set_camera", {"yaw": 45.0, "pitch": 15.0, "size": 3.0}))
+            (call_tool_result(server,"editor_set_camera", {"yaw": 45.0, "pitch": 15.0, "size": 3.0}))
         mock_send.assert_called_once_with(action="set_camera", yaw=45.0, pitch=15.0, size=3.0)
         self.assertNotIn("distance", mock_send.call_args.kwargs)
 
     def test_editor_set_camera_defaults(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_set_camera", {}))
+            (call_tool_result(server,"editor_set_camera", {}))
         mock_send.assert_called_once_with(action="set_camera")
 
     def test_editor_list_children_delegates(self) -> None:
         server = create_server()
         mock_response = {"success": True, "data": {"children": ["A", "B"]}}
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value=mock_response):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_list_children",
                     {
                         "hierarchy_path": "/Root",
@@ -3465,26 +3388,25 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_list_children_default_depth(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_list_children", {"hierarchy_path": "/Root"}))
+            (call_tool_result(server,"editor_list_children", {"hierarchy_path": "/Root"}))
         mock_send.assert_called_once_with(action="list_children", hierarchy_path="/Root", depth=1)
 
     def test_editor_list_materials_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_list_materials", {"hierarchy_path": "/Body"}))
+            (call_tool_result(server,"editor_list_materials", {"hierarchy_path": "/Body"}))
         mock_send.assert_called_once_with(action="list_materials", hierarchy_path="/Body")
 
     def test_editor_list_roots_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_list_roots", {}))
+            (call_tool_result(server,"editor_list_roots", {}))
         mock_send.assert_called_once_with(action="list_roots")
 
     def test_editor_get_material_property_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_get_material_property",
                     {
                         "hierarchy_path": "/Body",
@@ -3503,8 +3425,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_get_material_property_default_property_name(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_get_material_property",
                     {
                         "hierarchy_path": "/Body",
@@ -3522,8 +3443,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
     def test_editor_console_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_console",
                     {
                         "max_entries": 50,
@@ -3547,7 +3467,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
         """Issue #113: defaults are newest-first + 60-second window + empty cursor."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_console", {}))
+            (call_tool_result(server,"editor_console", {}))
         mock_send.assert_called_once_with(
             action="capture_console_logs",
             max_entries=200,
@@ -3563,7 +3483,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
         """Issue #113: explicit cursor token forwards verbatim."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_console", {"cursor": "opaque-token-42"}))
+            (call_tool_result(server,"editor_console", {"cursor": "opaque-token-42"}))
         mock_send.assert_called_once_with(
             action="capture_console_logs",
             max_entries=200,
@@ -3579,7 +3499,7 @@ class TestEditorReadOnlyTools(unittest.TestCase):
         """Issue #113: explicit ordering keyword forwards verbatim."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_console", {"order": "oldest_first"}))
+            (call_tool_result(server,"editor_console", {"order": "oldest_first"}))
         mock_send.assert_called_once_with(
             action="capture_console_logs",
             max_entries=200,
@@ -3601,7 +3521,7 @@ class TestEditorSideEffectTools(unittest.TestCase):
         # transport budget to cover a compile plus domain reload.
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _, result = _run(server.call_tool("editor_refresh", {}))
+            result = structured_payload(call_tool_result(server,"editor_refresh", {}))
         mock_send.assert_called_once_with(
             action="refresh_asset_database",
             timeout_sec=65,
@@ -3615,7 +3535,7 @@ class TestEditorSideEffectTools(unittest.TestCase):
         # ``editor_recompile_and_wait`` bridge action.
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_recompile", {}))
+            (call_tool_result(server,"editor_recompile", {}))
         mock_send.assert_called_once_with(
             action="editor_recompile_and_wait",
             timeout_sec=65,
@@ -3625,13 +3545,13 @@ class TestEditorSideEffectTools(unittest.TestCase):
     def test_editor_run_tests_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_run_tests", {}))
+            (call_tool_result(server,"editor_run_tests", {}))
         mock_send.assert_called_once_with(action="run_integration_tests", timeout_sec=300)
 
     def test_editor_run_tests_custom_timeout(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_view.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_run_tests", {"timeout_sec": 600}))
+            (call_tool_result(server,"editor_run_tests", {"timeout_sec": 600}))
         mock_send.assert_called_once_with(action="run_integration_tests", timeout_sec=600)
 
 
@@ -3643,7 +3563,7 @@ class TestEditorRecompileNaming(unittest.TestCase):
 
     def test_blocking_recompile_registered_and_fire_and_return_absent(self) -> None:
         server = create_server()
-        tools = _run(server.list_tools())
+        tools = run(server.list_tools())
         names = {t.name for t in tools}
         self.assertIn(
             "editor_recompile",
@@ -3665,7 +3585,7 @@ class TestEditorRecompileNaming(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_view.send_action",
             return_value={"success": True},
         ) as mock_send:
-            _run(server.call_tool("editor_recompile", {"timeout_sec": 30.0}))
+            (call_tool_result(server,"editor_recompile", {"timeout_sec": 30.0}))
         mock_send.assert_called_once_with(
             action="editor_recompile_and_wait",
             timeout_sec=35,
@@ -3719,7 +3639,7 @@ class TestEditorAuditReclassification(unittest.TestCase):
                         "prefab_sentinel.mcp_tools_editor_batch.send_action",
                     ) as b,
                 ):
-                    _, result = _run(server.call_tool(tool_name, args))
+                    result = structured_payload(call_tool_result(server,tool_name, args))
                     w.assert_not_called()
                     o.assert_not_called()
                     b.assert_not_called()
@@ -3729,32 +3649,23 @@ class TestEditorAuditReclassification(unittest.TestCase):
                     severity="error",
                 )
 
-    def test_de_audited_tools_reject_confirm_argument(self) -> None:
-        """T-49-2: the two de-audited tools raise TypeError on a confirm arg."""
-        server = create_server()
-        tools = server._tool_manager._tools
+    def test_de_audited_tools_omit_legacy_audit_arguments_from_schema(self) -> None:
+        """T-49-2: de-audited tools do not publish legacy audit arguments."""
+        tools_by_name = {
+            tool.name: tool for tool in run(create_server().list_tools())
+        }
+
         for tool_name in (
             "editor_batch_set_blend_shape",
             "editor_apply_animation_clip",
         ):
             with self.subTest(tool=tool_name):
-                fn = tools[tool_name].fn
-                with self.assertRaises(TypeError) as cm:
-                    if tool_name == "editor_batch_set_blend_shape":
-                        fn(
-                            hierarchy_path="/Obj",
-                            shapes=[],
-                            confirm=True,
-                            change_reason="x",
-                        )
-                    else:
-                        fn(
-                            asset_path="Assets/X.anim",
-                            target_hierarchy_path="/Obj",
-                            confirm=True,
-                            change_reason="x",
-                        )
-                self.assertIn("confirm", str(cm.exception))
+                properties = cast(
+                    dict[str, Any],
+                    tools_by_name[tool_name].input_schema["properties"],
+                )
+                self.assertNotIn("confirm", properties)
+                self.assertNotIn("change_reason", properties)
 
 
 class TestEditorAddUdonSharpComponentTool(unittest.TestCase):
@@ -3785,8 +3696,7 @@ class TestEditorAddUdonSharpComponentTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_udonsharp.send_action",
             return_value=bridge_envelope,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_add_udonsharp_component",
                     {
                         "hierarchy_path": "/UI/PlayButton",
@@ -3820,8 +3730,7 @@ class TestEditorAddUdonSharpComponentTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_udonsharp.send_action",
             return_value=bridge_envelope,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_add_udonsharp_component",
                     {
                         "hierarchy_path": "/UI/PlayButton",
@@ -3850,8 +3759,7 @@ class TestEditorSetPropertyValueSemantics(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_property",
                     {
                         "hierarchy_path": "/Obj",
@@ -3871,8 +3779,7 @@ class TestEditorSetPropertyValueSemantics(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_property",
                     {
                         "hierarchy_path": "/Obj",
@@ -3892,8 +3799,7 @@ class TestEditorSetPropertyValueSemantics(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_property",
                     {
                         "hierarchy_path": "/Obj",
@@ -3934,8 +3840,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_serialized_property.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_serialized_property_read",
                     {
                         "hierarchy_path": "/Obj",
@@ -3970,8 +3875,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_serialized_property.send_action",
             return_value=bridge_response,
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_serialized_property_read",
                     {
                         "hierarchy_path": "/Obj",
@@ -4009,7 +3913,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
         with patch("prefab_sentinel.mcp_tools_editor_serialized_property.send_action") as mock_send:
             for payload, expected_code in cases:
                 with self.subTest(expected_code=expected_code):
-                    _, result = _run(server.call_tool("editor_serialized_property_read", payload))
+                    result = structured_payload(call_tool_result(server,"editor_serialized_property_read", payload))
                     self.assertEqual((False, expected_code), (result["success"], result["code"]))
         mock_send.assert_not_called()
 
@@ -4019,14 +3923,12 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_serialized_property.send_action",
             return_value={"success": True, "code": "EDITOR_CTRL_SERIALIZED_PROPERTY_LIST_OK"},
         ) as mock_send:
-            _, default_result = _run(
-                server.call_tool(
+            default_result = structured_payload(call_tool_result(server,
                     "editor_serialized_property_list",
                     {"hierarchy_path": "/Obj", "component_type": "ExampleComponent"},
                 )
             )
-            _, cursor_result = _run(
-                server.call_tool(
+            cursor_result = structured_payload(call_tool_result(server,
                     "editor_serialized_property_list",
                     {
                         "hierarchy_path": "/Obj",
@@ -4079,7 +3981,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
             for extra, expected_code in cases:
                 payload = {**base, **extra}
                 with self.subTest(expected_code=expected_code, payload=payload):
-                    _, result = _run(server.call_tool("editor_serialized_property_list", payload))
+                    result = structured_payload(call_tool_result(server,"editor_serialized_property_list", payload))
                     self.assertEqual((False, expected_code), (result["success"], result["code"]))
         mock_send.assert_not_called()
 
@@ -4101,7 +4003,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
                     "property_path": "m_Name",
                     **extra,
                 }
-                _run(server.call_tool("editor_serialized_property_write", payload))
+                (call_tool_result(server,"editor_serialized_property_write", payload))
                 kwargs = mock_send.call_args.kwargs
                 self.assertTrue(kwargs[present_key])
                 self.assertEqual(expected_value, kwargs[value_key])
@@ -4123,7 +4025,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
             for extra, expected_code in cases:
                 payload = {**base, **extra}
                 with self.subTest(expected_code=expected_code):
-                    _, result = _run(server.call_tool("editor_serialized_property_write", payload))
+                    result = structured_payload(call_tool_result(server,"editor_serialized_property_write", payload))
                     self.assertEqual((False, expected_code), (result["success"], result["code"]))
         mock_send.assert_not_called()
 
@@ -4137,8 +4039,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
             "confirm": True,
         }
         with patch("prefab_sentinel.mcp_tools_editor_serialized_property.send_action") as mock_send:
-            _, rejected = _run(
-                server.call_tool(
+            rejected = structured_payload(call_tool_result(server,
                     "editor_serialized_property_write",
                     {**base, "change_reason": "   "},
                 )
@@ -4153,8 +4054,7 @@ class TestEditorSerializedPropertyTools(unittest.TestCase):
                 "success": True,
                 "code": "EDITOR_CTRL_SERIALIZED_PROPERTY_WRITE_OK",
             }
-            _, accepted = _run(
-                server.call_tool(
+            accepted = structured_payload(call_tool_result(server,
                     "editor_serialized_property_write",
                     {**base, "change_reason": "  audit reason  "},
                 )
@@ -4185,8 +4085,7 @@ class TestEditorSetUdonSharpFieldValueSemantics(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_udonsharp.send_action",
             return_value={"success": True},
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_set_udonsharp_field",
                     {
                         "hierarchy_path": "/UI/PlayButton",
@@ -4211,8 +4110,7 @@ class TestEditorSetUdonSharpFieldValueSemantics(unittest.TestCase):
         with patch(
             "prefab_sentinel.mcp_tools_editor_udonsharp.send_action",
         ) as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_set_udonsharp_field",
                     {
                         "hierarchy_path": "/UI/PlayButton",
@@ -4240,8 +4138,7 @@ class TestEditorDictPathValueSemantics(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Obj",
@@ -4265,8 +4162,7 @@ class TestEditorDictPathValueSemantics(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_batch.send_action",
             return_value={"success": True},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_batch_set_property",
                     {
                         "operations": [
@@ -4295,119 +4191,172 @@ class TestEditorDictPathValueSemantics(unittest.TestCase):
 class TestEditorArgumentNaming(unittest.TestCase):
     """T-53-1: editor_* address/property arguments conform to the conventions.
 
-    A conforming argument name is accepted; the legacy name raises TypeError.
+    Conforming names are accepted directly; legacy names stay absent from public
+    schemas, and missing canonical required fields drive protocol validation.
     """
 
     def setUp(self) -> None:
         os.environ.pop("UNITYTOOL_BRIDGE_WATCH_DIR", None)
+        self.server = create_server()
 
-    def _tool_fn(self, name: str):
-        return create_server()._tool_manager._tools[name].fn
+    def _call_tool(self, name: str, arguments: dict[str, object]) -> dict[str, Any]:
+        result = call_tool_result(self.server, name, arguments)
+        self.assertIs(result.is_error, False)
+        payload = structured_payload(result)
+        self.assertEqual({"success": True}, payload)
+        return payload
+
+    def _assert_schema_omits(
+        self,
+        name: str,
+        *legacy_arguments: str,
+    ) -> None:
+        tools_by_name = {
+            tool.name: tool for tool in run(self.server.list_tools())
+        }
+        properties = cast(
+            dict[str, Any],
+            tools_by_name[name].input_schema["properties"],
+        )
+        for legacy_argument in legacy_arguments:
+            self.assertNotIn(legacy_argument, properties)
+
+    def _assert_protocol_error(
+        self,
+        name: str,
+        arguments: dict[str, object],
+        canonical_argument: str,
+    ) -> None:
+        async def invoke() -> CallToolResult:
+            async with Client(self.server, mode="2026-07-28") as client:
+                return await client.call_tool(name, arguments)
+
+        result = run(invoke())
+        self.assertTrue(result.is_error)
+        self.assertIsNone(result.structured_content)
+        self.assertIsInstance(result.content[0], TextContent)
+        content = cast(TextContent, result.content[0])
+        self.assertIn(canonical_argument, content.text)
 
     def test_conforming_argument_names_accepted(self) -> None:
-        # editor_set_parent: parent_hierarchy_path
         with patch(
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True},
         ) as send:
-            self._tool_fn("editor_set_parent")(
-                hierarchy_path="/A",
-                parent_hierarchy_path="/B",
+            self._call_tool(
+                "editor_set_parent",
+                {
+                    "hierarchy_path": "/A",
+                    "parent_hierarchy_path": "/B",
+                },
             )
         send.assert_called_once()
-        # editor_open_scene: asset_path
+
         with patch(
             "prefab_sentinel.mcp_tools_editor_batch.send_action",
             return_value={"success": True},
         ) as send:
-            self._tool_fn("editor_open_scene")(asset_path="Assets/X.unity")
+            self._call_tool("editor_open_scene", {"asset_path": "Assets/X.unity"})
         send.assert_called_once()
-        # editor_set_material: material_asset_path
+
         with patch(
             "prefab_sentinel.mcp_tools_editor_write.send_action",
             return_value={"success": True},
         ) as send:
-            self._tool_fn("editor_set_material")(
-                hierarchy_path="/A",
-                material_index=0,
-                material_asset_path="Assets/M.mat",
+            self._call_tool(
+                "editor_set_material",
+                {
+                    "hierarchy_path": "/A",
+                    "material_index": 0,
+                    "material_asset_path": "Assets/M.mat",
+                },
             )
         send.assert_called_once()
-        # editor_wire_persistent_listener: target_hierarchy_path
+
         with patch(
             "prefab_sentinel.mcp_tools_editor_udonsharp.send_action",
             return_value={"success": True},
         ) as send:
-            self._tool_fn("editor_wire_persistent_listener")(
-                hierarchy_path="/A",
-                property_name="onValueChanged",
-                target_hierarchy_path="/B",
-                method="M",
-                arg="x",
-                confirm=True,
-                change_reason="wire listener",
+            self._call_tool(
+                "editor_wire_persistent_listener",
+                {
+                    "hierarchy_path": "/A",
+                    "property_name": "onValueChanged",
+                    "target_hierarchy_path": "/B",
+                    "method": "M",
+                    "arg": "x",
+                    "confirm": True,
+                    "change_reason": "wire listener",
+                },
             )
         send.assert_called_once()
 
-    def test_legacy_parent_path_argument_raises_type_error(self) -> None:
-        fn = self._tool_fn("editor_set_parent")
-        with self.assertRaises(TypeError) as cm:
-            fn(hierarchy_path="/A", parent_path="/B")
-        self.assertIn("parent_path", str(cm.exception))
+    def test_legacy_parent_path_is_absent_from_public_schema(self) -> None:
+        self._assert_schema_omits("editor_set_parent", "parent_path")
 
-    def test_legacy_scene_path_argument_raises_type_error(self) -> None:
-        fn = self._tool_fn("editor_open_scene")
-        with self.assertRaises(TypeError) as cm:
-            fn(scene_path="Assets/X.unity")
-        self.assertIn("scene_path", str(cm.exception))
+    def test_legacy_scene_path_is_absent_and_asset_path_is_required(self) -> None:
+        self._assert_schema_omits("editor_open_scene", "scene_path")
+        self._assert_protocol_error(
+            "editor_open_scene",
+            {"scene_path": "Assets/X.unity"},
+            "asset_path",
+        )
 
-    def test_legacy_material_path_argument_raises_type_error(self) -> None:
-        fn = self._tool_fn("editor_set_material")
-        with self.assertRaises(TypeError) as cm:
-            fn(hierarchy_path="/A", material_index=0, material_path="Assets/M.mat")
-        self.assertIn("material_path", str(cm.exception))
+    def test_legacy_material_path_is_absent_from_public_schema(self) -> None:
+        self._assert_schema_omits("editor_set_material", "material_path")
 
-    def test_legacy_target_path_argument_raises_type_error(self) -> None:
-        fn = self._tool_fn("editor_wire_persistent_listener")
-        with self.assertRaises(TypeError) as cm:
-            fn(
-                hierarchy_path="/A",
-                property_name="onValueChanged",
-                target_path="/B",
-                method="M",
-                arg="x",
-            )
-        self.assertIn("target_path", str(cm.exception))
+    def test_legacy_target_path_is_absent_and_canonical_field_is_required(self) -> None:
+        self._assert_schema_omits(
+            "editor_wire_persistent_listener",
+            "target_path",
+        )
+        self._assert_protocol_error(
+            "editor_wire_persistent_listener",
+            {
+                "hierarchy_path": "/A",
+                "property_name": "onValueChanged",
+                "target_path": "/B",
+                "method": "M",
+                "arg": "x",
+            },
+            "target_hierarchy_path",
+        )
 
-    def test_legacy_event_path_argument_raises_type_error(self) -> None:
+    def test_legacy_event_path_is_absent_and_canonical_field_is_required(self) -> None:
         """Issue #53/#58: the former event_path argument no longer binds."""
-        fn = self._tool_fn("editor_wire_persistent_listener")
-        with self.assertRaises(TypeError) as cm:
-            fn(
-                hierarchy_path="/A",
-                event_path="onValueChanged",
-                target_hierarchy_path="/B",
-                method="M",
-                arg="x",
-            )
-        self.assertIn("event_path", str(cm.exception))
+        self._assert_schema_omits(
+            "editor_wire_persistent_listener",
+            "event_path",
+        )
+        self._assert_protocol_error(
+            "editor_wire_persistent_listener",
+            {
+                "hierarchy_path": "/A",
+                "event_path": "onValueChanged",
+                "target_hierarchy_path": "/B",
+                "method": "M",
+                "arg": "x",
+            },
+            "property_name",
+        )
 
     def test_listener_property_name_travels_on_event_wire_field(self) -> None:
-        """Issue #61: the property_name argument is forwarded on the
-        event_property_name wire field; the misleading event_path wire
-        key is gone."""
+        """Issue #61: property_name uses event_property_name on the wire."""
         with patch(
             "prefab_sentinel.mcp_tools_editor_udonsharp.send_action",
             return_value={"success": True},
         ) as send:
-            self._tool_fn("editor_wire_persistent_listener")(
-                hierarchy_path="/A",
-                property_name="OnX",
-                target_hierarchy_path="/B",
-                method="M",
-                arg="x",
-                confirm=True,
-                change_reason="wire listener",
+            self._call_tool(
+                "editor_wire_persistent_listener",
+                {
+                    "hierarchy_path": "/A",
+                    "property_name": "OnX",
+                    "target_hierarchy_path": "/B",
+                    "method": "M",
+                    "arg": "x",
+                    "confirm": True,
+                    "change_reason": "wire listener",
+                },
             )
         kwargs = send.call_args.kwargs
         self.assertEqual(
@@ -4426,23 +4375,27 @@ class TestEditorArgumentNaming(unittest.TestCase):
 
 
 class TestEditorSetParentWireField(unittest.TestCase):
-    """Issue #56 — editor_set_parent transmits the parent address on the
-    dedicated parent_hierarchy_path wire field, not the rename field."""
+    """Issue #56 — editor_set_parent uses the dedicated parent wire field."""
 
     def setUp(self) -> None:
         os.environ.pop("UNITYTOOL_BRIDGE_WATCH_DIR", None)
+        self.server = create_server()
 
-    def _tool_fn(self, name: str):
-        return create_server()._tool_manager._tools[name].fn
+    def _call_set_parent(self, arguments: dict[str, object]) -> None:
+        result = call_tool_result(self.server, "editor_set_parent", arguments)
+        self.assertIs(result.is_error, False)
+        self.assertEqual({"success": True}, structured_payload(result))
 
     def test_parent_address_travels_on_dedicated_field(self) -> None:
         with patch(
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True},
         ) as send:
-            self._tool_fn("editor_set_parent")(
-                hierarchy_path="/A",
-                parent_hierarchy_path="/B",
+            self._call_set_parent(
+                {
+                    "hierarchy_path": "/A",
+                    "parent_hierarchy_path": "/B",
+                },
             )
         kwargs = send.call_args.kwargs
         self.assertEqual(
@@ -4464,7 +4417,7 @@ class TestEditorSetParentWireField(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True},
         ) as send:
-            self._tool_fn("editor_set_parent")(hierarchy_path="/A")
+            self._call_set_parent({"hierarchy_path": "/A"})
         kwargs = send.call_args.kwargs
         self.assertEqual(
             ("editor_set_parent", ""),
@@ -4483,8 +4436,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_instantiate_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_instantiate",
                     {
                         "asset_path": "Assets/Prefabs/Mic.prefab",
@@ -4503,8 +4455,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_instantiate_no_position(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_instantiate",
                     {
                         "asset_path": "Assets/Prefabs/Mic.prefab",
@@ -4520,8 +4471,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_instantiate_invalid_position_count(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action"):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_instantiate",
                     {
                         "asset_path": "Assets/X.prefab",
@@ -4535,8 +4485,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_instantiate_invalid_position_value(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action"):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_instantiate",
                     {
                         "asset_path": "Assets/X.prefab",
@@ -4550,8 +4499,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_set_material_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_material",
                     {
                         "hierarchy_path": "/Body",
@@ -4570,8 +4518,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_set_material_property_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_material_property",
                     {
                         "hierarchy_path": "/Foo",
@@ -4594,8 +4541,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_set_material_property_requires_audit_pair(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_set_material_property",
                     {
                         "hierarchy_path": "/Foo",
@@ -4616,8 +4562,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_batch_set_material_property_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_batch.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_batch_set_material_property",
                     {
                         "hierarchy_path": "/Avatar/Hair",
@@ -4643,8 +4588,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_batch_set_material_property_by_path_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_batch.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_batch_set_material_property",
                     {
                         "material_asset_path": "Assets/Materials/Hair.mat",
@@ -4663,8 +4607,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_batch_set_material_property_by_guid_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_batch.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_batch_set_material_property",
                     {
                         "material_asset_guid": "abc123def456abc123def456abc123de",
@@ -4684,7 +4627,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_delete_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_delete", {"hierarchy_path": "/OldObject"}))
+            (call_tool_result(server,"editor_delete", {"hierarchy_path": "/OldObject"}))
         mock_send.assert_called_once_with(action="delete_object", hierarchy_path="/OldObject")
 
     def test_editor_add_component_preserves_reused_envelope(self) -> None:
@@ -4713,8 +4656,7 @@ class TestEditorWriteTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_write.send_action",
             return_value=bridge_response,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_add_component",
                     {
                         "hierarchy_path": "/Player",
@@ -4751,8 +4693,7 @@ class TestEditorWriteTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_write.send_action",
             return_value=bridge_response,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_add_component",
                     {
                         "hierarchy_path": "/Player",
@@ -4767,8 +4708,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_remove_component_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_remove_component",
                     {
                         "hierarchy_path": "/Player",
@@ -4785,8 +4725,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_remove_component_with_index(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_remove_component",
                     {
                         "hierarchy_path": "/Player",
@@ -4808,8 +4747,7 @@ class TestEditorWriteTools(unittest.TestCase):
         with patch(
             "prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value={"success": True, "data": {}}
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4836,8 +4774,7 @@ class TestEditorWriteTools(unittest.TestCase):
         """confirm=True without change_reason returns error without calling bridge."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4856,8 +4793,7 @@ class TestEditorWriteTools(unittest.TestCase):
         """Empty platforms list returns validation error."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4875,8 +4811,7 @@ class TestEditorWriteTools(unittest.TestCase):
         """Invalid platform name returns validation error."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4894,8 +4829,7 @@ class TestEditorWriteTools(unittest.TestCase):
         """Duplicate platform returns validation error."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4921,8 +4855,7 @@ class TestEditorWriteTools(unittest.TestCase):
             },
         }
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value=bridge_response):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4949,8 +4882,7 @@ class TestEditorWriteTools(unittest.TestCase):
             },
         }
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value=bridge_response):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4974,8 +4906,7 @@ class TestEditorWriteTools(unittest.TestCase):
         server = create_server()
         bridge_response = {"success": True, "data": {"phase": "validated"}}
         with patch("prefab_sentinel.mcp_tools_editor_advanced.send_action", return_value=bridge_response):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "vrcsdk_upload",
                     {
                         "target_type": "avatar",
@@ -4990,8 +4921,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_get_blend_shapes_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_get_blend_shapes",
                     {
                         "hierarchy_path": "/Avatar/Body",
@@ -5012,8 +4942,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_get_blend_shapes_default_filter(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_get_blend_shapes",
                     {
                         "hierarchy_path": "/Avatar/Body",
@@ -5031,8 +4960,7 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_set_blend_shape_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_blend_shape",
                     {
                         "hierarchy_path": "/Avatar/Body",
@@ -5051,13 +4979,13 @@ class TestEditorWriteTools(unittest.TestCase):
     def test_editor_list_menu_items_delegates(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_list_menu_items", {"prefix": "Tools/"}))
+            (call_tool_result(server,"editor_list_menu_items", {"prefix": "Tools/"}))
         mock_send.assert_called_once_with(action="list_menu_items", filter="Tools/")
 
     def test_editor_list_menu_items_default_prefix(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_list_menu_items", {}))
+            (call_tool_result(server,"editor_list_menu_items", {}))
         mock_send.assert_called_once_with(action="list_menu_items", filter="")
 
     def test_editor_execute_menu_item_delegates(self) -> None:
@@ -5068,8 +4996,7 @@ class TestEditorWriteTools(unittest.TestCase):
         """
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_execute_menu_item",
                     {
                         "menu_path": "Tools/NDMF/Manual Bake",
@@ -5093,8 +5020,7 @@ class TestEditorWriteTools(unittest.TestCase):
         """
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_write.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_execute_menu_item",
                     {
                         "menu_path": "Tools/NDMF/Manual Bake",
@@ -5129,8 +5055,7 @@ class TestEditorWriteTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_write.send_action",
             return_value=bridge_envelope,
         ):
-            _, envelope = _run(
-                server.call_tool(
+            envelope = structured_payload(call_tool_result(server,
                     "editor_execute_menu_item",
                     {
                         "menu_path": "Tools/NDMF/Manual Bake",
@@ -5151,7 +5076,7 @@ class TestEditorWriteTools(unittest.TestCase):
         ]
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_batch.send_action", return_value={"success": True}) as mock_send:
-            _run(server.call_tool("editor_batch_add_component", {"operations": operations}))
+            (call_tool_result(server,"editor_batch_add_component", {"operations": operations}))
         self.assertIn("properties", operations[0])
         call_kwargs = mock_send.call_args[1]
         sent = json.loads(call_kwargs["batch_operations_json"])
@@ -5171,8 +5096,7 @@ class TestEditorExecTools(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_exec.send_action",
             return_value={"success": True, "code": "EDITOR_CTRL_RUN_SCRIPT_OK"},
         ) as mock_send:
-            _, parsed = _run(
-                server.call_tool(
+            parsed = structured_payload(call_tool_result(server,
                     "editor_run_script",
                     {
                         "code": "public static void Run() {}",
@@ -5199,8 +5123,7 @@ class TestEditorExecTools(unittest.TestCase):
         ``CHANGE_REASON_REQUIRED`` without contacting the bridge."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_exec.send_action") as mock_send:
-            _, parsed = _run(
-                server.call_tool(
+            parsed = structured_payload(call_tool_result(server,
                     "editor_run_script",
                     {
                         "code": "public static void Run() {}",
@@ -5218,8 +5141,7 @@ class TestEditorExecTools(unittest.TestCase):
         ``CHANGE_REASON_REQUIRED`` and the bridge is never invoked."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_exec.send_action") as mock_send:
-            _, parsed = _run(
-                server.call_tool(
+            parsed = structured_payload(call_tool_result(server,
                     "editor_run_script",
                     {
                         "code": "public static void Run() {}",
@@ -5248,8 +5170,7 @@ class TestInspectionTools(unittest.TestCase):
         server = create_server()
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_materials",
                     {
                         "asset_path": "Assets/Avatar.prefab",
@@ -5274,8 +5195,7 @@ class TestInspectionTools(unittest.TestCase):
         server = create_server()
         with patch("prefab_sentinel.session_cache.Phase1Orchestrator") as mock_cls:
             mock_cls.default.return_value = mock_orch
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "validate_structure",
                     {
                         "asset_path": "Assets/Scene.unity",
@@ -5307,8 +5227,7 @@ class TestRevertOverridesTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_patch.revert_overrides_impl",
             return_value=mock_resp,
         ) as mock_revert:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "revert_overrides",
                     {
                         "asset_path": "Assets/V.prefab",
@@ -5340,8 +5259,7 @@ class TestRevertOverridesTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_patch.revert_overrides_impl",
             return_value=mock_resp,
         ) as mock_revert:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "revert_overrides",
                     {
                         "asset_path": "Assets/V.prefab",
@@ -5371,8 +5289,7 @@ class TestRevertOverridesTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_patch.revert_overrides_impl",
             return_value=mock_resp,
         ) as mock_revert:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "revert_overrides",
                     {
                         "asset_path": "Assets/V.prefab",
@@ -5391,8 +5308,7 @@ class TestRevertOverridesTool(unittest.TestCase):
         with patch(
             "prefab_sentinel.mcp_tools_patch.revert_overrides_impl",
         ) as mock_revert:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "revert_overrides",
                     {
                         "asset_path": "Assets/V.prefab",
@@ -5424,7 +5340,7 @@ class TestInspectHierarchyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(server.call_tool("inspect_hierarchy", {"asset_path": "Assets/A.prefab"}))
+            result = structured_payload(call_tool_result(server,"inspect_hierarchy", {"asset_path": "Assets/A.prefab"}))
 
         self.assertTrue(result["success"])
         mock_orch.inspect_hierarchy.assert_called_once_with(
@@ -5448,8 +5364,7 @@ class TestInspectHierarchyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "inspect_hierarchy",
                     {
                         "asset_path": "Assets/A.prefab",
@@ -5480,8 +5395,7 @@ class TestInspectHierarchyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_hierarchy",
                     {
                         "asset_path": "Assets/A.prefab",
@@ -5508,8 +5422,7 @@ class TestInspectHierarchyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_hierarchy",
                     {
                         "asset_path": "Assets/A.prefab",
@@ -5538,8 +5451,7 @@ class TestEffectiveInspectorTools(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_transform_effective_values",
                     {"asset_path": "Assets/Host.prefab", "symbol_path": "Root/Child"},
                 )
@@ -5567,8 +5479,7 @@ class TestEffectiveInspectorTools(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "inspect_unity_event_listeners",
                     {
                         "asset_path": "Assets/Control.prefab",
@@ -5629,8 +5540,7 @@ class TestValidateRuntimeTool(unittest.TestCase):
 
         server = create_server()
         with patch.object(ProjectSession, "get_orchestrator", return_value=mock_orch):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "validate_runtime",
                     {"asset_path": "Assets/Scenes/Main.unity"},
                 )
@@ -5661,8 +5571,7 @@ class TestValidateRuntimeTool(unittest.TestCase):
 
         server = create_server()
         with patch.object(ProjectSession, "get_orchestrator", return_value=mock_orch):
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "validate_runtime",
                     {
                         "asset_path": "Assets/S.unity",
@@ -5746,7 +5655,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(server.call_tool("patch_apply", {"plan": plan_json}))
+            result = structured_payload(call_tool_result(server,"patch_apply", {"plan": plan_json}))
 
         self.assertTrue(result["success"])
         mock_orch.patch_apply.assert_called_once_with(
@@ -5780,8 +5689,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": plan_json,
@@ -5839,8 +5747,7 @@ class TestPatchApplyTool(unittest.TestCase):
                     return_value=orchestrator,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "patch_apply",
                         {"plan": plan},
                     )
@@ -5951,8 +5858,7 @@ class TestPatchApplyTool(unittest.TestCase):
                     return_value=orchestrator,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "patch_apply",
                         {
                             "plan": {
@@ -6082,8 +5988,7 @@ class TestPatchApplyTool(unittest.TestCase):
         secret = "SECRET_JSON"
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "patch_apply",
                 {"plan": f'{{"plan_version": "{secret}"'},
             )
@@ -6113,8 +6018,7 @@ class TestPatchApplyTool(unittest.TestCase):
                 "get_orchestrator",
                 return_value=orchestrator,
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "patch_apply",
                         {
                             "plan": {
@@ -6154,8 +6058,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             side_effect=ValueError(secret),
         ) as get_orchestrator:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": plan,
@@ -6192,8 +6095,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ) as get_orchestrator:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": plan,
@@ -6239,8 +6141,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ) as get_orchestrator:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": plan,
@@ -6336,8 +6237,7 @@ class TestPatchApplyTool(unittest.TestCase):
                                 return_value=orchestrator,
                             ),
                         ):
-                            _, result = _run(
-                                server.call_tool(
+                            result = structured_payload(call_tool_result(server,
                                     "patch_apply",
                                     {
                                         "plan": plan,
@@ -6382,8 +6282,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orchestrator,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": "[]",
@@ -6411,8 +6310,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": '{"plan_version": "2"}',
@@ -6432,8 +6330,7 @@ class TestPatchApplyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": '{"plan_version": "2"}',
@@ -6490,8 +6387,7 @@ class TestPatchTransactionAuditPreflight(unittest.TestCase):
                 "get_orchestrator",
                 return_value=orchestrator,
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "patch_apply",
                         {
                             "plan": plan,
@@ -6584,8 +6480,7 @@ class TestPatchTransactionAuditPreflight(unittest.TestCase):
                     return_value=orchestrator,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "patch_apply",
                         {
                             "plan": self._ELIGIBLE_PLAN,
@@ -6688,8 +6583,7 @@ class TestPatchTransactionAuditPreflight(unittest.TestCase):
                     return_value=orchestrator,
                 ),
             ):
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "patch_apply",
                         {
                             "plan": plan,
@@ -6896,8 +6790,7 @@ class TestPatchTransactionAuditPreflight(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "patch_apply",
                     {
                         "plan": self._ELIGIBLE_PLAN,
@@ -7085,8 +6978,7 @@ class TestPatchTransactionAuditPreflight(unittest.TestCase):
                         return_value=orchestrator,
                     ),
                 ):
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "patch_apply",
                             {
                                 "plan": self._ELIGIBLE_PLAN,
@@ -7283,8 +7175,7 @@ class TestPatchTransactionAuditPreflight(unittest.TestCase):
                     "get_orchestrator",
                     return_value=orchestrator,
                 ):
-                    _, result = _run(
-                        server.call_tool(
+                    result = structured_payload(call_tool_result(server,
                             "patch_apply",
                             {
                                 "plan": {
@@ -7491,7 +7382,7 @@ class TestActivateProjectBatchScope(unittest.TestCase):
         mock_build.return_value = {}
         mock_guid.return_value = {}
         server = create_server()
-        _, result = _run(server.call_tool("activate_project", {"scope": "Assets/MyScope"}))
+        result = structured_payload(call_tool_result(server,"activate_project", {"scope": "Assets/MyScope"}))
 
         self.assertEqual(True, result["success"], result)
         self.assertNotIn("suggested_reads", result["data"])
@@ -7510,7 +7401,7 @@ class TestKnowledgeResourcesNotRegisteredForBatch(unittest.TestCase):
 
     def test_create_server_registers_no_knowledge_resources(self) -> None:
         server = create_server()
-        resources = _run(server.list_resources())
+        resources = run(server.list_resources())
 
         knowledge_uris = [str(r.uri) for r in resources if "knowledge/" in str(r.uri)]
         self.assertEqual([], knowledge_uris)
@@ -7598,16 +7489,17 @@ class TestExpectedRootProviderLifespan(unittest.TestCase):
 
         async def exercise() -> dict[str, object]:
             server = create_server(project_root=expected_root)
-            async with server._mcp_server.lifespan(cast(Any, server)):
+            async with Client(server, mode="2026-07-28"):
                 result, _ = self._send_with_fake_response(self._successful_editor_state(actual_root))
             return result
 
-        result = _run(exercise())
+        result = run(exercise())
+        data = cast(dict[str, object], result["data"])
 
         self.assertEqual(False, result["success"], result)
         self.assertEqual("EDITOR_BRIDGE_PROJECT_ROOT_MISMATCH", result["code"])
-        self.assertEqual(expected_root, result["data"]["expected_project_root"])
-        self.assertEqual(actual_root, result["data"]["actual_project_root"])
+        self.assertEqual(expected_root, data["expected_project_root"])
+        self.assertEqual(actual_root, data["actual_project_root"])
 
     def test_lifespan_clears_expected_root_before_shutdown(self) -> None:
         expected_root = "/workspace/ExpectedProject"
@@ -7620,10 +7512,10 @@ class TestExpectedRootProviderLifespan(unittest.TestCase):
             server = create_server(project_root=expected_root)
             with patch("prefab_sentinel.session.ProjectSession.shutdown", fail_shutdown):
                 with self.assertRaisesRegex(RuntimeError, "shutdown failed"):
-                    async with server._mcp_server.lifespan(cast(Any, server)):
+                    async with Client(server, mode="2026-07-28"):
                         pass
 
-        _run(exercise_failed_shutdown())
+        run(exercise_failed_shutdown())
         try:
             result, _ = self._send_with_fake_response(self._successful_editor_state(actual_root))
             self.assertEqual(True, result["success"], result)
@@ -7665,8 +7557,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         old_meta.write_text("guid: abc", encoding="utf-8")
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7683,8 +7574,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         """When parent has no old files, removed_old_files is empty."""
         self._mock_successful_refresh(mock_send)
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7699,8 +7589,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         self._mock_successful_refresh(mock_send)
         deep_target = self._project_root / "Assets" / "NewDir" / "SubDir" / "Bridge"
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(deep_target)},
             )
@@ -7714,8 +7603,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         """VRCSDKUploadHandler.cs is always copied unconditionally."""
         self._mock_successful_refresh(mock_send)
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7730,8 +7618,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         """PrefabSentinel.Editor.asmdef is copied alongside C# files."""
         self._mock_successful_refresh(mock_send)
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7746,8 +7633,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         """Response data must not contain skipped_files key."""
         self._mock_successful_refresh(mock_send)
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7764,8 +7650,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         (parent / "PrefabSentinel.EditorBridge.cs").write_text("// old", encoding="utf-8")
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7784,8 +7669,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         (parent / "PrefabSentinel.Legacy.cs").write_text("// old", encoding="utf-8")
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7804,8 +7688,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         (self._target / "Dummy.cs.meta").write_text("guid: dummy", encoding="utf-8")
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7824,8 +7707,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         (subdir / "keep.txt").write_text("keep", encoding="utf-8")
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7843,8 +7725,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         (self._target / "OldFile.cs").write_text("// old", encoding="utf-8")
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7860,8 +7741,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         (self._target / "Stale.cs").write_text("// stale", encoding="utf-8")
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7876,8 +7756,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         self._mock_successful_refresh(mock_send)
         fresh_target = self._project_root / "Assets" / "Editor" / "FreshDeploy"
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(fresh_target)},
             )
@@ -7900,8 +7779,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         mock_send.return_value = refresh_failure
 
         server = create_server(project_root=str(self._project_root))
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "deploy_bridge",
                 {"target_dir": str(self._target)},
             )
@@ -7928,8 +7806,7 @@ class TestDeployBridgeCleanup(unittest.TestCase):
         mcp_mod.__file__ = str(fake_pkg / "mcp_tools_session.py")
         try:
             server = create_server(project_root=str(self._project_root))
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "deploy_bridge",
                     {"target_dir": str(self._target)},
                 )
@@ -7962,8 +7839,7 @@ class TestCopyAssetTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_asset",
                     {
                         "source_path": "Assets/Mat/A.mat",
@@ -7990,8 +7866,7 @@ class TestCopyAssetTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_asset",
                     {
                         "source_path": "Assets/Mat/A.mat",
@@ -8022,8 +7897,7 @@ class TestRenameAssetTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "rename_asset",
                     {
                         "asset_path": "Assets/Mat/Old.mat",
@@ -8050,8 +7924,7 @@ class TestRenameAssetTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "rename_asset",
                     {
                         "asset_path": "Assets/Mat/Old.mat",
@@ -8082,8 +7955,7 @@ class PatchAssetDeleteToolTests(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "delete_asset",
                     {"asset_path": "Assets/Foo.prefab"},
                 )
@@ -8110,8 +7982,7 @@ class PatchAssetDeleteToolTests(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "delete_assets",
                     {"asset_paths": ["Assets/Foo.prefab"]},
                 )
@@ -8137,8 +8008,7 @@ class PatchAssetDeleteToolTests(unittest.TestCase):
             patch.object(ProjectSession, "get_orchestrator", return_value=mock_orch),
             patch.object(ProjectSession, "resolve_scope", return_value="Assets/Resolved"),
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "delete_assets",
                     {
                         "asset_paths": ["Assets/Foo.prefab"],
@@ -8167,8 +8037,7 @@ class PatchAssetDeleteToolTests(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "delete_assets",
                     {
                         "asset_paths": ["Assets/Foo.prefab"],
@@ -8197,8 +8066,7 @@ class TestSetMaterialPropertyTool(unittest.TestCase):
             "get_orchestrator",
             return_value=mock_orch,
         ):
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_material_property",
                     {
                         "asset_path": "Assets/M.mat",
@@ -8327,8 +8195,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "copy_component_fields",
                         {
                             "src_asset_path": str(src),
@@ -8382,8 +8249,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "copy_component_fields",
                         {
                             "src_asset_path": str(src),
@@ -8420,8 +8286,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "copy_component_fields",
                         {
                             "src_asset_path": str(src),
@@ -8453,8 +8318,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
                 mock_orch.patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "copy_component_fields",
                         {
                             "src_asset_path": str(p),
@@ -8488,8 +8352,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
                 mock_orch.maybe_auto_refresh.return_value = "done"
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "copy_component_fields",
                         {
                             "src_asset_path": str(src),
@@ -8526,8 +8389,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8555,8 +8417,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8583,8 +8444,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8610,8 +8470,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8637,8 +8496,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8664,8 +8522,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8714,8 +8571,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 server_inst = create_server(project_root=td)
-                _, result = _run(
-                    server_inst.call_tool(
+                result = structured_payload(call_tool_result(server_inst,
                         "copy_component_fields",
                         {
                             "src_asset_path": str(src),
@@ -8744,8 +8600,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8773,8 +8628,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
             src.write_text(src_text, encoding="utf-8")
             dst.write_text(dst_text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "copy_component_fields",
                     {
                         "src_asset_path": str(src),
@@ -8793,8 +8647,7 @@ class TestCopyComponentFieldsTool(unittest.TestCase):
     def test_confirm_requires_change_reason(self) -> None:
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "copy_component_fields",
                 {
                     "src_asset_path": "Assets/DoesNotExist.prefab",
@@ -8869,7 +8722,7 @@ class TestSetPropertiesTool(unittest.TestCase):
     def test_legacy_tool_name_not_registered(self) -> None:
         """T-41-2: ``set_component_fields`` is not registered; ``set_properties`` is."""
         server = create_server()
-        names = {t.name for t in _run(server.list_tools())}
+        names = {t.name for t in run(server.list_tools())}
         self.assertIn("set_properties", names)
         self.assertNotIn("set_component_fields", names)
 
@@ -8890,8 +8743,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -8907,19 +8759,16 @@ class TestSetPropertiesTool(unittest.TestCase):
             result["symbol_resolution"]["resolved_component"],
         )
 
-    def test_component_keyword_argument_raises_type_error(self) -> None:
-        """T-41-1: passing a residual ``component`` keyword raises ``TypeError``."""
-        server = create_server()
-        registered = server._tool_manager._tools
-        fn = registered["set_properties"].fn
-        with self.assertRaises(TypeError) as cm:
-            fn(
-                asset_path="x.prefab",
-                symbol_path="Cube/MeshRenderer",
-                component="MeshRenderer",
-                properties={"m_Enabled": 0},
-            )
-        self.assertIn("component", str(cm.exception))
+    def test_component_keyword_is_absent_from_public_schema(self) -> None:
+        """T-41-1: the residual component keyword is not published."""
+        tools_by_name = {
+            tool.name: tool for tool in run(create_server().list_tools())
+        }
+        properties = cast(
+            dict[str, Any],
+            tools_by_name["set_properties"].input_schema["properties"],
+        )
+        self.assertNotIn("component", properties)
 
     def test_dry_run_multiple_properties(self) -> None:
         """Dry-run with 2 properties builds a 2-op plan and enriches symbol_resolution."""
@@ -8938,8 +8787,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -8989,8 +8837,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 # Two MeshRenderers on one GameObject — addressing the
                 # first by #0 must resolve uniquely. ``m_GameObject`` is
                 # the property present on the bare synthetic fixture.
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9026,8 +8873,7 @@ class TestSetPropertiesTool(unittest.TestCase):
 
                 report_path = Path(td) / "report.json"
                 server = create_server(project_root=td)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9076,8 +8922,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 server = create_server(project_root=td)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9115,8 +8960,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9140,8 +8984,7 @@ class TestSetPropertiesTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": str(p),
@@ -9168,8 +9011,7 @@ class TestSetPropertiesTool(unittest.TestCase):
             p.write_text(text, encoding="utf-8")
 
             # Two root GameObjects named 'Cube', each with a MeshRenderer.
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": str(p),
@@ -9194,8 +9036,7 @@ class TestSetPropertiesTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": str(p),
@@ -9220,8 +9061,7 @@ class TestSetPropertiesTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": str(p),
@@ -9240,8 +9080,7 @@ class TestSetPropertiesTool(unittest.TestCase):
         """EMPTY_FIELDS error returned before any file I/O when properties dict is empty."""
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": "Assets/DoesNotExist.prefab",
@@ -9257,8 +9096,7 @@ class TestSetPropertiesTool(unittest.TestCase):
         """CHANGE_REASON_REQUIRED when confirm=True without change_reason."""
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": "Assets/DoesNotExist.prefab",
@@ -9279,8 +9117,7 @@ class TestSetPropertiesTool(unittest.TestCase):
         """OUT_REPORT_REQUIRED when confirm=True with change_reason but no out_report."""
         server = create_server()
 
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": "Assets/DoesNotExist.prefab",
@@ -9306,8 +9143,7 @@ class TestSetPropertiesTool(unittest.TestCase):
         ):
             outside_report = Path(outside_directory) / "outside_project.json"
             server = create_server(project_root=project_directory)
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": "Assets/DoesNotExist.prefab",
@@ -9349,8 +9185,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_orch = MagicMock()
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -9376,8 +9211,7 @@ class TestSetPropertiesTool(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             out_path = Path(td) / "report.json"
             server = create_server()  # no project_root
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": "Assets/DoesNotExist.prefab",
@@ -9413,8 +9247,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 server = create_server(project_root=td)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9447,8 +9280,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 server = create_server(project_root=td)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9482,8 +9314,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 server = create_server(project_root=td)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9518,8 +9349,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 server = create_server(project_root=td)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -9560,8 +9390,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_orch.maybe_auto_refresh.return_value = "done"
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -9620,8 +9449,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 )
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -9680,8 +9508,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 )
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -9762,8 +9589,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 )
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -9816,8 +9642,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 )
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -9876,8 +9701,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 ) as invalidate_symbol_tree,
             ):
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -9916,8 +9740,7 @@ class TestSetPropertiesTool(unittest.TestCase):
             escaped_target = (Path(project_directory).parent / "secret.prefab").resolve()
             with patch.object(ProjectSession, "get_orchestrator") as get_orchestrator:
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": "../secret.prefab",
@@ -9993,8 +9816,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = failed_response
                 mock_cls.default.return_value = mock_orch
                 server = create_server(project_root=project_directory)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(asset_path),
@@ -10070,8 +9892,7 @@ class TestSetPropertiesTool(unittest.TestCase):
                 mock_cls.default.return_value = mock_orch
 
                 server = create_server(project_root=td)
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_properties",
                         {
                             "asset_path": str(p),
@@ -10104,8 +9925,7 @@ class TestSetPropertiesTool(unittest.TestCase):
             p = Path(td) / "test.prefab"
             p.write_text(text, encoding="utf-8")
 
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": str(p),
@@ -10165,8 +9985,7 @@ class TestSetPropertyTool37(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _run(
-                    server.call_tool(
+                (call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -10206,8 +10025,7 @@ class TestSetPropertyTool37(unittest.TestCase):
                 mock_orch.serialized_value_patch_apply.return_value = mock_resp
                 mock_cls.default.return_value = mock_orch
 
-                _, result = _run(
-                    server.call_tool(
+                result = structured_payload(call_tool_result(server,
                         "set_property",
                         {
                             "asset_path": str(p),
@@ -10241,7 +10059,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
     def test_legacy_tool_name_not_registered(self) -> None:
         """T-41-2: ``editor_set_component_fields`` is gone; ``editor_set_properties`` present."""
         server = create_server()
-        names = {t.name for t in _run(server.list_tools())}
+        names = {t.name for t in run(server.list_tools())}
         self.assertIn("editor_set_properties", names)
         self.assertNotIn("editor_set_component_fields", names)
 
@@ -10252,8 +10070,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True, "data": {}},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Foo/Bar",
@@ -10285,8 +10102,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True, "data": {}},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Obj",
@@ -10312,8 +10128,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True, "data": {}},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Ctrl",
@@ -10339,8 +10154,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
         """EDITOR_SET_COMP_EMPTY_FIELDS returned for empty properties list."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_ops.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Obj",
@@ -10361,8 +10175,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
         """EDITOR_SET_COMP_INVALID_FIELD when an entry has no 'property_name' key."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_ops.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Obj",
@@ -10383,8 +10196,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
         """EDITOR_SET_COMP_INVALID_FIELD when entry has property_name but no value/ref."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_ops.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Obj",
@@ -10405,8 +10217,7 @@ class TestEditorSetPropertiesTool(unittest.TestCase):
         """EDITOR_SET_COMP_INVALID_FIELD when entry supplies both value and object_reference."""
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_ops.send_action") as mock_send:
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "editor_set_properties",
                     {
                         "hierarchy_path": "/Obj",
@@ -10446,8 +10257,7 @@ class TestSetPropertiesIntegration(unittest.TestCase):
             p.write_text(text, encoding="utf-8")
 
             server = create_server(project_root=td)
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": str(p),
@@ -10494,8 +10304,7 @@ class TestSetPropertiesIntegration(unittest.TestCase):
             report_path = Path(td) / "report.json"
 
             server = create_server(project_root=td)
-            _, result = _run(
-                server.call_tool(
+            result = structured_payload(call_tool_result(server,
                     "set_properties",
                     {
                         "asset_path": str(p),
@@ -10530,8 +10339,7 @@ class TestEditorSetPropertiesIntegration(unittest.TestCase):
         follow-up; post-#270 the bridge dispatch surface has no mode env var).
         """
         server = create_server()
-        _, result = _run(
-            server.call_tool(
+        result = structured_payload(call_tool_result(server,
                 "editor_set_properties",
                 {
                     "hierarchy_path": "/DualButtonController/Controller",
@@ -10578,8 +10386,7 @@ class TestSafeSaveAsPrefabPython(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True, "data": {}},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_safe_save_prefab",
                     {
                         "hierarchy_path": "/Obj",
@@ -10625,8 +10432,7 @@ class TestSafeSaveAsPrefabPython(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value=bridge_envelope,
         ):
-            _, envelope = _run(
-                server.call_tool(
+            envelope = structured_payload(call_tool_result(server,
                     "editor_safe_save_prefab",
                     {
                         "hierarchy_path": "/Obj",
@@ -10645,8 +10451,7 @@ class TestSafeSaveAsPrefabPython(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True, "data": {}},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_safe_save_prefab",
                     {
                         "hierarchy_path": "/Obj",
@@ -10670,8 +10475,7 @@ class TestSafeSaveAsPrefabPython(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True, "data": {}},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_safe_save_prefab",
                     {
                         "hierarchy_path": "/Obj",
@@ -10694,8 +10498,7 @@ class TestSafeSaveAsPrefabPython(unittest.TestCase):
             "prefab_sentinel.mcp_tools_editor_ops.send_action",
             return_value={"success": True, "data": {}},
         ) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_safe_save_prefab",
                     {
                         "hierarchy_path": "/Obj",
@@ -10720,7 +10523,7 @@ class TestMcpServerToolNames(unittest.TestCase):
 
     def test_safe_save_prefab_is_only_prefab_save_tool(self) -> None:
         server = create_server()
-        tools = _run(server.list_tools())
+        tools = run(server.list_tools())
         names = {t.name for t in tools}
         self.assertIn("editor_safe_save_prefab", names)
         self.assertNotIn("editor_save_as_prefab", names)
@@ -10732,8 +10535,7 @@ class TestEditorBatchCreateComponents(unittest.TestCase):
     def test_editor_batch_create_components_serialized(self) -> None:
         server = create_server()
         with patch("prefab_sentinel.mcp_tools_editor_batch.send_action", return_value={"success": True}) as mock_send:
-            _run(
-                server.call_tool(
+            (call_tool_result(server,
                     "editor_batch_create",
                     {"objects": [{"name": "Box", "components": ["BoxCollider"]}]},
                 )

--- a/tests/test_mcp_smoke.py
+++ b/tests/test_mcp_smoke.py
@@ -2,32 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
-import json
 import os
 import unittest
 from pathlib import Path
 from typing import Any, ClassVar
 
 from prefab_sentinel.mcp_server import create_server
+from tests._mcp_test_support import call_tool_result, structured_payload
 
 FIXTURES = Path(__file__).parent / "fixtures" / "smoke"
-
-
-def _run(coro: Any) -> Any:
-    """Run an async coroutine synchronously.
-
-    When the result is a call_tool response (list[TextContent]), normalises
-    across MCP versions to always return a 2-tuple (content_list, parsed_dict)
-    so tests can use ``_, result = _run(server.call_tool(...))``.
-    """
-    raw = asyncio.run(coro)
-    if isinstance(raw, tuple) and len(raw) == 2 and isinstance(raw[1], dict):
-        return raw
-    if isinstance(raw, list) and raw and hasattr(raw[0], "text"):
-        parsed = json.loads(raw[0].text)
-        return raw, parsed
-    return raw
 
 
 def _fixture_asset(name: str) -> str:
@@ -47,7 +30,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_inspect_wiring_envelope_structure(self) -> None:
         """inspect_wiring returns a well-formed envelope response."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "inspect_wiring",
             {"asset_path": _fixture_asset("basic.prefab")},
         ))
@@ -57,7 +40,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_inspect_wiring_null_ratio_correct(self) -> None:
         """basic.prefab has 1 null ref out of 2 fields -> null_ratio='1/2'."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "inspect_wiring",
             {"asset_path": _fixture_asset("basic.prefab")},
         ))
@@ -67,7 +50,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_inspect_wiring_null_field_names_correct(self) -> None:
         """basic.prefab null_field_names should be ['nullRef']."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "inspect_wiring",
             {"asset_path": _fixture_asset("basic.prefab")},
         ))
@@ -78,7 +61,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_validate_refs_detects_broken_ref(self) -> None:
         """broken_ref.prefab has fileID:99999 that does not exist."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "validate_refs",
             {"scope": str(FIXTURES / "broken_ref.prefab"), "details": True},
         ))
@@ -95,7 +78,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_validate_refs_clean_file_no_broken_local_ids(self) -> None:
         """basic.prefab has no broken internal fileID references."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "validate_refs",
             {"scope": str(FIXTURES / "basic.prefab"), "details": True},
         ))
@@ -111,7 +94,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_inspect_hierarchy_returns_root(self) -> None:
         """hierarchy.prefab has Root as the only root node."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "inspect_hierarchy",
             {"asset_path": _fixture_asset("hierarchy.prefab")},
         ))
@@ -134,7 +117,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_validate_structure_clean_file(self) -> None:
         """hierarchy.prefab should pass structure validation (no dup fileIDs)."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "validate_structure",
             {"asset_path": _fixture_asset("hierarchy.prefab")},
         ))
@@ -144,7 +127,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_validate_structure_basic_file(self) -> None:
         """basic.prefab should also pass structure validation."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "validate_structure",
             {"asset_path": _fixture_asset("basic.prefab")},
         ))
@@ -154,7 +137,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_get_unity_symbols_returns_symbols(self) -> None:
         """hierarchy.prefab should return symbols (requires Transform for tree)."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "get_unity_symbols",
             {"asset_path": _fixture_asset("hierarchy.prefab")},
         ))
@@ -164,7 +147,7 @@ class McpSmokeTests(unittest.TestCase):
 
     def test_get_unity_symbols_hierarchy_root(self) -> None:
         """hierarchy.prefab root-level symbols should contain Root."""
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "get_unity_symbols",
             {"asset_path": _fixture_asset("hierarchy.prefab")},
         ))
@@ -186,12 +169,14 @@ class McpSmokeExternalTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.server = create_server()
         cls.project_root = os.environ["SMOKE_PROJECT_ROOT"]
-        _run(cls.server.call_tool(
-            "activate_project", {"scope": cls.project_root},
+        structured_payload(call_tool_result(
+            cls.server,
+            "activate_project",
+            {"scope": cls.project_root},
         ))
 
     def test_validate_refs_structure(self) -> None:
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "validate_refs",
             {"scope": self.project_root},
         ))
@@ -206,7 +191,7 @@ class McpSmokeExternalTests(unittest.TestCase):
         )
         if not prefabs:
             self.skipTest("no .prefab files in project")
-        _, result = _run(self.server.call_tool(
+        result = structured_payload(call_tool_result(self.server,
             "inspect_wiring",
             {"asset_path": prefabs[0]},
         ))

--- a/tests/test_mcp_stdio_transport.py
+++ b/tests/test_mcp_stdio_transport.py
@@ -1,0 +1,141 @@
+"""Subprocess contract tests for the real MCP stdio CLI transport."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any, cast
+
+from tests._mcp_wire_support import (
+    assert_jsonrpc_error,
+    assert_jsonrpc_result,
+    modern_request,
+    running_mcp_cli,
+)
+
+
+class TestMCPStdioTransport(unittest.TestCase):
+    def test_modern_wire_contract_and_graceful_eof(self) -> None:
+        requests: list[dict[str, object]] = [
+            modern_request("server/discover", request_id=1),
+            modern_request("tools/list", request_id=2),
+            modern_request(
+                "tools/call",
+                request_id=3,
+                params={"name": "get_project_status", "arguments": {}},
+            ),
+            modern_request("initialize", request_id=4),
+            modern_request("resources/list", request_id=5),
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            },
+        ]
+
+        with running_mcp_cli(
+            "--transport",
+            "stdio",
+            "--port",
+            "65535",
+            pipe_stdin=True,
+        ) as child:
+            decoded = [child.request_json_line(request) for request in requests[:5]]
+            child.write_json_line(requests[5])
+            child.communicate()
+            self.assertEqual(0, child.returncode)
+
+            wire_responses = [json.loads(line) for line in child.stdout.splitlines()]
+            self.assertEqual(decoded, wire_responses)
+            self.assertEqual(5, len(decoded), f"responses={decoded!r}")
+            responses = {cast(int, item["id"]): cast(dict[str, Any], item) for item in decoded}
+            self.assertEqual({1, 2, 3, 4, 5}, set(responses))
+
+            discovery = assert_jsonrpc_result(self, responses[1], request_id=1)
+            self.assertEqual(["2026-07-28"], discovery["supportedVersions"])
+            self.assertEqual({"tools": {"listChanged": False}}, discovery["capabilities"])
+
+            listed = assert_jsonrpc_result(self, responses[2], request_id=2)
+            self.assertIn("get_project_status", {tool["name"] for tool in listed["tools"]})
+
+            tool_result = assert_jsonrpc_result(self, responses[3], request_id=3)
+            self.assertIs(tool_result["isError"], False)
+            self.assertEqual("SESSION_STATUS", tool_result["structuredContent"]["code"])
+
+            # Pinned MCP SDK v2.0.0 handles initialize inside its modern stdio
+            # loop before product middleware:
+            # https://github.com/modelcontextprotocol/python-sdk/blob/v2.0.0/src/mcp/server/runner.py#L701-L755
+            sdk_initialize_error = assert_jsonrpc_error(
+                self,
+                responses[4],
+                request_id=4,
+                code=-32022,
+                message=(
+                    "connection is serving the 2026-07-28 protocol; "
+                    "the initialize handshake is not accepted"
+                ),
+            )
+            self.assertEqual(
+                {"supported": ["2026-07-28"]},
+                sdk_initialize_error.get("data"),
+            )
+            assert_jsonrpc_error(
+                self,
+                responses[5],
+                request_id=5,
+                code=-32601,
+                message="Method not found: resources/list",
+            )
+
+    def test_read_timeout_reaps_child_and_joins_process_readers(self) -> None:
+        with running_mcp_cli("--transport", "stdio", pipe_stdin=True) as child:
+            with self.assertRaisesRegex(AssertionError, "timed out waiting for one MCP stdio response"):
+                child.read_json_line(timeout=0.0)
+            child.stop()
+            self.assertIsNotNone(child.returncode)
+            self.assertFalse(child.reader_threads_alive)
+
+    def test_port_option_is_documented_bounded_and_stdio_inert(self) -> None:
+        with running_mcp_cli("--help") as child:
+            help_text, _ = child.communicate()
+            self.assertEqual(0, child.returncode)
+            self.assertIn("--port PORT", help_text)
+            self.assertIn("Streamable HTTP loopback port (default: 8000)", help_text)
+            for forbidden in (
+                "--host",
+                "--oauth",
+                "--public-bind",
+                "--stateless",
+                "--session",
+                "--json-response",
+                "--sse",
+            ):
+                self.assertNotIn(forbidden, help_text)
+
+        with running_mcp_cli(
+            "--transport",
+            "stdio",
+            "--port",
+            "1",
+            pipe_stdin=True,
+        ) as child:
+            stdout, _ = child.communicate("")
+            self.assertEqual(0, child.returncode)
+            self.assertEqual("", stdout)
+
+        for invalid_port in ("0", "65536", "not-an-integer"):
+            with self.subTest(port=invalid_port):
+                with running_mcp_cli(
+                    "--transport",
+                    "stdio",
+                    "--port",
+                    invalid_port,
+                    pipe_stdin=True,
+                ) as child:
+                    stdout, _ = child.communicate("")
+                    self.assertEqual(2, child.returncode)
+                    self.assertEqual("", stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_tools_editor_batch.py
+++ b/tests/test_mcp_tools_editor_batch.py
@@ -42,7 +42,7 @@ _DOCUMENTED_TOOLS = {
 
 
 class RecorderServerNameKwargTests(unittest.TestCase):
-    """Issue #260 — recorder registration follows FastMCP name rules."""
+    """Issue #260 — recorder registration follows MCPServer name rules."""
 
     def test_explicit_name_kwarg_is_used_as_registration_key(self) -> None:
         server = ToolRecorderServer()

--- a/tests/test_mcp_tools_editor_udonsharp.py
+++ b/tests/test_mcp_tools_editor_udonsharp.py
@@ -24,9 +24,14 @@ route requests to a live bridge mid-test (issue #88, #89).
 from __future__ import annotations
 
 import unittest
+from typing import Any
 from unittest.mock import patch
 
+from mcp.server.mcpserver.exceptions import ToolError
+
 from prefab_sentinel import mcp_tools_editor_udonsharp
+from prefab_sentinel.mcp_server import create_server
+from tests._mcp_test_support import call_tool_result, structured_payload
 
 _BRIDGE_OK = {
     "success": True,
@@ -38,34 +43,25 @@ _BRIDGE_OK = {
 }
 
 
-def _resolve_tool(name: str):
-    """Resolve a registered FastMCP tool by *name* by registering tools
-    against a stub server and returning the underlying callable.
-
-    The registration entry point uses ``@server.tool()`` decorators
-    which the FastMCP server records in its ``_tool_manager``; the
-    underlying callable is exposed as ``Tool.fn`` (or the equivalent
-    attribute on the FastMCP version under test).
-    """
-    from mcp.server.fastmcp import FastMCP
-
-    server = FastMCP(name="udonsharp-test")
-    mcp_tools_editor_udonsharp.register_editor_udonsharp_tools(server)
-    tools = server._tool_manager._tools  # type: ignore[attr-defined]
-    return tools[name].fn
-
-
 class _UdonSharpToolHarness(unittest.TestCase):
-    """Common harness: resolve the three tools once per test class.
+    """Common harness that invokes UdonSharp tools through MCPServer."""
 
-    The tools are stored as staticmethods so unittest does not treat
-    them as bound methods of the test class (which would inject
-    ``self`` as the first argument and break the tool signature).
-    """
+    def setUp(self) -> None:
+        self.server = create_server()
 
-    add_tool = staticmethod(_resolve_tool("editor_add_udonsharp_component"))
-    set_tool = staticmethod(_resolve_tool("editor_set_udonsharp_field"))
-    wire_tool = staticmethod(_resolve_tool("editor_wire_persistent_listener"))
+    def _call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        result = call_tool_result(self.server, name, arguments)
+        self.assertIs(result.is_error, False)
+        return structured_payload(result)
+
+    def add_tool(self, **arguments: Any) -> dict[str, Any]:
+        return self._call_tool("editor_add_udonsharp_component", arguments)
+
+    def set_tool(self, **arguments: Any) -> dict[str, Any]:
+        return self._call_tool("editor_set_udonsharp_field", arguments)
+
+    def wire_tool(self, **arguments: Any) -> dict[str, Any]:
+        return self._call_tool("editor_wire_persistent_listener", arguments)
 
 
 class AddUdonSharpComponentForwardingTests(_UdonSharpToolHarness):
@@ -119,7 +115,7 @@ class AddUdonSharpComponentForwardingTests(_UdonSharpToolHarness):
                 confirm=True,
                 change_reason="add play controller",
             )
-        self.assertIs(_BRIDGE_OK, resp)
+        self.assertEqual(_BRIDGE_OK, resp)
 
     def test_requires_audit_pair(self) -> None:
         with patch.object(mcp_tools_editor_udonsharp, "send_action") as send:
@@ -208,7 +204,7 @@ class SetUdonSharpFieldArrayTests(_UdonSharpToolHarness):
                 change_reason="set label array",
             )
 
-        self.assertIs(response, _BRIDGE_OK)
+        self.assertEqual(response, _BRIDGE_OK)
         self.assertEqual(
             {
                 "action": "editor_set_udonsharp_field",
@@ -222,7 +218,7 @@ class SetUdonSharpFieldArrayTests(_UdonSharpToolHarness):
             msg=f"array payload was not forwarded exactly: {send.call_args.kwargs!r}",
         )
 
-    def test_empty_values_json_is_forwarded_as_explicit_array_input(self) -> None:
+    def test_empty_values_json_is_treated_as_omitted(self) -> None:
         with patch.object(
             mcp_tools_editor_udonsharp, "send_action", return_value=_BRIDGE_OK,
         ) as send:
@@ -231,20 +227,17 @@ class SetUdonSharpFieldArrayTests(_UdonSharpToolHarness):
                 property_name="labels",
                 values_json="",
                 confirm=True,
-                change_reason="set empty label array",
+                change_reason="leave label array omitted",
             )
 
-        self.assertIs(response, _BRIDGE_OK)
+        send.assert_not_called()
         self.assertEqual(
-            {
-                "action": "editor_set_udonsharp_field",
-                "hierarchy_path": "/World/Udon",
-                "field_name": "labels",
-                "values_json": "",
-                "values_json_present": True,
-            },
-            send.call_args.kwargs,
-            msg=f"empty array payload did not stay explicit: {send.call_args.kwargs!r}",
+            (False, "error", "EDITOR_CTRL_UDON_SET_FIELD_NO_VALUE"),
+            (
+                response["success"],
+                response["severity"],
+                response["code"],
+            ),
         )
 
     def test_values_json_rejects_conflicts(self) -> None:
@@ -287,7 +280,7 @@ class SetUdonSharpFieldValidationTests(_UdonSharpToolHarness):
         self.assertEqual("EDITOR_CTRL_UDON_SET_FIELD_INPUT_CONFLICT", resp["code"])
         send.assert_not_called()
 
-    def test_rejects_neither_input(self) -> None:
+    def test_omitted_values_json_is_not_supplied(self) -> None:
         with patch.object(mcp_tools_editor_udonsharp, "send_action") as send:
             resp = self.set_tool(
                 hierarchy_path="/UI/Play",
@@ -297,6 +290,17 @@ class SetUdonSharpFieldValidationTests(_UdonSharpToolHarness):
         self.assertEqual("error", resp["severity"])
         self.assertEqual("EDITOR_CTRL_UDON_SET_FIELD_NO_VALUE", resp["code"])
         send.assert_not_called()
+
+    def test_explicit_null_values_json_is_rejected_by_public_validation(self) -> None:
+        with self.assertRaises(ToolError) as cm:
+            self.set_tool(
+                hierarchy_path="/UI/Play",
+                property_name="labels",
+                values_json=None,
+            )
+
+        self.assertIn("values_json", str(cm.exception))
+        self.assertIn("valid string", str(cm.exception))
 
 
 class WirePersistentListenerForwardingTests(_UdonSharpToolHarness):

--- a/tests/test_serialized_object_package.py
+++ b/tests/test_serialized_object_package.py
@@ -17,7 +17,6 @@ prefix.
 
 from __future__ import annotations
 
-import asyncio
 import tempfile
 import unittest
 from pathlib import Path
@@ -38,17 +37,7 @@ from prefab_sentinel.services.serialized_object.patch_preview import (
 from prefab_sentinel.services.serialized_object.service import (
     SerializedObjectService as _ServiceSerializedObjectService,
 )
-from tests._typing_helpers import load_json_object
-
-
-def _run_call_tool(coro: Any) -> dict[str, Any]:
-    """Run a server.call_tool coroutine and return the parsed JSON dict."""
-    raw = asyncio.run(coro)
-    if isinstance(raw, tuple) and len(raw) == 2 and isinstance(raw[1], dict):
-        return raw[1]
-    if isinstance(raw, list) and raw and hasattr(raw[0], "text"):
-        return load_json_object(raw[0].text, "call_tool response")
-    raise RuntimeError("Unexpected call_tool return shape")
+from tests._mcp_test_support import call_tool_result, structured_payload
 
 
 def _meshrenderer_prefab() -> str:
@@ -124,7 +113,7 @@ class SetComponentFieldsSER003Tests(unittest.TestCase):
         prefab_path = assets / "test.prefab"
         prefab_path.write_text(_meshrenderer_prefab(), encoding="utf-8")
         server = create_server()
-        activation = _run_call_tool(server.call_tool(
+        activation = structured_payload(call_tool_result(server,
             "activate_project",
             {"scope": "Assets", "project_root": str(td)},
         ))
@@ -139,7 +128,7 @@ class SetComponentFieldsSER003Tests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as raw:
             td = Path(raw)
             server, prefab_path = self._setup_server_and_prefab(td)
-            result = _run_call_tool(server.call_tool(
+            result = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": str(prefab_path),
@@ -165,7 +154,7 @@ class SetComponentFieldsSER003Tests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as raw:
             td = Path(raw)
             server, prefab_path = self._setup_server_and_prefab(td)
-            result = _run_call_tool(server.call_tool(
+            result = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": str(prefab_path),
@@ -192,7 +181,7 @@ class SetComponentFieldsSER003Tests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as raw:
             td = Path(raw)
             server, prefab_path = self._setup_server_and_prefab(td)
-            result = _run_call_tool(server.call_tool(
+            result = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": str(prefab_path),
@@ -218,7 +207,7 @@ class SetComponentFieldsSER003Tests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as raw:
             td = Path(raw)
             server, prefab_path = self._setup_server_and_prefab(td)
-            result = _run_call_tool(server.call_tool(
+            result = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": str(prefab_path),

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1394,7 +1394,7 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
         suggestions, read_only) and the diagnostic by full-string
         equality on path / location / detail / evidence."""
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
-        from tests.test_mcp_server import _run  # noqa: PLC0415
+        from tests._mcp_test_support import call_tool_result, structured_payload  # noqa: PLC0415
 
         with tempfile.TemporaryDirectory() as raw:
             td = Path(raw)
@@ -1403,7 +1403,7 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             from prefab_sentinel.mcp_server import create_server  # noqa: PLC0415
 
             server = create_server()
-            _, response = _run(server.call_tool(
+            response = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": str(prefab_path),
@@ -1449,7 +1449,7 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
         resolution with ``SYMBOL_NOT_FOUND`` (the legacy
         component-not-found SER003 branch no longer exists)."""
         from tests._assertion_helpers import assert_error_envelope  # noqa: PLC0415
-        from tests.test_mcp_server import _run  # noqa: PLC0415
+        from tests._mcp_test_support import call_tool_result, structured_payload  # noqa: PLC0415
 
         with tempfile.TemporaryDirectory() as raw:
             td = Path(raw)
@@ -1458,7 +1458,7 @@ class PatchValidatorEnvelopeTests(unittest.TestCase):
             from prefab_sentinel.mcp_server import create_server  # noqa: PLC0415
 
             server = create_server()
-            _, response = _run(server.call_tool(
+            response = structured_payload(call_tool_result(server,
                 "set_properties",
                 {
                     "asset_path": str(prefab_path),

--- a/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
+++ b/tools/unity/PrefabSentinel.UnityEditorControlBridge.cs
@@ -19,7 +19,7 @@ namespace PrefabSentinel
     public static partial class UnityEditorControlBridge
     {
         public const int ProtocolVersion = 1;
-        public const string BridgeVersion = "0.8.9";
+        public const string BridgeVersion = "0.9.0";
         private static readonly string BridgeSessionId = Guid.NewGuid().ToString("N");
         private static readonly string BridgeInstanceId = Guid.NewGuid().ToString("N");
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,8 @@ requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
-    "python_full_version < '3.13'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.13' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
 ]
 
 [[package]]
@@ -348,6 +349,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -363,21 +377,38 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -580,15 +611,15 @@ linkify = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -598,9 +629,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -690,6 +734,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -727,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "prefab-sentinel"
-version = "0.8.9"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },
@@ -743,6 +799,7 @@ mcp = [
     { name = "mcp" },
 ]
 test = [
+    { name = "httpx" },
     { name = "unittest-parallel" },
 ]
 watch = [
@@ -758,8 +815,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bump-my-version", marker = "extra == 'lint'", specifier = ">=0.31" },
+    { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0,<0.29.0" },
     { name = "jsonschema", specifier = ">=4.25,<5" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.12" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2,<3" },
     { name = "mypy", marker = "extra == 'lint'", specifier = ">=1.13" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.8" },
     { name = "unittest-parallel", marker = "extra == 'test'", specifier = ">=1.6,<2" },
@@ -1385,6 +1443,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,8 +1498,8 @@ name = "uvicorn"
 version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- prefab-sentinel `0.9.0` を公開し、MCP server を Python SDK 2.x / MCP `2026-07-28` の Tools-only contract へ移行します。
- stdio を既定のまま維持し、任意の Streamable HTTP endpoint は `127.0.0.1:<port>/mcp` の loopback に限定します。外部公開用 host 設定は追加しません。
- `editor_set_udonsharp_field.values_json` の explicit `null` を拒否し、省略または空文字列は従来どおり「配列値なし」として扱います。
- protocol / transport / distribution contract のテストと、README・専門ドキュメント・CHANGELOG・各配布 manifest を同期します。

## Public release boundary

- 開発専用 artifact、ローカルパス、個人プロジェクト識別子、credentials、非公開 provenance は含めません。
- legacy MCP handshake / session lifecycle は意図的に非対応とし、破壊的変更として文書化しています。
- 公開 golden fixture に開発 repository の `source_commit` を保持しないことを回帰テストで固定しています。

## Related issues

公開 issue はありません。

Source sync: [tyunta/prefab-sentinel-dev@ce728f9](https://github.com/tyunta/prefab-sentinel-dev/commit/ce728f97549ea0e25ff36ccac7c1f90702129b8e)

## Verification

- `uv run pytest`: 3353 passed, 7 skipped
- `uv run ruff check .`: passed
- `uv lock --check`: passed
- `git diff --check`: passed
- Unity `2022.3.22f1` / VRChat Worlds SDK `3.10.4` live Bridge smoke: Python/Bridge `0.9.0`、Console error 0、C# compiler error 0
- Independent review: Critical 0 / Important 0 after publication-boundary fix
- `SKIP_BUMP=1` was used only for the already-versioned `0.9.0` release amend and the post-review test-only flake-fix commit, preserving release version `0.9.0`; no `--no-verify` was used, and lint/full tests were rerun.

## Checklist

- [x] Tests added or updated to cover the changed surface
- [x] README.md updated
- [x] AGENTS.md reviewed; no operational-rule or audit-pair change was required
- [x] `CHANGELOG.md` `0.9.0` entry added
- [x] Source traceability link is present; no public issue exists for this release sync
- [x] CI is green
- [x] No `--no-verify` use; every `SKIP_BUMP=1` use is documented above

